### PR TITLE
🧪 test(registry): add test case for unknown tool execution

### DIFF
--- a/src/tools/registry-unknown-tool.test.ts
+++ b/src/tools/registry-unknown-tool.test.ts
@@ -1,6 +1,6 @@
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { describe, expect, it, vi } from 'vitest'
 import { registerTools } from './registry.js'
-import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 
 // Mock the composite tools to isolate the test
 vi.mock('./composite/attachments.js', () => ({ attachments: vi.fn() }))
@@ -9,7 +9,7 @@ vi.mock('./composite/messages.js', () => ({ messages: vi.fn() }))
 vi.mock('./composite/send.js', () => ({ send: vi.fn() }))
 
 // Mock account config (minimal)
-const mockAccounts = []
+const mockAccounts: any[] = []
 
 describe('registerTools', () => {
   it('should handle unknown tool execution gracefully', async () => {
@@ -19,11 +19,11 @@ describe('registerTools', () => {
     }
 
     // Call the function under test
-    registerTools(mockServer as any, mockAccounts as any)
+    registerTools(mockServer as any, mockAccounts)
 
     // Find the handler for CallToolRequestSchema
     // The first argument to setRequestHandler is the schema, the second is the handler
-    const call = mockServer.setRequestHandler.mock.calls.find(call => call[0] === CallToolRequestSchema)
+    const call = mockServer.setRequestHandler.mock.calls.find((call) => call[0] === CallToolRequestSchema)
     expect(call).toBeDefined()
 
     const handler = call![1]


### PR DESCRIPTION
This PR adds a new test file `src/tools/registry-unknown-tool.test.ts` to improve test coverage for `src/tools/registry.ts`.

### 🎯 **What:**
- Added a test case for the `default` switch case in `registerTools` which handles unknown tool requests.

### 📊 **Coverage:**
- Tests the scenario where `CallToolRequestSchema` handler receives a request with an invalid tool name.
- Mocks composite tool dependencies (`attachments`, `folders`, `messages`, `send`) to isolate the test.
- Verifies that the handler returns an MCP error response (`isError: true`) with the expected error message ("Unknown tool: ...").

### ✨ **Result:**
- Increases confidence in error handling logic for the tool registry.
- Ensures the server responds gracefully to invalid tool requests.

---
*PR created automatically by Jules for task [11849635763491359917](https://jules.google.com/task/11849635763491359917) started by @n24q02m*