### PR TITLE
🔒 [Security Fix] Remove unused zod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
 		"html-to-text": "^9.0.5",
 		"imapflow": "^1.0.172",
 		"mailparser": "^3.7.2",
-		"nodemailer": "^7.0.5",
-		"zod": "^4.1.13"
+		"nodemailer": "^7.0.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       nodemailer:
         specifier: ^7.0.5
         version: 7.0.13
-      zod:
-        specifier: ^4.1.13
-        version: 4.3.6
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.8


### PR DESCRIPTION
🔒 Remove unused `zod` dependency

## 🎯 What
Removed `zod` from `package.json` as it was listed as a direct dependency but was not imported or used anywhere in the codebase.

## ⚠️ Risk
Leaving unused dependencies increases the attack surface (potential supply chain vulnerabilities) and bloats the project unnecessarily.

## 🛡️ Solution
Removed `"zod": "^4.1.13"` from `package.json` and updated `pnpm-lock.yaml`.
Verified that the build and tests pass successfully (`pnpm build && pnpm test`). Note that `zod` remains in `pnpm-lock.yaml` as a peer dependency of `@modelcontextprotocol/sdk`, which is expected and safe.

---
*PR created automatically by Jules for task [14288160354655438817](https://jules.google.com/task/14288160354655438817) started by @n24q02m*