### PR TITLE
test: add integration test for missing documentation in help tool

### DIFF
--- a/src/tools/registry.integration.test.ts
+++ b/src/tools/registry.integration.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock dependencies before importing registry
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  statSync: vi.fn()
+}))
+
+// Import after mocking
+import { registerTools } from './registry.js'
+
+describe('registry.ts - help tool error handling', () => {
+  let mockServer: any
+  let callToolHandler: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockServer = {
+      setRequestHandler: vi.fn((schema, handler) => {
+        if (schema === CallToolRequestSchema) {
+          callToolHandler = handler
+        }
+      })
+    }
+  })
+
+  it('should return a friendly error when documentation is missing', async () => {
+    // 1. Register tools
+    registerTools(mockServer, [])
+
+    // 2. Ensure handler was registered
+    expect(callToolHandler).toBeDefined()
+
+    // 3. Mock readFileSync to throw an error (simulating missing file)
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('File not found')
+    })
+
+    // 4. Call the handler with 'help' tool
+    const result = await callToolHandler({
+      params: {
+        name: 'help',
+        arguments: { tool_name: 'nonexistent-tool' }
+      }
+    })
+
+    // 5. Verify the error response
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('Documentation not found for: nonexistent-tool')
+  })
+})


### PR DESCRIPTION
Added a new integration test `src/tools/registry.integration.test.ts` to verify that the 'help' tool correctly handles missing documentation files by returning a friendly error message.

This addresses the testing gap for the `catch` block in `src/tools/registry.ts:181`.

## Changes
- Created `src/tools/registry.integration.test.ts`
- Mocked `node:fs` to simulate `readFileSync` failure.
- Verified that the error is caught and wrapped in an `EmailMCPError`.

## Verification
- Ran `pnpm vitest run src/tools/registry.integration.test.ts` -> Passed
- Ran `pnpm test` (full suite) -> Passed
- Ran `pnpm check` and `pnpm type-check` -> Passed

---
*PR created automatically by Jules for task [5084329954491318707](https://jules.google.com/task/5084329954491318707) started by @n24q02m*