### PR TITLE
Refactor email provider settings to remove duplication

### DIFF
--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -3,50 +3,6 @@
  * Parses EMAIL_CREDENTIALS env var and auto-discovers IMAP/SMTP settings
  */
 
-/** Well-known email provider settings */
-const PROVIDER_MAP: Record<string, { imap: ServerConfig; smtp: ServerConfig }> = {
-  'gmail.com': {
-    imap: { host: 'imap.gmail.com', port: 993, secure: true },
-    smtp: { host: 'smtp.gmail.com', port: 465, secure: true }
-  },
-  'googlemail.com': {
-    imap: { host: 'imap.gmail.com', port: 993, secure: true },
-    smtp: { host: 'smtp.gmail.com', port: 465, secure: true }
-  },
-  'outlook.com': {
-    imap: { host: 'outlook.office365.com', port: 993, secure: true },
-    smtp: { host: 'smtp.office365.com', port: 587, secure: false }
-  },
-  'hotmail.com': {
-    imap: { host: 'outlook.office365.com', port: 993, secure: true },
-    smtp: { host: 'smtp.office365.com', port: 587, secure: false }
-  },
-  'live.com': {
-    imap: { host: 'outlook.office365.com', port: 993, secure: true },
-    smtp: { host: 'smtp.office365.com', port: 587, secure: false }
-  },
-  'yahoo.com': {
-    imap: { host: 'imap.mail.yahoo.com', port: 993, secure: true },
-    smtp: { host: 'smtp.mail.yahoo.com', port: 465, secure: true }
-  },
-  'icloud.com': {
-    imap: { host: 'imap.mail.me.com', port: 993, secure: true },
-    smtp: { host: 'smtp.mail.me.com', port: 587, secure: false }
-  },
-  'me.com': {
-    imap: { host: 'imap.mail.me.com', port: 993, secure: true },
-    smtp: { host: 'smtp.mail.me.com', port: 587, secure: false }
-  },
-  'zoho.com': {
-    imap: { host: 'imap.zoho.com', port: 993, secure: true },
-    smtp: { host: 'smtp.zoho.com', port: 465, secure: true }
-  },
-  'protonmail.com': {
-    imap: { host: 'imap.protonmail.ch', port: 993, secure: true },
-    smtp: { host: 'smtp.protonmail.ch', port: 465, secure: true }
-  }
-}
-
 export interface ServerConfig {
   host: string
   port: number
@@ -59,6 +15,50 @@ export interface AccountConfig {
   password: string
   imap: ServerConfig
   smtp: ServerConfig
+}
+
+/** Well-known email provider settings */
+const GMAIL_SETTINGS = {
+  imap: { host: 'imap.gmail.com', port: 993, secure: true },
+  smtp: { host: 'smtp.gmail.com', port: 465, secure: true }
+}
+
+const OUTLOOK_SETTINGS = {
+  imap: { host: 'outlook.office365.com', port: 993, secure: true },
+  smtp: { host: 'smtp.office365.com', port: 587, secure: false }
+}
+
+const YAHOO_SETTINGS = {
+  imap: { host: 'imap.mail.yahoo.com', port: 993, secure: true },
+  smtp: { host: 'smtp.mail.yahoo.com', port: 465, secure: true }
+}
+
+const ICLOUD_SETTINGS = {
+  imap: { host: 'imap.mail.me.com', port: 993, secure: true },
+  smtp: { host: 'smtp.mail.me.com', port: 587, secure: false }
+}
+
+const ZOHO_SETTINGS = {
+  imap: { host: 'imap.zoho.com', port: 993, secure: true },
+  smtp: { host: 'smtp.zoho.com', port: 465, secure: true }
+}
+
+const PROTONMAIL_SETTINGS = {
+  imap: { host: 'imap.protonmail.ch', port: 993, secure: true },
+  smtp: { host: 'smtp.protonmail.ch', port: 465, secure: true }
+}
+
+const PROVIDER_MAP: Record<string, { imap: ServerConfig; smtp: ServerConfig }> = {
+  'gmail.com': GMAIL_SETTINGS,
+  'googlemail.com': GMAIL_SETTINGS,
+  'outlook.com': OUTLOOK_SETTINGS,
+  'hotmail.com': OUTLOOK_SETTINGS,
+  'live.com': OUTLOOK_SETTINGS,
+  'yahoo.com': YAHOO_SETTINGS,
+  'icloud.com': ICLOUD_SETTINGS,
+  'me.com': ICLOUD_SETTINGS,
+  'zoho.com': ZOHO_SETTINGS,
+  'protonmail.com': PROTONMAIL_SETTINGS
 }
 
 /**


### PR DESCRIPTION
Extracted duplicated email provider settings into shared constants (`GMAIL_SETTINGS`, `OUTLOOK_SETTINGS`, etc.).
Updated `PROVIDER_MAP` to use these constants.
Verified changes with existing tests.

This refactoring improves maintainability and adheres to the DRY principle.

---
*PR created automatically by Jules for task [16849556170577466367](https://jules.google.com/task/16849556170577466367) started by @n24q02m*