### PR TITLE
🧪 Add test for ambiguous account in send tool

### DIFF
--- a/src/tools/composite/send.test.ts
+++ b/src/tools/composite/send.test.ts
@@ -290,4 +290,33 @@ describe('send - validation', () => {
       })
     ).rejects.toThrow()
   })
+
+  it('throws when multiple accounts match', async () => {
+    const ambiguousAccounts: AccountConfig[] = [
+      {
+        id: 'user1_gmail_com',
+        email: 'user1@gmail.com',
+        password: 'p1',
+        imap: { host: 'imap.gmail.com', port: 993, secure: true },
+        smtp: { host: 'smtp.gmail.com', port: 465, secure: true }
+      },
+      {
+        id: 'user2_gmail_com',
+        email: 'user2@gmail.com',
+        password: 'p2',
+        imap: { host: 'imap.gmail.com', port: 993, secure: true },
+        smtp: { host: 'smtp.gmail.com', port: 465, secure: true }
+      }
+    ]
+
+    await expect(
+      send(ambiguousAccounts, {
+        action: 'new',
+        account: 'gmail.com',
+        to: 'r@test.com',
+        subject: 'T',
+        body: 'B'
+      })
+    ).rejects.toThrow('Multiple accounts matched')
+  })
 })


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `send` tool logic for resolving accounts included a check for ambiguous matches (e.g., `account: 'gmail.com'` matching multiple Gmail accounts), but this scenario was not covered by existing tests.

📊 **Coverage:** What scenarios are now tested
A new test case has been added to `src/tools/composite/send.test.ts` that:
- Defines a configuration with two accounts that both match the query "gmail.com".
- Calls the `send` function with this ambiguous query.
- Asserts that the function throws an error with the message "Multiple accounts matched".

✨ **Result:** The improvement in test coverage
This ensures that the `send` tool correctly prevents accidental operations when the account specification is ambiguous, and prevents regression of this safety check.

---
*PR created automatically by Jules for task [8926680714237304152](https://jules.google.com/task/8926680714237304152) started by @n24q02m*