### PR TITLE
🔒 Fix sensitive data exposure in configuration logs

### DIFF
--- a/src/tools/helpers/config.test.ts
+++ b/src/tools/helpers/config.test.ts
@@ -160,3 +160,18 @@ describe('loadConfig', () => {
     }
   })
 })
+
+it('vulnerability reproduction: exposes sensitive data in logs', () => {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const sensitivePart = 'SecretPassword'
+  // malformed entry: short email concatenated with password, no colon
+  const input = `me@x.com${sensitivePart}`
+  // "me@x.comSecretPassword"
+  // substring(0, 20) -> "me@x.comSecretPasswo"
+
+  parseCredentials(input)
+
+  // The vulnerability is that it logs the substring which contains the password
+  expect(spy).not.toHaveBeenCalledWith(expect.stringContaining('SecretPasswo'))
+  spy.mockRestore()
+})

--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -115,7 +115,7 @@ export function parseCredentials(envValue: string): AccountConfig[] {
 
     const parts = trimmed.split(':')
     if (parts.length < 2) {
-      console.error(`Skipping invalid credential entry (expected email:password): ${trimmed.substring(0, 20)}...`)
+      console.error('Skipping invalid credential entry (expected email:password)')
       continue
     }
 


### PR DESCRIPTION
This change addresses a security vulnerability in `src/tools/helpers/config.ts` where sensitive data (passwords) could be inadvertently logged when parsing malformed credential strings.

**The Fix:**
- Removed the logging of the substring of the invalid credential entry.
- Replaced it with a generic error message: `Skipping invalid credential entry (expected email:password)`.

**Verification:**
- Added a regression test case in `src/tools/helpers/config.test.ts` to confirm that sensitive data is not exposed in the logs.
- Ran existing tests to ensure no regressions.
- Verified that formatting and linting checks pass.

---
*PR created automatically by Jules for task [7333440991235122313](https://jules.google.com/task/7333440991235122313) started by @n24q02m*