### PR TITLE
Refactor: Use RESOURCES as source of truth for documentation paths

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -107,10 +107,10 @@ describe('TOOLS structure', () => {
 
 describe('RESOURCES structure', () => {
   const EXPECTED_RESOURCES = [
-    { uri: 'email://docs/messages', name: 'Messages Tool Docs', file: 'messages.md' },
-    { uri: 'email://docs/folders', name: 'Folders Tool Docs', file: 'folders.md' },
-    { uri: 'email://docs/attachments', name: 'Attachments Tool Docs', file: 'attachments.md' },
-    { uri: 'email://docs/send', name: 'Send Tool Docs', file: 'send.md' }
+    { tool: 'messages', uri: 'email://docs/messages', name: 'Messages Tool Docs', file: 'messages.md' },
+    { tool: 'folders', uri: 'email://docs/folders', name: 'Folders Tool Docs', file: 'folders.md' },
+    { tool: 'attachments', uri: 'email://docs/attachments', name: 'Attachments Tool Docs', file: 'attachments.md' },
+    { tool: 'send', uri: 'email://docs/send', name: 'Send Tool Docs', file: 'send.md' }
   ]
 
   it('has exactly 4 resources', () => {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -34,10 +34,10 @@ const DOCS_DIR = __dirname.endsWith('bin')
  * Documentation resources for full tool details
  */
 const RESOURCES = [
-  { uri: 'email://docs/messages', name: 'Messages Tool Docs', file: 'messages.md' },
-  { uri: 'email://docs/folders', name: 'Folders Tool Docs', file: 'folders.md' },
-  { uri: 'email://docs/attachments', name: 'Attachments Tool Docs', file: 'attachments.md' },
-  { uri: 'email://docs/send', name: 'Send Tool Docs', file: 'send.md' }
+  { tool: 'messages', uri: 'email://docs/messages', name: 'Messages Tool Docs', file: 'messages.md' },
+  { tool: 'folders', uri: 'email://docs/folders', name: 'Folders Tool Docs', file: 'folders.md' },
+  { tool: 'attachments', uri: 'email://docs/attachments', name: 'Attachments Tool Docs', file: 'attachments.md' },
+  { tool: 'send', uri: 'email://docs/send', name: 'Send Tool Docs', file: 'send.md' }
 ]
 
 /**
@@ -252,12 +252,21 @@ export function registerTools(server: Server, accounts: AccountConfig[]) {
           break
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
-          const docFile = `${toolName}.md`
+          const resource = RESOURCES.find((r) => r.tool === toolName)
+
+          if (!resource) {
+            throw new EmailMCPError(`Documentation not found for: ${toolName}`, 'DOC_NOT_FOUND', 'Check tool_name')
+          }
+
           try {
-            const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')
+            const content = readFileSync(join(DOCS_DIR, resource.file), 'utf-8')
             result = { tool: toolName, documentation: content }
           } catch {
-            throw new EmailMCPError(`Documentation not found for: ${toolName}`, 'DOC_NOT_FOUND', 'Check tool_name')
+            throw new EmailMCPError(
+              `Documentation file not found: ${resource.file}`,
+              'DOC_FILE_NOT_FOUND',
+              'Check installation'
+            )
           }
           break
         }


### PR DESCRIPTION
Refactored the documentation path resolution in `src/tools/registry.ts` to use the `RESOURCES` constant as the source of truth, eliminating fragile string interpolation. Updated `src/tools/registry.test.ts` to reflect the changes in `RESOURCES` structure. This change improves maintainability by centralizing the documentation file mapping and preventing errors due to assumed naming conventions. Verified with tests.

---
*PR created automatically by Jules for task [6452822786742214956](https://jules.google.com/task/6452822786742214956) started by @n24q02m*