### PR TITLE
refactor: use marked library for robust markdown to HTML conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"html-to-text": "^9.0.5",
 		"imapflow": "^1.0.172",
 		"mailparser": "^3.7.2",
+		"marked": "^17.0.3",
 		"nodemailer": "^7.0.5",
 		"zod": "^4.1.13"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       mailparser:
         specifier: ^3.7.2
         version: 3.9.3
+      marked:
+        specifier: ^17.0.3
+        version: 17.0.3
       nodemailer:
         specifier: ^7.0.5
         version: 7.0.13
@@ -1011,6 +1014,11 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  marked@17.0.3:
+    resolution: {integrity: sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2231,6 +2239,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  marked@17.0.3: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/tools/helpers/smtp-client.test.ts
+++ b/src/tools/helpers/smtp-client.test.ts
@@ -13,7 +13,7 @@ vi.mock('nodemailer', () => ({
 }))
 
 import { createTransport } from 'nodemailer'
-import { forwardEmail, replyToEmail, sendNewEmail } from './smtp-client.js'
+import { forwardEmail, replyToEmail, sendNewEmail, textToHtml } from './smtp-client.js'
 
 const account: AccountConfig = {
   id: 'test_gmail_com',
@@ -100,7 +100,7 @@ describe('sendNewEmail', () => {
     })
 
     const callArgs = mockSendMail.mock.calls[0]![0]
-    expect(callArgs.html).toContain('<b>Important</b>')
+    expect(callArgs.html).toContain('<strong>Important</strong>')
   })
 
   it('converts empty lines to br tags', async () => {
@@ -111,7 +111,7 @@ describe('sendNewEmail', () => {
     })
 
     const callArgs = mockSendMail.mock.calls[0]![0]
-    expect(callArgs.html).toContain('<br>')
+    expect(callArgs.html).toContain('<p>Line 2</p>')
   })
 
   it('always closes transport', async () => {
@@ -255,5 +255,31 @@ describe('forwardEmail', () => {
     const callArgs = mockSendMail.mock.calls[0]![0]
     expect(callArgs.cc).toBe('cc@test.com')
     expect(callArgs.bcc).toBe('bcc@test.com')
+  })
+})
+
+// ============================================================================
+// textToHtml (Direct tests)
+// ============================================================================
+
+describe('textToHtml', () => {
+  it('converts basic markdown list to valid HTML list (with ul)', () => {
+    const input = `Here is a list:
+- Item 1
+- Item 2
+- Item 3`
+
+    const output = textToHtml(input)
+    expect(output).toContain('<ul>')
+    expect(output).toContain('<li>Item 1</li>')
+    expect(output).toContain('<li>Item 2</li>')
+    expect(output).toContain('<li>Item 3</li>')
+    expect(output).toContain('</ul>')
+  })
+
+  it('handles single newlines with <br> (breaks: true)', () => {
+    const input = 'Line 1\nLine 2'
+    const output = textToHtml(input)
+    expect(output).toContain('<br>')
   })
 })

--- a/src/tools/helpers/smtp-client.ts
+++ b/src/tools/helpers/smtp-client.ts
@@ -3,6 +3,7 @@
  * Send, reply, and forward emails via SMTP using Nodemailer
  */
 
+import { marked } from 'marked'
 import { createTransport } from 'nodemailer'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
@@ -35,19 +36,9 @@ function createSmtpTransport(account: AccountConfig) {
 /**
  * Convert markdown-like text to simple HTML for email
  */
-function textToHtml(text: string): string {
-  return text
-    .split('\n')
-    .map((line) => {
-      if (line.startsWith('# ')) return `<h1>${line.substring(2)}</h1>`
-      if (line.startsWith('## ')) return `<h2>${line.substring(3)}</h2>`
-      if (line.startsWith('### ')) return `<h3>${line.substring(4)}</h3>`
-      if (line.startsWith('- ')) return `<li>${line.substring(2)}</li>`
-      if (line.startsWith('**') && line.endsWith('**')) return `<b>${line.slice(2, -2)}</b>`
-      if (line.trim() === '') return '<br>'
-      return `<p>${line}</p>`
-    })
-    .join('\n')
+export function textToHtml(text: string): string {
+  // marked.parse is synchronous when no async extensions are used
+  return marked.parse(text, { breaks: true }) as string
 }
 
 /**


### PR DESCRIPTION
Replaced the manual `textToHtml` function in `src/tools/helpers/smtp-client.ts` with the `marked` library to fix invalid HTML generation for lists (missing `<ul>` wrappers) and improve overall markdown support.

Changes:
- Replaced custom regex-based parsing with `marked.parse(text, { breaks: true })`.
- Updated `package.json` to include `marked`.
- Updated existing tests in `src/tools/helpers/smtp-client.test.ts` to match `marked`'s HTML output (e.g., `<strong>` instead of `<b>`).
- Added new tests for list generation and line break handling.

Verification:
- Ran `pnpm test src/tools/helpers/smtp-client.test.ts` which covers the new implementation and regressions.
- Ran full test suite `pnpm test` to ensure no other regressions.
- Linted and formatted code.

---
*PR created automatically by Jules for task [11266158572590355620](https://jules.google.com/task/11266158572590355620) started by @n24q02m*