### PR TITLE
🧹 Remove dead code in recursive folder listing

### DIFF
--- a/src/tools/helpers/imap-client.test.ts
+++ b/src/tools/helpers/imap-client.test.ts
@@ -369,35 +369,6 @@ describe('listFolders', () => {
     expect(result[0]!.path).toBe('INBOX')
     expect(result[0]!.flags).toContain('\\HasNoChildren')
   })
-
-  it('handles folders with children', async () => {
-    const childFolders = new Map([
-      [
-        'Sent',
-        {
-          name: 'Sent',
-          path: '[Gmail]/Sent',
-          flags: new Set(['\\Sent']),
-          delimiter: '/'
-        }
-      ]
-    ])
-    mockClient.list.mockResolvedValue([
-      {
-        name: '[Gmail]',
-        path: '[Gmail]',
-        flags: new Set(['\\Noselect']),
-        delimiter: '/',
-        folders: childFolders
-      }
-    ])
-
-    const result = await listFolders(account)
-
-    expect(result).toHaveLength(1)
-    expect(result[0]!.children).toHaveLength(1)
-    expect(result[0]!.children![0]!.name).toBe('Sent')
-  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -52,7 +52,6 @@ export interface FolderInfo {
   path: string
   flags: string[]
   delimiter: string
-  children?: FolderInfo[]
 }
 
 /**
@@ -354,15 +353,7 @@ export async function listFolders(account: AccountConfig): Promise<FolderInfo[]>
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),
-      delimiter: mb.delimiter || '/',
-      children: (mb as any).folders
-        ? (Array.from((mb as any).folders) as [any, any][]).map(([, child]) => ({
-            name: child.name,
-            path: child.path,
-            flags: Array.from(child.flags || []),
-            delimiter: child.delimiter || '/'
-          }))
-        : undefined
+      delimiter: mb.delimiter || '/'
     }))
   })
 }


### PR DESCRIPTION
Removed dead code in `src/tools/helpers/imap-client.ts` related to recursive folder listing.

- **What:** Removed logic attempting to access `folders` property on `imapflow` list results, and removed `children` property from `FolderInfo` interface.
- **Why:** The `imapflow` library's `list()` method returns a flat list of mailboxes, so the `folders` property was always undefined, making the recursive mapping code dead and misleading.
- **Verification:** Verified by running tests (`pnpm test`) and type checking (`pnpm type-check`). Removed a test case that was testing this dead code with incorrect mocks.
- **Result:** Improved code maintainability by removing unused and confusing logic.

---
*PR created automatically by Jules for task [2321961300803133874](https://jules.google.com/task/2321961300803133874) started by @n24q02m*