### PR TITLE
⚡ Bolt: Parallelize email search across accounts

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -160,12 +160,12 @@ export async function searchEmails(
   folder: string,
   limit: number
 ): Promise<EmailSummary[]> {
-  const results: EmailSummary[] = []
   const criteria = buildSearchCriteria(query)
 
-  for (const account of accounts) {
+  // Execute searches in parallel
+  const searchPromises = accounts.map(async (account) => {
     try {
-      const emails = await withConnection(account, async (client) => {
+      return await withConnection(account, async (client) => {
         const lock = await client.getMailboxLock(folder)
         try {
           const summaries: EmailSummary[] = []
@@ -204,25 +204,27 @@ export async function searchEmails(
           lock.release()
         }
       })
-
-      results.push(...emails)
     } catch (error: any) {
-      // Include error info but continue with other accounts
-      results.push({
-        account_id: account.id,
-        account_email: account.email,
-        uid: 0,
-        subject: `[ERROR] ${error.message}`,
-        from: '',
-        to: '',
-        date: '',
-        flags: [],
-        snippet: `Failed to search ${account.email}: ${error.message}`
-      })
+      // Include error info but return as a result
+      return [
+        {
+          account_id: account.id,
+          account_email: account.email,
+          uid: 0,
+          subject: `[ERROR] ${error.message}`,
+          from: '',
+          to: '',
+          date: '',
+          flags: [],
+          snippet: `Failed to search ${account.email}: ${error.message}`
+        }
+      ]
     }
-  }
+  })
 
-  return results
+  // Wait for all searches to complete and flatten results
+  const results = await Promise.all(searchPromises)
+  return results.flat()
 }
 
 /**


### PR DESCRIPTION
This PR optimizes the `searchEmails` function to query multiple email accounts in parallel rather than sequentially. This change significantly improves search performance for users with multiple configured accounts, reducing the total wait time to be bounded by the slowest account rather than the sum of all account latencies.

The implementation uses `Promise.all` to execute searches concurrently while maintaining robust error handling: if one account fails, it returns an error result for that specific account without blocking or failing the entire search operation for other accounts.

Verification:
- A reproduction test confirmed the original sequential behavior (~300ms for 3 accounts with 100ms delay).
- The same test confirmed the optimized parallel behavior (~100ms for the same setup).
- Existing unit tests passed, ensuring no regressions in functionality or error handling.

---
*PR created automatically by Jules for task [7496707797193073773](https://jules.google.com/task/7496707797193073773) started by @n24q02m*