### PR TITLE
⚡ Bolt: Parallelize IMAP requests with Promise.all

### DIFF
--- a/src/tools/composite/folders.ts
+++ b/src/tools/composite/folders.ts
@@ -50,25 +50,25 @@ async function handleList(accounts: AccountConfig[], input: FoldersInput): Promi
     }
   }
 
-  const results: any[] = []
-
-  for (const account of targetAccounts) {
+  const accountPromises = targetAccounts.map(async (account) => {
     try {
       const folderList = await listFolders(account)
-      results.push({
+      return {
         account_id: account.id,
         account_email: account.email,
         folders: folderList
-      })
+      }
     } catch (error: any) {
-      results.push({
+      return {
         account_id: account.id,
         account_email: account.email,
         error: error.message,
         folders: []
-      })
+      }
     }
-  }
+  })
+
+  const results = await Promise.all(accountPromises)
 
   return {
     action: 'list',

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -160,10 +160,9 @@ export async function searchEmails(
   folder: string,
   limit: number
 ): Promise<EmailSummary[]> {
-  const results: EmailSummary[] = []
   const criteria = buildSearchCriteria(query)
 
-  for (const account of accounts) {
+  const accountPromises = accounts.map(async (account) => {
     try {
       const emails = await withConnection(account, async (client) => {
         const lock = await client.getMailboxLock(folder)
@@ -205,24 +204,27 @@ export async function searchEmails(
         }
       })
 
-      results.push(...emails)
+      return emails
     } catch (error: any) {
       // Include error info but continue with other accounts
-      results.push({
-        account_id: account.id,
-        account_email: account.email,
-        uid: 0,
-        subject: `[ERROR] ${error.message}`,
-        from: '',
-        to: '',
-        date: '',
-        flags: [],
-        snippet: `Failed to search ${account.email}: ${error.message}`
-      })
+      return [
+        {
+          account_id: account.id,
+          account_email: account.email,
+          uid: 0,
+          subject: `[ERROR] ${error.message}`,
+          from: '',
+          to: '',
+          date: '',
+          flags: [],
+          snippet: `Failed to search ${account.email}: ${error.message}`
+        }
+      ]
     }
-  }
+  })
 
-  return results
+  const resultsArrays = await Promise.all(accountPromises)
+  return resultsArrays.flat()
 }
 
 /**


### PR DESCRIPTION
💡 What: Replaced sequential iteration over email accounts with concurrent mapping and `Promise.all` in `searchEmails` (`src/tools/helpers/imap-client.ts`) and `handleList` (`src/tools/composite/folders.ts`).
🎯 Why: Iterating over configured email accounts sequentially introduces artificial O(N) latency since each account requires distinct, independent network requests via IMAP.
📊 Impact: Expected execution time for multi-account queries will reduce from the sum of all individual response latencies to roughly the latency of the slowest responding account, effectively making multi-account operations O(1) relative to total connection time.
🔬 Measurement: Verify by executing a search or list operation with multiple accounts configured; observe significant time reduction vs sequentially executing requests. Also tracked by running test suite ensuring identical behavior and fault-tolerance per-account.

---
*PR created automatically by Jules for task [16425431440045123270](https://jules.google.com/task/16425431440045123270) started by @n24q02m*