### PR TITLE
🧪 Fix missing test for Resource not found in registry

### DIFF
--- a/src/tools/registry.logic.test.ts
+++ b/src/tools/registry.logic.test.ts
@@ -1,5 +1,6 @@
-import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { CallToolRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { describe, expect, it, vi } from 'vitest'
+import { EmailMCPError } from './helpers/errors.js'
 import { registerTools } from './registry.js'
 
 describe('registerTools', () => {
@@ -40,6 +41,32 @@ describe('registerTools', () => {
         }
       ],
       isError: true
+    })
+  })
+
+  it('should throw RESOURCE_NOT_FOUND when requesting an invalid URI', async () => {
+    // Mock server
+    const server = {
+      setRequestHandler: vi.fn()
+    } as any
+
+    // Call registerTools
+    registerTools(server, [])
+
+    // Find the handler for ReadResourceRequestSchema
+    const readResourceHandler = server.setRequestHandler.mock.calls.find(
+      (call: any) => call[0] === ReadResourceRequestSchema
+    )?.[1]
+
+    expect(readResourceHandler).toBeDefined()
+
+    // Simulate request with invalid URI
+    await expect(readResourceHandler({ params: { uri: 'email://docs/nonexistent' } })).rejects.toThrow(EmailMCPError)
+    await expect(readResourceHandler({ params: { uri: 'email://docs/nonexistent' } })).rejects.toThrow(
+      /Resource not found/
+    )
+    await expect(readResourceHandler({ params: { uri: 'email://docs/nonexistent' } })).rejects.toMatchObject({
+      code: 'RESOURCE_NOT_FOUND'
     })
   })
 })


### PR DESCRIPTION
🎯 **What:** 
Added a missing test case in `src/tools/registry.logic.test.ts` to cover the `ReadResourceRequestSchema` handler when an invalid/non-existent URI is requested. It ensures that the registry correctly throws an `EmailMCPError` with the `RESOURCE_NOT_FOUND` error code.

📊 **Coverage:** 
The scenario of requesting a missing resource URI (e.g., `email://docs/nonexistent`) is now explicitly covered under unit tests, simulating how the `ReadResourceRequestSchema` handler behaves and fails safely.

✨ **Result:** 
Enhanced test coverage for `registry.ts`. The codebase now verifies that resource not found errors are appropriately handled, improving the reliability and maintainability of the MCP server's resource operations.

---
*PR created automatically by Jules for task [9332673189470442383](https://jules.google.com/task/9332673189470442383) started by @n24q02m*