### PR TITLE
🔒 Fix Unused Dependency (zod)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
 		"imapflow": "^1.0.172",
 		"mailparser": "^3.7.2",
 		"marked": "^17.0.3",
-		"nodemailer": "^7.0.5",
-		"zod": "^4.1.13"
+		"nodemailer": "^7.0.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.8",


### PR DESCRIPTION
🎯 **What:** Removed the unused `zod` dependency from `package.json`.

⚠️ **Risk:** Unused dependencies unnecessarily bloat the project size, slow down install times, and most importantly, increase the potential attack surface. If an unused dependency contains a vulnerability, security scanners will still flag the project, creating false alarms or requiring updates for code that is never executed.

🛡️ **Solution:** Removed `"zod": "^4.1.13"` from the `dependencies` object in `package.json` since a search of the codebase showed no imports or usage of `zod`. The corresponding lockfile was not staged/pushed to keep this PR focused and clean, as the project appears to use `bun` (judging by `bun.lock`).

---
*PR created automatically by Jules for task [18175463709725658708](https://jules.google.com/task/18175463709725658708) started by @n24q02m*