### PR TITLE
🧪 Add missing coverage for help tool missing documentation

### DIFF
--- a/src/tools/registry.integration.test.ts
+++ b/src/tools/registry.integration.test.ts
@@ -1,12 +1,11 @@
-import { readFileSync } from 'node:fs'
-import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { readFile } from 'node:fs/promises'
+import { CallToolRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EmailMCPError } from './helpers/errors.js'
 
 // Mock dependencies before importing registry
-vi.mock('node:fs', () => ({
-  readFileSync: vi.fn(),
-  existsSync: vi.fn(),
-  statSync: vi.fn()
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn()
 }))
 
 // Import after mocking
@@ -15,6 +14,7 @@ import { registerTools } from './registry.js'
 describe('registry.ts - help tool error handling', () => {
   let mockServer: any
   let callToolHandler: any
+  let readResourceHandler: any
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -23,6 +23,8 @@ describe('registry.ts - help tool error handling', () => {
       setRequestHandler: vi.fn((schema, handler) => {
         if (schema === CallToolRequestSchema) {
           callToolHandler = handler
+        } else if (schema === ReadResourceRequestSchema) {
+          readResourceHandler = handler
         }
       })
     }
@@ -36,9 +38,7 @@ describe('registry.ts - help tool error handling', () => {
     expect(callToolHandler).toBeDefined()
 
     // 3. Mock readFileSync to throw an error (simulating missing file)
-    vi.mocked(readFileSync).mockImplementation(() => {
-      throw new Error('File not found')
-    })
+    vi.mocked(readFile).mockRejectedValue(new Error('File not found'))
 
     // 4. Call the handler with 'help' tool
     const result = await callToolHandler({
@@ -51,5 +51,22 @@ describe('registry.ts - help tool error handling', () => {
     // 5. Verify the error response
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toContain('Documentation not found for: nonexistent-tool')
+  })
+
+  it('should throw EmailMCPError when reading an unknown resource uri', async () => {
+    // 1. Register tools
+    registerTools(mockServer, [])
+
+    // 2. Ensure handler was registered
+    expect(readResourceHandler).toBeDefined()
+
+    // 3. Call the handler with an unknown uri
+    const request = {
+      params: { uri: 'email://docs/unknown' }
+    }
+
+    // 4. Verify it throws EmailMCPError
+    await expect(readResourceHandler(request)).rejects.toThrow(EmailMCPError)
+    await expect(readResourceHandler(request)).rejects.toThrow('Resource not found: email://docs/unknown')
   })
 })


### PR DESCRIPTION
🎯 **What:** The `catch` block that throws an `EmailMCPError` when tool documentation is not found in the `help` tool (`registry.ts:261`) and the resource not found check (`registry.ts:181`) lacked proper testing. 
📊 **Coverage:** Replaced an ineffective `vi.mock('node:fs')` mock with a correct `vi.mock('node:fs/promises')` mock, ensuring the test simulating missing documentation correctly fails the `readFile` promise and hits the catch block. Also added a new test covering the `ReadResourceRequestSchema` handler when an unknown URI is provided.
✨ **Result:** Both the missing documentation path and unknown resource URI path are correctly unit-tested and fully covered now, resolving the testing gap.

---
*PR created automatically by Jules for task [10017469733863216109](https://jules.google.com/task/10017469733863216109) started by @n24q02m*