### PR TITLE
⚡ Cache Folder Listing for Archive Action

### DIFF
--- a/src/tools/composite/messages.ts
+++ b/src/tools/composite/messages.ts
@@ -8,7 +8,7 @@ import { EmailMCPError, withErrorHandling } from '../helpers/errors.js'
 import { listFolders, modifyFlags, moveEmails, readEmail, searchEmails, trashEmails } from '../helpers/imap-client.js'
 
 // Simple in-memory cache for archive folder paths to avoid repeated IMAP calls
-const archiveFolderCache = new Map<string, string>()
+const archiveFolderCache = new Map<string, Promise<string>>()
 
 export interface MessagesInput {
   action: 'search' | 'read' | 'mark_read' | 'mark_unread' | 'flag' | 'unflag' | 'move' | 'archive' | 'trash'
@@ -281,36 +281,41 @@ async function handleArchive(accounts: AccountConfig[], input: MessagesInput): P
   const folder = input.folder || 'INBOX'
 
   // Check cache first
-  let archiveFolder = archiveFolderCache.get(account.id)
+  let archiveFolderPromise = archiveFolderCache.get(account.id)
 
-  if (!archiveFolder) {
-    // Detect archive folder based on provider
-    archiveFolder = '[Gmail]/All Mail'
-    if (account.imap.host.includes('office365') || account.imap.host.includes('outlook')) {
-      archiveFolder = 'Archive'
-    } else if (account.imap.host.includes('yahoo')) {
-      archiveFolder = 'Archive'
-    }
-
-    // Try to find actual archive folder
-    try {
-      const folders = await listFolders(account)
-      const found = folders.find(
-        (f) =>
-          f.path.toLowerCase().includes('archive') ||
-          f.path.toLowerCase().includes('all mail') ||
-          f.flags.some((flag) => flag.toLowerCase().includes('archive') || flag.toLowerCase().includes('all'))
-      )
-      if (found) {
-        archiveFolder = found.path
+  if (!archiveFolderPromise) {
+    archiveFolderPromise = (async () => {
+      // Detect archive folder based on provider
+      let detectedFolder = '[Gmail]/All Mail'
+      if (account.imap.host.includes('office365') || account.imap.host.includes('outlook')) {
+        detectedFolder = 'Archive'
+      } else if (account.imap.host.includes('yahoo')) {
+        detectedFolder = 'Archive'
       }
-    } catch {
-      // Use default if folder listing fails
-    }
 
-    // Cache the result
-    archiveFolderCache.set(account.id, archiveFolder)
+      // Try to find actual archive folder
+      try {
+        const folders = await listFolders(account)
+        const found = folders.find(
+          (f) =>
+            f.path.toLowerCase().includes('archive') ||
+            f.path.toLowerCase().includes('all mail') ||
+            f.flags.some((flag) => flag.toLowerCase().includes('archive') || flag.toLowerCase().includes('all'))
+        )
+        if (found) {
+          detectedFolder = found.path
+        }
+      } catch {
+        // Use default if folder listing fails
+      }
+      return detectedFolder
+    })()
+
+    // Cache the promise immediately so concurrent calls wait on the same resolution
+    archiveFolderCache.set(account.id, archiveFolderPromise)
   }
+
+  const archiveFolder = await archiveFolderPromise
 
   const result = await moveEmails(account, uids, folder, archiveFolder)
 


### PR DESCRIPTION
💡 What:
Modified `archiveFolderCache` in `src/tools/composite/messages.ts` from a `Map<string, string>` to a `Map<string, Promise<string>>`. The `handleArchive` function now immediately caches the unsettled Promise representing the folder listing operation instead of waiting for resolution.

🎯 Why:
To prevent race conditions on concurrent archive actions. When multiple emails were archived simultaneously, all requests experienced a cache miss and fired parallel `listFolders` requests (which require IMAP connection setup). Caching the Promise ensures subsequent concurrent requests simply wait on the first request's network call.

📊 Measured Improvement:
Baseline latency for concurrent calls was gated by multiple network round-trips. With the Promise cache, concurrent archive operations block on a single IMAP folder listing, reducing redundant network usage from N calls down to 1 call per account.

---
*PR created automatically by Jules for task [3785885114492056735](https://jules.google.com/task/3785885114492056735) started by @n24q02m*