### PR TITLE
🧪 Add test for unknown tool execution in registry

### DIFF
--- a/src/tools/registry.logic.test.ts
+++ b/src/tools/registry.logic.test.ts
@@ -42,4 +42,38 @@ describe('registerTools', () => {
       isError: true
     })
   })
+
+  it('should return error when an unknown tool is requested', async () => {
+    // Mock server
+    const server = {
+      setRequestHandler: vi.fn()
+    } as any
+
+    // Mock accounts
+    const accounts = [] as any
+
+    // Call registerTools
+    registerTools(server, accounts)
+
+    // Find the handler for CallToolRequestSchema
+    const callToolHandler = server.setRequestHandler.mock.calls.find(
+      (call: any) => call[0] === CallToolRequestSchema
+    )?.[1]
+
+    expect(callToolHandler).toBeDefined()
+
+    // Simulate request with an unknown tool name
+    const request = {
+      params: {
+        name: 'unknown_tool',
+        arguments: {}
+      }
+    }
+
+    const result = await callToolHandler(request)
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('Unknown tool: unknown_tool')
+    expect(result.content[0].text).toContain('Available tools:')
+  })
 })


### PR DESCRIPTION
🎯 **What:** 
Added a missing test case in `src/tools/registry.logic.test.ts` to ensure that executing an unknown or missing tool correctly returns an `EmailMCPError` formatted as an MCP error response.

📊 **Coverage:**
The test verifies the `default:` branch of the tool execution `switch` statement within the `CallToolRequestSchema` handler in `src/tools/registry.ts`.

✨ **Result:**
The testing for the tool registry dispatcher logic is more complete, confidently catching missing or misconfigured external tool executions without regression.

---
*PR created automatically by Jules for task [9940741949358572055](https://jules.google.com/task/9940741949358572055) started by @n24q02m*