### PR TITLE
🧹 Refactor Email Provider Settings in Config Helper

### DIFF
--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -18,34 +18,37 @@ export interface AccountConfig {
 }
 
 /** Well-known email provider settings */
+const DEFAULT_IMAP = { port: 993, secure: true }
+const DEFAULT_SMTP = { port: 465, secure: true }
+
 const GMAIL_SETTINGS = {
-  imap: { host: 'imap.gmail.com', port: 993, secure: true },
-  smtp: { host: 'smtp.gmail.com', port: 465, secure: true }
+  imap: { host: 'imap.gmail.com', ...DEFAULT_IMAP },
+  smtp: { host: 'smtp.gmail.com', ...DEFAULT_SMTP }
 }
 
 const OUTLOOK_SETTINGS = {
-  imap: { host: 'outlook.office365.com', port: 993, secure: true },
+  imap: { host: 'outlook.office365.com', ...DEFAULT_IMAP },
   smtp: { host: 'smtp.office365.com', port: 587, secure: false }
 }
 
 const YAHOO_SETTINGS = {
-  imap: { host: 'imap.mail.yahoo.com', port: 993, secure: true },
-  smtp: { host: 'smtp.mail.yahoo.com', port: 465, secure: true }
+  imap: { host: 'imap.mail.yahoo.com', ...DEFAULT_IMAP },
+  smtp: { host: 'smtp.mail.yahoo.com', ...DEFAULT_SMTP }
 }
 
 const ICLOUD_SETTINGS = {
-  imap: { host: 'imap.mail.me.com', port: 993, secure: true },
+  imap: { host: 'imap.mail.me.com', ...DEFAULT_IMAP },
   smtp: { host: 'smtp.mail.me.com', port: 587, secure: false }
 }
 
 const ZOHO_SETTINGS = {
-  imap: { host: 'imap.zoho.com', port: 993, secure: true },
-  smtp: { host: 'smtp.zoho.com', port: 465, secure: true }
+  imap: { host: 'imap.zoho.com', ...DEFAULT_IMAP },
+  smtp: { host: 'smtp.zoho.com', ...DEFAULT_SMTP }
 }
 
 const PROTONMAIL_SETTINGS = {
-  imap: { host: 'imap.protonmail.ch', port: 993, secure: true },
-  smtp: { host: 'smtp.protonmail.ch', port: 465, secure: true }
+  imap: { host: 'imap.protonmail.ch', ...DEFAULT_IMAP },
+  smtp: { host: 'smtp.protonmail.ch', ...DEFAULT_SMTP }
 }
 
 const PROVIDER_MAP: Record<string, { imap: ServerConfig; smtp: ServerConfig }> = {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored duplicated `imap: { port: 993, secure: true }` and `smtp: { port: 465, secure: true }` property settings into shared `DEFAULT_IMAP` and `DEFAULT_SMTP` constants in `src/tools/helpers/config.ts`.

💡 **Why:** How this improves maintainability
The shared constants simplify modifications, prevent typos or forgotten values, and consolidate repetitive details in well-known provider configs.

✅ **Verification:** How you confirmed the change is safe
Ran `pnpm test` successfully (all 190 tests passed). Ran linting checks to ensure code style stays intact.

✨ **Result:** The improvement achieved
A cleaner `src/tools/helpers/config.ts` without repeated default port and secure parameters.

---
*PR created automatically by Jules for task [11703579910447931259](https://jules.google.com/task/11703579910447931259) started by @n24q02m*