### PR TITLE
🧪 [testing improvement] Add AMBIGUOUS_ACCOUNT test in send tool

### DIFF
--- a/src/tools/composite/send.test.ts
+++ b/src/tools/composite/send.test.ts
@@ -291,7 +291,7 @@ describe('send - validation', () => {
     ).rejects.toThrow()
   })
 
-  it('throws when multiple accounts match', async () => {
+  it('throws AMBIGUOUS_ACCOUNT when multiple accounts match', async () => {
     const ambiguousAccounts: AccountConfig[] = [
       {
         id: 'user1_gmail_com',
@@ -309,14 +309,18 @@ describe('send - validation', () => {
       }
     ]
 
-    await expect(
-      send(ambiguousAccounts, {
+    try {
+      await send(ambiguousAccounts, {
         action: 'new',
         account: 'gmail.com',
         to: 'r@test.com',
         subject: 'T',
         body: 'B'
       })
-    ).rejects.toThrow('Multiple accounts matched')
+      expect.fail('Should have thrown')
+    } catch (e: any) {
+      expect(e.message).toContain('Multiple accounts matched')
+      expect(e.code).toBe('AMBIGUOUS_ACCOUNT')
+    }
   })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -47,6 +47,9 @@ function sanitizeErrorDetails(error: any): any {
  * Enhance email-related errors with helpful context
  */
 export function enhanceError(error: any): EmailMCPError {
+  if (error instanceof EmailMCPError && error.code !== 'UNKNOWN_ERROR') {
+    return error
+  }
   const message = error.message || 'Unknown error occurred'
 
   // IMAP authentication errors


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a missing explicit test to verify that the `send` tool throws an `AMBIGUOUS_ACCOUNT` error when multiple accounts match a filter. Also fixed a bug in `enhanceError` that was inadvertently swallowing custom `EmailMCPError` codes (like `AMBIGUOUS_ACCOUNT`) by overwriting them with `UNKNOWN_ERROR`.

📊 **Coverage:** What scenarios are now tested
- `src/tools/composite/send.test.ts`: Now includes a test that asserts the specific `AMBIGUOUS_ACCOUNT` error code is thrown, testing the `matched.length > 1` branch.
- `src/tools/helpers/errors.ts`: `enhanceError` now preserves existing custom error codes for wrapped internal tool errors.

✨ **Result:** The improvement in test coverage
Test coverage for the `send` tool and its error handling logic is more comprehensive, and the previously swallowed custom error codes are correctly exposed.

---
*PR created automatically by Jules for task [7284845329181333953](https://jules.google.com/task/7284845329181333953) started by @n24q02m*