### PR TITLE
⚡ Bolt: Parallelize email snippet extraction in searchEmails

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -196,25 +196,27 @@ export async function searchEmails(
             { uid: true }
           )
 
-          const summaries: EmailSummary[] = []
-          for (const msg of messages) {
-            const snippet = msg.source ? await extractSnippet(msg.source) : ''
+          // Process snippets in parallel to avoid sequential await bottleneck
+          const summaries: EmailSummary[] = await Promise.all(
+            messages.map(async (msg) => {
+              const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
-            summaries.push({
-              account_id: account.id,
-              account_email: account.email,
-              uid: msg.uid,
-              message_id: msg.envelope?.messageId,
-              subject: msg.envelope?.subject || '(No subject)',
-              from: msg.envelope?.from?.[0]
-                ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
-                : '',
-              to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
-              date: msg.envelope?.date?.toISOString() || '',
-              flags: Array.from(msg.flags || []),
-              snippet
+              return {
+                account_id: account.id,
+                account_email: account.email,
+                uid: msg.uid,
+                message_id: msg.envelope?.messageId,
+                subject: msg.envelope?.subject || '(No subject)',
+                from: msg.envelope?.from?.[0]
+                  ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
+                  : '',
+                to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
+                date: msg.envelope?.date?.toISOString() || '',
+                flags: Array.from(msg.flags || []),
+                snippet
+              }
             })
-          }
+          )
 
           return summaries
         } finally {


### PR DESCRIPTION
💡 What: Refactored the sequential `for...of` loop in `searchEmails` (`src/tools/helpers/imap-client.ts`) that awaits `extractSnippet` for each individual email message into a concurrent operation using `Promise.all`.
🎯 Why: `extractSnippet` is an asynchronous operation. Processing an array of messages sequentially in a loop means the total execution time is the sum of all individual wait times, leading to a performance bottleneck for large inbox search queries. Processing them concurrently resolves this.
📊 Impact: Significantly speeds up the execution time of `searchEmails` (and thereby the `messages` search tool) when fetching multiple results, as the snippet extractions can now happen in parallel instead of one-by-one.
🔬 Measurement: Run `pnpm test src/tools/helpers/imap-client.test.ts` to verify the mapping functionality correctly preserved and no regressions were introduced. Performance gain is visible when running a search against a real IMAP server with a large result limit (e.g., 50+ messages).

---
*PR created automatically by Jules for task [14043651876598992091](https://jules.google.com/task/14043651876598992091) started by @n24q02m*