### PR TITLE
⚡ Bolt: parallelize email snippet extraction in searchEmails

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -196,11 +196,11 @@ export async function searchEmails(
             { uid: true }
           )
 
-          const summaries: EmailSummary[] = []
-          for (const msg of messages) {
+          // Process snippets in parallel to improve performance
+          const summariesPromises = messages.map(async (msg) => {
             const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
-            summaries.push({
+            return {
               account_id: account.id,
               account_email: account.email,
               uid: msg.uid,
@@ -213,10 +213,10 @@ export async function searchEmails(
               date: msg.envelope?.date?.toISOString() || '',
               flags: Array.from(msg.flags || []),
               snippet
-            })
-          }
+            }
+          })
 
-          return summaries
+          return Promise.all(summariesPromises)
         } finally {
           lock.release()
         }


### PR DESCRIPTION
💡 What: 
Refactored the `searchEmails` loop in `src/tools/helpers/imap-client.ts` to process email summaries via a `.map` resulting in a `Promise.all` mapping instead of sequentially processing them with a `for...of` loop and individual `await` calls.

🎯 Why: 
Extracting a short snippet from the email body can involve parsing HTML using `simpleParser` from `mailparser` and further sanitizing it via the internal regex-based `fastExtractSnippet`. Performing these potentially expensive CPU-bound or I/O-bound (in the form of streams inside `simpleParser`) operations sequentially blocks the thread and significantly increases the time it takes to return a list of search results.

📊 Impact: 
Significantly reduces wait times for `searchEmails` requests, especially when querying with large limits, as the extraction parses the `msg.source` concurrently across all returned IMAP messages for the request.

🔬 Measurement: 
To verify the improvement, you can bench the `searchEmails` function with a mock server or execute the MCP `messages` `search` action with a `limit: 20` argument and compare the execution time before and after the patch.

---
*PR created automatically by Jules for task [463156782405970721](https://jules.google.com/task/463156782405970721) started by @n24q02m*