### PR TITLE
🎨 Palette: [UX improvement] Mask sensitive credential input

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -629,8 +629,6 @@
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
-    "@n24q02m/mcp-relay-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
     "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -15,7 +15,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
     {
       key: 'EMAIL_CREDENTIALS',
       label: 'Email Credentials',
-      type: 'text',
+      type: 'password',
       placeholder: 'user@gmail.com:app-password',
       helpText:
         'Format: email:app-password. (Use App Passwords, not regular account passwords). Multiple accounts: email1:pass1,email2:pass2',


### PR DESCRIPTION
🎨 Palette: [UX improvement] Mask sensitive credential input

Use `type: 'password'` instead of `text` for `EMAIL_CREDENTIALS` in `RELAY_SCHEMA` to obfuscate sensitive passwords and tokens from being displayed in cleartext in the UI.

💡 What: Changed the input type of the `EMAIL_CREDENTIALS` field from `text` to `password` in `src/relay-schema.ts`.
🎯 Why: To improve security and UX by ensuring users' app passwords and tokens are not exposed during screen sharing or shoulder surfing.
📸 Before/After: Visual text is masked as standard password dots.
♿ Accessibility: The browser can properly interpret this field as a sensitive input, which assists screen readers and password managers.

---
*PR created automatically by Jules for task [2948437398118994183](https://jules.google.com/task/2948437398118994183) started by @n24q02m*