### PR TITLE
[FIX] Complex function: parseCredentials

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -629,8 +629,6 @@
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
-    "@n24q02m/mcp-relay-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
     "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],

--- a/bun.lock
+++ b/bun.lock
@@ -629,6 +629,8 @@
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
+    "@n24q02m/mcp-relay-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],

--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -105,6 +105,105 @@ function emailToId(email: string): string {
 }
 
 /**
+ * Parse a single credential entry
+ */
+async function parseSingleCredential(entry: string): Promise<AccountConfig | null> {
+  const trimmed = entry.trim()
+  if (!trimmed) return null
+
+  const parts = trimmed.split(':')
+  const email = parts[0]!.trim()
+
+  // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
+  if (parts.length < 2) {
+    if (isOutlookDomain(email)) {
+      const discovered = discoverSettings(email)
+      if (!discovered) return null
+      const account: AccountConfig = {
+        id: emailToId(email),
+        email,
+        password: '',
+        authType: 'oauth2',
+        imap: discovered.imap,
+        smtp: discovered.smtp
+      }
+      const tokens = await loadStoredTokens(email)
+      if (tokens) account.oauth2 = tokens
+      return account
+    }
+    console.error('Skipping invalid credential entry (expected email:password)')
+    return null
+  }
+
+  let password: string
+  let customImapHost: string | undefined
+
+  if (parts.length === 2) {
+    // email:password
+    password = parts[1]!
+  } else if (parts.length === 3) {
+    // Could be email:password:imap_host OR email:password_with_colon
+    // Heuristic: if last part looks like a hostname (contains a dot), treat as imap host
+    const lastPart = parts[2]!
+    if (lastPart.includes('.')) {
+      password = parts[1]!
+      customImapHost = lastPart
+    } else {
+      // password contains a colon
+      password = `${parts[1]}:${parts[2]}`
+    }
+  } else {
+    // 4+ parts: everything between email and last part (if hostname) is password
+    const lastPart = parts[parts.length - 1]!
+    if (lastPart.includes('.')) {
+      password = parts.slice(1, -1).join(':')
+      customImapHost = lastPart
+    } else {
+      password = parts.slice(1).join(':')
+    }
+  }
+
+  // Auto-discover or use custom host
+  let imap: ServerConfig
+  let smtp: ServerConfig
+
+  if (customImapHost) {
+    imap = { host: customImapHost, port: 993, secure: true }
+    // Guess SMTP from IMAP host
+    smtp = { host: customImapHost.replace('imap.', 'smtp.'), port: 587, secure: false }
+  } else {
+    const discovered = discoverSettings(email)
+    if (!discovered) {
+      console.error('Cannot auto-discover settings for the provided email. Use format: email:password:imap.server.com')
+      return null
+    }
+    imap = discovered.imap
+    smtp = discovered.smtp
+  }
+
+  const account: AccountConfig = {
+    id: emailToId(email),
+    email,
+    password,
+    authType: 'password',
+    imap,
+    smtp
+  }
+
+  // For Outlook domains, always use OAuth2 — password auth is not supported.
+  // ensureValidToken handles auto-auth (Device Code flow) when tokens are missing.
+  if (isOutlookDomain(email)) {
+    account.authType = 'oauth2'
+    const tokens = await loadStoredTokens(email)
+    if (tokens) {
+      account.oauth2 = tokens
+    }
+  }
+
+  return account
+}
+
+/**
  * Parse EMAIL_CREDENTIALS environment variable
  *
  * Supported formats:
@@ -120,109 +219,9 @@ export async function parseCredentials(envValue: string): Promise<AccountConfig[
     return []
   }
 
-  const accounts: AccountConfig[] = []
   const entries = envValue.split(',')
-
-  for (const entry of entries) {
-    const trimmed = entry.trim()
-    if (!trimmed) continue
-
-    const parts = trimmed.split(':')
-    const email = parts[0]!.trim()
-
-    // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
-    if (parts.length < 2) {
-      if (isOutlookDomain(email)) {
-        const discovered = discoverSettings(email)
-        if (!discovered) continue
-        const account: AccountConfig = {
-          id: emailToId(email),
-          email,
-          password: '',
-          authType: 'oauth2',
-          imap: discovered.imap,
-          smtp: discovered.smtp
-        }
-        const tokens = await loadStoredTokens(email)
-        if (tokens) account.oauth2 = tokens
-        accounts.push(account)
-        continue
-      }
-      console.error('Skipping invalid credential entry (expected email:password)')
-      continue
-    }
-
-    let password: string
-    let customImapHost: string | undefined
-
-    if (parts.length === 2) {
-      // email:password
-      password = parts[1]!
-    } else if (parts.length === 3) {
-      // Could be email:password:imap_host OR email:password_with_colon
-      // Heuristic: if last part looks like a hostname (contains a dot), treat as imap host
-      const lastPart = parts[2]!
-      if (lastPart.includes('.')) {
-        password = parts[1]!
-        customImapHost = lastPart
-      } else {
-        // password contains a colon
-        password = `${parts[1]}:${parts[2]}`
-      }
-    } else {
-      // 4+ parts: everything between email and last part (if hostname) is password
-      const lastPart = parts[parts.length - 1]!
-      if (lastPart.includes('.')) {
-        password = parts.slice(1, -1).join(':')
-        customImapHost = lastPart
-      } else {
-        password = parts.slice(1).join(':')
-      }
-    }
-
-    // Auto-discover or use custom host
-    let imap: ServerConfig
-    let smtp: ServerConfig
-
-    if (customImapHost) {
-      imap = { host: customImapHost, port: 993, secure: true }
-      // Guess SMTP from IMAP host
-      smtp = { host: customImapHost.replace('imap.', 'smtp.'), port: 587, secure: false }
-    } else {
-      const discovered = discoverSettings(email)
-      if (!discovered) {
-        console.error(
-          'Cannot auto-discover settings for the provided email. Use format: email:password:imap.server.com'
-        )
-        continue
-      }
-      imap = discovered.imap
-      smtp = discovered.smtp
-    }
-
-    const account: AccountConfig = {
-      id: emailToId(email),
-      email,
-      password,
-      authType: 'password',
-      imap,
-      smtp
-    }
-
-    // For Outlook domains, always use OAuth2 — password auth is not supported.
-    // ensureValidToken handles auto-auth (Device Code flow) when tokens are missing.
-    if (isOutlookDomain(email)) {
-      account.authType = 'oauth2'
-      const tokens = await loadStoredTokens(email)
-      if (tokens) {
-        account.oauth2 = tokens
-      }
-    }
-
-    accounts.push(account)
-  }
-
-  return accounts
+  const results = await Promise.all(entries.map((entry) => parseSingleCredential(entry)))
+  return results.filter((account): account is AccountConfig => account !== null)
 }
 
 /**

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1267,7 +1267,11 @@ describe('error handling', () => {
       expect(text).toBeTruthy()
       // Server returns either "No email accounts configured" (zero accounts)
       // or "Account not found" (has accounts but this one doesn't match)
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
 
     it('folders should return error when no accounts exist or account not found', async () => {
@@ -1278,7 +1282,11 @@ describe('error handling', () => {
       expect(result.isError).toBe(true)
       const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? ''
       expect(text).toBeTruthy()
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
 
     it('attachments should return error when no accounts exist or account not found', async () => {
@@ -1289,7 +1297,11 @@ describe('error handling', () => {
       expect(result.isError).toBe(true)
       const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? ''
       expect(text).toBeTruthy()
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
 
     it('send should return error when no accounts exist or account not found', async () => {
@@ -1306,7 +1318,11 @@ describe('error handling', () => {
       expect(result.isError).toBe(true)
       const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? ''
       expect(text).toBeTruthy()
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
   })
 


### PR DESCRIPTION
Extracted the parsing of a single credential entry into a `parseSingleCredential(entry)` helper function. This refactoring improves readability and modularity, reducing the complexity of the `parseCredentials` function. Concurrent processing of entries is now handled via `Promise.all`.

---
*PR created automatically by Jules for task [4315284416706950740](https://jules.google.com/task/4315284416706950740) started by @n24q02m*