### PR TITLE
🎨 Palette: Obfuscate sensitive credentials in setup UI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -629,8 +629,6 @@
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
-    "@n24q02m/mcp-relay-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
     "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],

--- a/bun.lock
+++ b/bun.lock
@@ -629,6 +629,8 @@
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
+    "@n24q02m/mcp-relay-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -15,7 +15,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
     {
       key: 'EMAIL_CREDENTIALS',
       label: 'Email Credentials',
-      type: 'text',
+      type: 'password',
       placeholder: 'user@gmail.com:app-password',
       helpText:
         'Format: email:app-password. (Use App Passwords, not regular account passwords). Multiple accounts: email1:pass1,email2:pass2',

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1267,7 +1267,11 @@ describe('error handling', () => {
       expect(text).toBeTruthy()
       // Server returns either "No email accounts configured" (zero accounts)
       // or "Account not found" (has accounts but this one doesn't match)
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
 
     it('folders should return error when no accounts exist or account not found', async () => {
@@ -1278,7 +1282,11 @@ describe('error handling', () => {
       expect(result.isError).toBe(true)
       const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? ''
       expect(text).toBeTruthy()
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
 
     it('attachments should return error when no accounts exist or account not found', async () => {
@@ -1289,7 +1297,11 @@ describe('error handling', () => {
       expect(result.isError).toBe(true)
       const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? ''
       expect(text).toBeTruthy()
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
 
     it('send should return error when no accounts exist or account not found', async () => {
@@ -1306,7 +1318,11 @@ describe('error handling', () => {
       expect(result.isError).toBe(true)
       const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? ''
       expect(text).toBeTruthy()
-      expect(text.includes('No email accounts') || text.includes('Account not found') || text.includes('Email credentials are not configured yet')).toBe(true)
+      expect(
+        text.includes('No email accounts') ||
+          text.includes('Account not found') ||
+          text.includes('Email credentials are not configured yet')
+      ).toBe(true)
     })
   })
 


### PR DESCRIPTION
💡 What: Changed the `EMAIL_CREDENTIALS` field in `RELAY_SCHEMA` from `type: 'text'` to `type: 'password'`.
🎯 Why: To prevent shoulder surfing and improve user privacy by obfuscating app passwords and email credentials as they are being entered in the setup UI.
📸 Before/After: Visual presentation of the input field changes from plaintext to masked dots (e.g., `••••••••`).
♿ Accessibility: Improves privacy and security posture without impacting screen reader accessibility, as standard password inputs are well-supported.

---
*PR created automatically by Jules for task [182764767531816631](https://jules.google.com/task/182764767531816631) started by @n24q02m*