### PR TITLE
🎨 Palette: [UX improvement] Mask credential inputs in relay schema

### DIFF
--- a/src/relay-schema.test.ts
+++ b/src/relay-schema.test.ts
@@ -11,7 +11,7 @@ describe('RELAY_SCHEMA', () => {
     const emailCredentialsField = RELAY_SCHEMA.fields?.find((field: any) => field.key === 'EMAIL_CREDENTIALS')
     expect(emailCredentialsField).toBeDefined()
     expect(emailCredentialsField?.label).toBe('Email Credentials')
-    expect(emailCredentialsField?.type).toBe('text')
+    expect(emailCredentialsField?.type).toBe('password')
     expect(emailCredentialsField?.placeholder).toBe('user@gmail.com:app-password')
     expect(emailCredentialsField?.helpText).toContain('Use App Passwords, not regular account passwords')
     expect(emailCredentialsField?.required).toBe(true)

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -15,7 +15,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
     {
       key: 'EMAIL_CREDENTIALS',
       label: 'Email Credentials',
-      type: 'text',
+      type: 'password',
       placeholder: 'user@gmail.com:app-password',
       helpText:
         'Format: email:app-password. (Use App Passwords, not regular account passwords). Multiple accounts: email1:pass1,email2:pass2',


### PR DESCRIPTION
💡 What: Changed the field type for `EMAIL_CREDENTIALS` from `text` to `password` in the `RELAY_SCHEMA`.
🎯 Why: The previous schema left app-passwords in plain text, causing a poor UX and risking accidental disclosure via shoulder surfing. Masking the field prevents this.
📸 Before/After: Visual field is now obfuscated dots instead of plain text.
♿ Accessibility: Maintains existing focus rings and labels, but enhances visual security context.

---
*PR created automatically by Jules for task [16468418500112757477](https://jules.google.com/task/16468418500112757477) started by @n24q02m*