### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential exposure in UI schema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
  **Vulnerability:** Insufficient testing of `isSafeUrl` utility, specifically the error handling path for malformed URLs and potential HTML entity bypasses.
  **Learning:** Node.js `URL` constructor has specific failure modes for strings like `http://`, `://`, and malformed IPv6 addresses, which must be explicitly verified to ensure the utility fails closed (returns `false`). HTML entities like `data&colon;` can also be used in bypass attempts.
  **Prevention:** Use a comprehensive test suite that includes not just protocol allowlists, but also malformed strings and encoded bypass vectors to ensure security utilities handle all edge cases correctly.
+## 2026-04-10 - Secure Schema Configurations
+ **Vulnerability:** Config schema (RELAY_SCHEMA) used `type: 'text'` for sensitive credentials field (`EMAIL_CREDENTIALS`).
+ **Learning:** Using `text` type for fields handling sensitive tokens exposes credentials in plaintext during UI data entry, leading to unintended disclosure.
+ **Prevention:** Always use `type: 'password'` for credential configuration fields in UI schemas to obfuscate sensitive values visually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.22.4 (2026-04-13)
+
+### Bug Fixes
+
+- Remove direct better-sqlite3 dep; add trustedDependencies for Bun script skip
+  ([`1f895e0`](https://github.com/n24q02m/better-email-mcp/commit/1f895e04284be3210a668b02b96b81c8466cf30f))
+
+
 ## v1.22.3 (2026-04-13)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"codex",
 		"opencode"
 	],
-	"version": "1.22.3",
+	"version": "1.22.4",
 	"license": "MIT",
 	"type": "module",
 	"publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.22.3",
+  "version": "1.22.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/relay-schema.test.ts
+++ b/src/relay-schema.test.ts
@@ -11,7 +11,7 @@ describe('RELAY_SCHEMA', () => {
     const emailCredentialsField = RELAY_SCHEMA.fields?.find((field: any) => field.key === 'EMAIL_CREDENTIALS')
     expect(emailCredentialsField).toBeDefined()
     expect(emailCredentialsField?.label).toBe('Email Credentials')
-    expect(emailCredentialsField?.type).toBe('text')
+    expect(emailCredentialsField?.type).toBe('password')
     expect(emailCredentialsField?.placeholder).toBe('user@gmail.com:app-password')
     expect(emailCredentialsField?.helpText).toContain('Use App Passwords, not regular account passwords')
     expect(emailCredentialsField?.required).toBe(true)

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -15,7 +15,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
     {
       key: 'EMAIL_CREDENTIALS',
       label: 'Email Credentials',
-      type: 'text',
+      type: 'password',
       placeholder: 'user@gmail.com:app-password',
       helpText:
         'Format: email:app-password. (Use App Passwords, not regular account passwords). Multiple accounts: email1:pass1,email2:pass2',


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** Config schema (`RELAY_SCHEMA`) used `type: 'text'` for sensitive credentials field (`EMAIL_CREDENTIALS`), which exposes credentials in plaintext during UI data entry.
**🎯 Impact:** Users entering their email app passwords could have their passwords stolen via shoulder surfing or screen sharing, leading to unauthorized email access.
**🔧 Fix:** Changed `type: 'text'` to `type: 'password'` in `src/relay-schema.ts` to obfuscate sensitive values visually. Also updated the corresponding test.
**✅ Verification:** Ran `bun run test` locally and ensured the schema validation passes correctly with the updated type.

---
*PR created automatically by Jules for task [4291940238661104954](https://jules.google.com/task/4291940238661104954) started by @n24q02m*