### PR TITLE
🎨 Palette: Obfuscate sensitive credentials in setup form

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.22.4 (2026-04-13)
+
+### Bug Fixes
+
+- Remove direct better-sqlite3 dep; add trustedDependencies for Bun script skip
+  ([`1f895e0`](https://github.com/n24q02m/better-email-mcp/commit/1f895e04284be3210a668b02b96b81c8466cf30f))
+
+
 ## v1.22.3 (2026-04-13)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"codex",
 		"opencode"
 	],
-	"version": "1.22.3",
+	"version": "1.22.4",
 	"license": "MIT",
 	"type": "module",
 	"publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.22.3",
+  "version": "1.22.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/relay-schema.test.ts
+++ b/src/relay-schema.test.ts
@@ -11,7 +11,7 @@ describe('RELAY_SCHEMA', () => {
     const emailCredentialsField = RELAY_SCHEMA.fields?.find((field: any) => field.key === 'EMAIL_CREDENTIALS')
     expect(emailCredentialsField).toBeDefined()
     expect(emailCredentialsField?.label).toBe('Email Credentials')
-    expect(emailCredentialsField?.type).toBe('text')
+    expect(emailCredentialsField?.type).toBe('password')
     expect(emailCredentialsField?.placeholder).toBe('user@gmail.com:app-password')
     expect(emailCredentialsField?.helpText).toContain('Use App Passwords, not regular account passwords')
     expect(emailCredentialsField?.required).toBe(true)

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -15,7 +15,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
     {
       key: 'EMAIL_CREDENTIALS',
       label: 'Email Credentials',
-      type: 'text',
+      type: 'password',
       placeholder: 'user@gmail.com:app-password',
       helpText:
         'Format: email:app-password. (Use App Passwords, not regular account passwords). Multiple accounts: email1:pass1,email2:pass2',


### PR DESCRIPTION
💡 What: Changed the input type of the `EMAIL_CREDENTIALS` field from `text` to `password` in `RELAY_SCHEMA`.
🎯 Why: To prevent the unintended disclosure of sensitive application passwords (shoulder-surfing) when users configure their email credentials in the UI.
📸 Before/After: Before, credentials were in plain text. After, credentials will be masked (e.g. `••••••••`).
♿ Accessibility: Standardizes the input field to expected web practices for sensitive information, allowing password managers to interact securely if needed.

---
*PR created automatically by Jules for task [8183661379242872451](https://jules.google.com/task/8183661379242872451) started by @n24q02m*