### PR TITLE
⚡ Bolt: [PERF] Run parseCredentials concurrently with Promise.all

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.22.4 (2026-04-13)
+
+### Bug Fixes
+
+- Remove direct better-sqlite3 dep; add trustedDependencies for Bun script skip
+  ([`1f895e0`](https://github.com/n24q02m/better-email-mcp/commit/1f895e04284be3210a668b02b96b81c8466cf30f))
+
+
 ## v1.22.3 (2026-04-13)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"codex",
 		"opencode"
 	],
-	"version": "1.22.3",
+	"version": "1.22.4",
 	"license": "MIT",
 	"type": "module",
 	"publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.22.3",
+  "version": "1.22.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -115,114 +115,115 @@ function emailToId(email: string): string {
  * For passwords containing colons, use the 3-field format to disambiguate:
  *   email:password_with:colon:imap_host
  */
+async function parseSingleCredential(entry: string): Promise<AccountConfig | null> {
+  const trimmed = entry.trim()
+  if (!trimmed) return null
+
+  const parts = trimmed.split(':')
+  const email = parts[0]!.trim()
+
+  // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
+  if (parts.length < 2) {
+    if (isOutlookDomain(email)) {
+      const discovered = discoverSettings(email)
+      if (!discovered) return null
+      const account: AccountConfig = {
+        id: emailToId(email),
+        email,
+        password: '',
+        authType: 'oauth2',
+        imap: discovered.imap,
+        smtp: discovered.smtp
+      }
+      const tokens = await loadStoredTokens(email)
+      if (tokens) account.oauth2 = tokens
+      return account
+    }
+    console.error('Skipping invalid credential entry (expected email:password)')
+    return null
+  }
+
+  let password: string
+  let customImapHost: string | undefined
+
+  if (parts.length === 2) {
+    // email:password
+    password = parts[1]!
+  } else if (parts.length === 3) {
+    // Could be email:password:imap_host OR email:password_with_colon
+    // Heuristic: if last part looks like a hostname (contains a dot), treat as imap host
+    const lastPart = parts[2]!
+    if (lastPart.includes('.')) {
+      password = parts[1]!
+      customImapHost = lastPart
+    } else {
+      // password contains a colon
+      password = `${parts[1]}:${parts[2]}`
+    }
+  } else {
+    // 4+ parts: everything between email and last part (if hostname) is password
+    const lastPart = parts[parts.length - 1]!
+    if (lastPart.includes('.')) {
+      password = parts.slice(1, -1).join(':')
+      customImapHost = lastPart
+    } else {
+      password = parts.slice(1).join(':')
+    }
+  }
+
+  // Auto-discover or use custom host
+  let imap: ServerConfig
+  let smtp: ServerConfig
+
+  if (customImapHost) {
+    imap = { host: customImapHost, port: 993, secure: true }
+    // Guess SMTP from IMAP host
+    smtp = { host: customImapHost.replace('imap.', 'smtp.'), port: 587, secure: false }
+  } else {
+    const discovered = discoverSettings(email)
+    if (!discovered) {
+      console.error('Cannot auto-discover settings for the provided email. Use format: email:password:imap.server.com')
+      return null
+    }
+    imap = discovered.imap
+    smtp = discovered.smtp
+  }
+
+  const account: AccountConfig = {
+    id: emailToId(email),
+    email,
+    password,
+    authType: 'password',
+    imap,
+    smtp
+  }
+
+  // For Outlook domains, always use OAuth2 — password auth is not supported.
+  // ensureValidToken handles auto-auth (Device Code flow) when tokens are missing.
+  if (isOutlookDomain(email)) {
+    account.authType = 'oauth2'
+    const tokens = await loadStoredTokens(email)
+    if (tokens) {
+      account.oauth2 = tokens
+    }
+  }
+
+  return account
+}
+
 export async function parseCredentials(envValue: string): Promise<AccountConfig[]> {
   if (!envValue || envValue.trim() === '') {
     return []
   }
 
-  const accounts: AccountConfig[] = []
   const entries = envValue.split(',')
 
-  for (const entry of entries) {
-    const trimmed = entry.trim()
-    if (!trimmed) continue
+  // ⚡ Bolt: Run credential parsing concurrently.
+  // Loading OAuth2 tokens from disk for multiple accounts is I/O bound.
+  // Using Promise.all reduces total parsing time from O(N) to O(1) in respect to I/O latency.
+  const accounts = await Promise.all(entries.map(parseSingleCredential))
 
-    const parts = trimmed.split(':')
-    const email = parts[0]!.trim()
-
-    // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
-    if (parts.length < 2) {
-      if (isOutlookDomain(email)) {
-        const discovered = discoverSettings(email)
-        if (!discovered) continue
-        const account: AccountConfig = {
-          id: emailToId(email),
-          email,
-          password: '',
-          authType: 'oauth2',
-          imap: discovered.imap,
-          smtp: discovered.smtp
-        }
-        const tokens = await loadStoredTokens(email)
-        if (tokens) account.oauth2 = tokens
-        accounts.push(account)
-        continue
-      }
-      console.error('Skipping invalid credential entry (expected email:password)')
-      continue
-    }
-
-    let password: string
-    let customImapHost: string | undefined
-
-    if (parts.length === 2) {
-      // email:password
-      password = parts[1]!
-    } else if (parts.length === 3) {
-      // Could be email:password:imap_host OR email:password_with_colon
-      // Heuristic: if last part looks like a hostname (contains a dot), treat as imap host
-      const lastPart = parts[2]!
-      if (lastPart.includes('.')) {
-        password = parts[1]!
-        customImapHost = lastPart
-      } else {
-        // password contains a colon
-        password = `${parts[1]}:${parts[2]}`
-      }
-    } else {
-      // 4+ parts: everything between email and last part (if hostname) is password
-      const lastPart = parts[parts.length - 1]!
-      if (lastPart.includes('.')) {
-        password = parts.slice(1, -1).join(':')
-        customImapHost = lastPart
-      } else {
-        password = parts.slice(1).join(':')
-      }
-    }
-
-    // Auto-discover or use custom host
-    let imap: ServerConfig
-    let smtp: ServerConfig
-
-    if (customImapHost) {
-      imap = { host: customImapHost, port: 993, secure: true }
-      // Guess SMTP from IMAP host
-      smtp = { host: customImapHost.replace('imap.', 'smtp.'), port: 587, secure: false }
-    } else {
-      const discovered = discoverSettings(email)
-      if (!discovered) {
-        console.error(
-          'Cannot auto-discover settings for the provided email. Use format: email:password:imap.server.com'
-        )
-        continue
-      }
-      imap = discovered.imap
-      smtp = discovered.smtp
-    }
-
-    const account: AccountConfig = {
-      id: emailToId(email),
-      email,
-      password,
-      authType: 'password',
-      imap,
-      smtp
-    }
-
-    // For Outlook domains, always use OAuth2 — password auth is not supported.
-    // ensureValidToken handles auto-auth (Device Code flow) when tokens are missing.
-    if (isOutlookDomain(email)) {
-      account.authType = 'oauth2'
-      const tokens = await loadStoredTokens(email)
-      if (tokens) {
-        account.oauth2 = tokens
-      }
-    }
-
-    accounts.push(account)
-  }
-
-  return accounts
+  return accounts.filter((account): account is AccountConfig => account !== null)
 }
 
 /**


### PR DESCRIPTION
💡 What: Refactored `parseCredentials` to extract the individual configuration parsing into `parseSingleCredential` and parse comma-separated credentials concurrently using `Promise.all`.
🎯 Why: `parseCredentials` invokes `await loadStoredTokens(email)` which loads from disk and is I/O-bound. Waiting sequentially via an `await` loop for multiple credentials has O(N) I/O wait times where N is the number of credentials. By doing this concurrently with `Promise.all`, the I/O wait latency scales to O(1).
📊 Impact: Reduced the total time spent parsing credentials scaling by the number of credentials, changing performance from linear (I/O wait-wise) to flat. 
🔬 Measurement: Verified with `bun run check` and `bun run test` that existing behavior and configurations work correctly.

---
*PR created automatically by Jules for task [7261655826237390615](https://jules.google.com/task/7261655826237390615) started by @n24q02m*