### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sensitive credential disclosure in UI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.22.4 (2026-04-13)
+
+### Bug Fixes
+
+- Remove direct better-sqlite3 dep; add trustedDependencies for Bun script skip
+  ([`1f895e0`](https://github.com/n24q02m/better-email-mcp/commit/1f895e04284be3210a668b02b96b81c8466cf30f))
+
+
 ## v1.22.3 (2026-04-13)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"codex",
 		"opencode"
 	],
-	"version": "1.22.3",
+	"version": "1.22.4",
 	"license": "MIT",
 	"type": "module",
 	"publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.22.3",
+  "version": "1.22.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/relay-schema.test.ts
+++ b/src/relay-schema.test.ts
@@ -11,7 +11,7 @@ describe('RELAY_SCHEMA', () => {
     const emailCredentialsField = RELAY_SCHEMA.fields?.find((field: any) => field.key === 'EMAIL_CREDENTIALS')
     expect(emailCredentialsField).toBeDefined()
     expect(emailCredentialsField?.label).toBe('Email Credentials')
-    expect(emailCredentialsField?.type).toBe('text')
+    expect(emailCredentialsField?.type).toBe('password')
     expect(emailCredentialsField?.placeholder).toBe('user@gmail.com:app-password')
     expect(emailCredentialsField?.helpText).toContain('Use App Passwords, not regular account passwords')
     expect(emailCredentialsField?.required).toBe(true)

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -15,7 +15,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
     {
       key: 'EMAIL_CREDENTIALS',
       label: 'Email Credentials',
-      type: 'text',
+      type: 'password',
       placeholder: 'user@gmail.com:app-password',
       helpText:
         'Format: email:app-password. (Use App Passwords, not regular account passwords). Multiple accounts: email1:pass1,email2:pass2',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `EMAIL_CREDENTIALS` field in the relay schema was set to `type: 'text'`, meaning that when users entered their sensitive credentials (email and app-password) into the UI, the input was displayed in plain text. This could lead to unintended disclosure via shoulder surfing or accidental screen exposure.
🎯 Impact: An attacker or unauthorized individual could potentially view the user's plain text email credentials if they have visual access to the user's screen during the setup process.
🔧 Fix: Changed the `type` of the `EMAIL_CREDENTIALS` field from `'text'` to `'password'` in `src/relay-schema.ts`. This ensures that the UI masks the input characters. Also updated the corresponding unit test to expect the new type.
✅ Verification: Ran the test suite using `bun run test` and `bun run check`. The tests passed successfully, confirming the schema change and that no regressions were introduced.

---
*PR created automatically by Jules for task [9343600137038206341](https://jules.google.com/task/9343600137038206341) started by @n24q02m*