### PR TITLE
🎨 Palette: Add keyboard focus indicators and contextual ARIA labels

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.22.4 (2026-04-13)
+
+### Bug Fixes
+
+- Remove direct better-sqlite3 dep; add trustedDependencies for Bun script skip
+  ([`1f895e0`](https://github.com/n24q02m/better-email-mcp/commit/1f895e04284be3210a668b02b96b81c8466cf30f))
+
+
 ## v1.22.3 (2026-04-13)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"codex",
 		"opencode"
 	],
-	"version": "1.22.3",
+	"version": "1.22.4",
 	"license": "MIT",
 	"type": "module",
 	"publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.22.3",
+  "version": "1.22.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -120,6 +120,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
             font-size: 0.75rem;
         }
         .remove-btn:hover { background-color: rgba(248, 113, 113, 0.08); }
+        .remove-btn:focus-visible { outline: 2px solid #f87171; outline-offset: 2px; }
         .field-group { margin-bottom: 0.875rem; }
         .field-label {
             display: flex;
@@ -180,6 +181,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
             transition: background-color 0.15s ease, border-color 0.15s ease;
         }
         .add-btn:hover { background-color: rgba(108, 155, 210, 0.08); border-color: #4a6fa5; }
+        .add-btn:focus-visible { outline: 2px solid #6c9bd2; outline-offset: 2px; }
         .submit-btn {
             width: 100%;
             background-color: #4a6fa5;
@@ -193,6 +195,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
             margin-top: 0.5rem;
         }
         .submit-btn:hover { background-color: #5a7fb5; }
+        .submit-btn:focus-visible { outline: 2px solid #5a7fb5; outline-offset: 2px; }
         .submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
         .status-box {
             display: none;
@@ -338,7 +341,10 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     var titleEl = cards[i].querySelector(".account-title");
                     if (titleEl) titleEl.textContent = "Account " + (i + 1);
                     var removeBtn = cards[i].querySelector(".remove-btn");
-                    if (removeBtn) removeBtn.style.display = i === 0 ? "none" : "";
+                    if (removeBtn) {
+                        removeBtn.style.display = i === 0 ? "none" : "";
+                        removeBtn.setAttribute("aria-label", "Remove Account " + (i + 1));
+                    }
                 }
             }
 
@@ -403,6 +409,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                 removeBtn.type = "button";
                 removeBtn.className = "remove-btn";
                 removeBtn.textContent = "Remove";
+                removeBtn.setAttribute("aria-label", "Remove Account " + (idx + 1));
                 removeBtn.addEventListener("click", function () {
                     card.remove();
                     updateAccountNumbers();


### PR DESCRIPTION
💡 What:
Added specific `:focus-visible` CSS rules for the ".remove-btn", ".add-btn", and ".submit-btn" classes to ensure keyboard navigation displays a clear, stylized focus indicator. Additionally, updated the form generation logic (`updateAccountNumbers` and `createAccountCard`) to dynamically set contextual `aria-label`s on the `.remove-btn` elements.

🎯 Why:
The previous iteration lacked focus rings for keyboard users, leaving navigation entirely invisible. Furthermore, when building dynamic forms where identical sub-components can be added and removed, simply labelling a button "Remove" creates an accessibility gap. Screen readers would just announce "Remove, button" for every entry, removing the context of what is being removed.

📸 Before/After:
[Review attached Playwright screenshot showing the new "Remove Account 2" ARIA label logic tested via UI automation]

♿ Accessibility:
- Contextualized generic action buttons for screen reader users via ARIA labels.
- Ensured interactive components visibly display active focus states for keyboard users.

---
*PR created automatically by Jules for task [5002798169661616156](https://jules.google.com/task/5002798169661616156) started by @n24q02m*