### PR TITLE
🎨 Palette: Add contextual ARIA labels to dynamic UI buttons

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.22.4 (2026-04-13)
+
+### Bug Fixes
+
+- Remove direct better-sqlite3 dep; add trustedDependencies for Bun script skip
+  ([`1f895e0`](https://github.com/n24q02m/better-email-mcp/commit/1f895e04284be3210a668b02b96b81c8466cf30f))
+
+
 ## v1.22.3 (2026-04-13)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"codex",
 		"opencode"
 	],
-	"version": "1.22.3",
+	"version": "1.22.4",
 	"license": "MIT",
 	"type": "module",
 	"publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.22.3",
+  "version": "1.22.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -338,7 +338,10 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     var titleEl = cards[i].querySelector(".account-title");
                     if (titleEl) titleEl.textContent = "Account " + (i + 1);
                     var removeBtn = cards[i].querySelector(".remove-btn");
-                    if (removeBtn) removeBtn.style.display = i === 0 ? "none" : "";
+                    if (removeBtn) {
+                        removeBtn.style.display = i === 0 ? "none" : "";
+                        removeBtn.setAttribute("aria-label", "Remove Account " + (i + 1));
+                    }
                 }
             }
 
@@ -403,6 +406,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                 removeBtn.type = "button";
                 removeBtn.className = "remove-btn";
                 removeBtn.textContent = "Remove";
+                removeBtn.setAttribute("aria-label", "Remove Account " + (idx + 1));
                 removeBtn.addEventListener("click", function () {
                     card.remove();
                     updateAccountNumbers();


### PR DESCRIPTION
**What:**
Injected contextual state (`Remove Account {X}`) into the `aria-label` of generic action buttons within dynamic/repeatable list components in the credential form.

**Why:**
Screen reader users would previously encounter multiple generic "Remove" buttons and lose context about exactly which account they are removing. Providing explicit context improves accessibility and usability.

**Accessibility:**
Significantly enhances the screen reader experience by uniquely identifying repetitive interactive elements.

---
*PR created automatically by Jules for task [14479115347348429595](https://jules.google.com/task/14479115347348429595) started by @n24q02m*