### PR TITLE
[FIX] Use of XXX as dummy nonce

### DIFF
--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -15,7 +15,7 @@
  *    user code back into this form.
  *
  * This form POSTs plain JSON `{ EMAIL_CREDENTIALS: "..." }` to the
- * mcp-core OAuth `/authorize?nonce=xxx` endpoint.
+ * mcp-core OAuth `/authorize?nonce=<nonce>` endpoint.
  *
  * All dynamic DOM content is built with createElement + textContent +
  * setAttribute. No innerHTML with user-provided values anywhere.


### PR DESCRIPTION
Replace `nonce=xxx` with `nonce=<nonce>` in the `src/credential-form.ts` file-level block comment to use a more standard and clearer placeholder. This change is purely documentation and does not affect functionality.

---
*PR created automatically by Jules for task [6387497295071683444](https://jules.google.com/task/6387497295071683444) started by @n24q02m*