### PR TITLE
[FIX] Actionable FIXME/TODO

### DIFF
--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -15,9 +15,7 @@
  *    user code back into this form.
  *
  * This form POSTs plain JSON `{ EMAIL_CREDENTIALS: "..." }` to the
- * mcp-core OAuth `/authorize?nonce=xxx` endpoint. The old mcp-relay-core
- * ECDH+AES crypto flow has been removed -- mcp-core handles nonce-based
- * decryption itself.
+ * mcp-core OAuth `/authorize?nonce=xxx` endpoint.
  *
  * All dynamic DOM content is built with createElement + textContent +
  * setAttribute. No innerHTML with user-provided values anywhere.


### PR DESCRIPTION
Removed outdated comment in src/credential-form.ts referencing old mcp-relay-core crypto flow and ECDH+AES logic. The system now correctly references mcp-core handling the /authorize endpoint.

---
*PR created automatically by Jules for task [12865860055898292664](https://jules.google.com/task/12865860055898292664) started by @n24q02m*