### PR TITLE
[FIX] Deprecated comment

### DIFF
--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -1,7 +1,7 @@
 /**
  * OAuth2 for Outlook.com / Hotmail / Live accounts
  *
- * Microsoft deprecated Basic Auth for consumer IMAP/SMTP.
+ * Microsoft has disabled Basic Auth for Outlook/Hotmail/Live accounts (September 2024).
  * This module implements Device Code Grant (RFC 8628) for CLI-based auth,
  * persistent token storage, and automatic token refresh.
  */


### PR DESCRIPTION
Updated the file-level comment in `src/tools/helpers/oauth2.ts` to reflect that Microsoft has fully disabled Basic Authentication for personal accounts as of September 2024. The previous comment used the term 'deprecated', which is now outdated.

---
*PR created automatically by Jules for task [14208248652500790556](https://jules.google.com/task/14208248652500790556) started by @n24q02m*