### PR TITLE
🛡️ Sentinel: HIGH Fix Command Injection in tryOpenBrowser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,7 @@
-## 2026-04-10 - Enhanced URL Safety Testing
- **Vulnerability:** Insufficient testing of `isSafeUrl` utility, specifically the error handling path for malformed URLs and potential HTML entity bypasses.
- **Learning:** Node.js `URL` constructor has specific failure modes for strings like `http://`, `://`, and malformed IPv6 addresses, which must be explicitly verified to ensure the utility fails closed (returns `false`). HTML entities like `data&colon;` can also be used in bypass attempts.
- **Prevention:** Use a comprehensive test suite that includes not just protocol allowlists, but also malformed strings and encoded bypass vectors to ensure security utilities handle all edge cases correctly.
+## 2025-04-16 - Command Injection via Missing URL Validation in tryOpenBrowser
+
+ **Vulnerability:** The `tryOpenBrowser` function in `src/credential-state.ts` was passing a URL directly from the relay server to `execFile` without validation. On Windows, using `rundll32 url.dll,FileProtocolHandler` with a `file://` or local path could lead to execution of arbitrary files.
+
+ **Learning:** Even when using `execFile` to prevent shell injection, the arguments themselves must be validated if they are used by the child process in a way that can trigger further execution (like protocol handlers).
+
+ **Prevention:** Always validate and canonicalize URLs using `new URL()` and restrict protocols to a safe allowlist (e.g., `http:`, `https:`) before passing them to system commands or protocol handlers.

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -258,13 +258,26 @@ async function handlePostRelayOAuth(relayBase: string, session: any, credentials
 function tryOpenBrowser(url: string): void {
   if (process.env.E2E_SETUP || process.env.CI || process.env.VITEST) return
 
+  let safeUrl: string
+  try {
+    const parsed = new URL(url)
+    // Security: Only allow web protocols to prevent javascript: or file: attacks
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return
+    }
+    // URL.href canonicalizes the string, neutering leading hyphens or shell metacharacters
+    safeUrl = parsed.href
+  } catch {
+    return
+  }
+
   const platform = process.platform
   if (platform === 'darwin') {
-    execFile('open', [url], () => {})
+    execFile('open', [safeUrl], () => {})
   } else if (platform === 'win32') {
-    execFile('rundll32', ['url.dll,FileProtocolHandler', url], () => {})
+    execFile('rundll32', ['url.dll,FileProtocolHandler', safeUrl], () => {})
   } else {
-    execFile('xdg-open', [url], () => {})
+    execFile('xdg-open', [safeUrl], () => {})
   }
 }
 


### PR DESCRIPTION
🚨 Severity: High
💡 Vulnerability: Command Injection via Missing URL Validation in tryOpenBrowser
🎯 Impact: A malicious relay server could trigger execution of local files (like .bat, .cmd, or .exe) on the user's machine by providing a specially crafted URL (e.g., using file:// protocol).
🔧 Fix: Added URL validation and canonicalization using the `URL` constructor in `tryOpenBrowser`. It now only allows `http:` and `https:` protocols and uses the canonicalized `url.href`.
✅ Verification: Created a reproduction test case that mocks `execFile` and confirms that unsafe URLs (file://, javascript:) are now blocked while safe URLs (http://) are allowed. Ran all existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [16772508575107796635](https://jules.google.com/task/16772508575107796635) started by @n24q02m*