### PR TITLE
🎨 Palette: Add contextual ARIA labels to repeatable UI components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-16 - Add contextual ARIA labels to repeatable UI components
+**Learning:** Generic action buttons (e.g., "Remove") in dynamic, repeatable lists (like form arrays or account lists) lack context for screen reader users when multiple instances exist on the page.
+**Action:** Always inject contextual state (like the current item's index or name) into the `aria-label`s of generic action buttons (e.g., `aria-label="Remove Account 1"`) to preserve accessibility context for screen readers.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -338,7 +338,10 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     var titleEl = cards[i].querySelector(".account-title");
                     if (titleEl) titleEl.textContent = "Account " + (i + 1);
                     var removeBtn = cards[i].querySelector(".remove-btn");
-                    if (removeBtn) removeBtn.style.display = i === 0 ? "none" : "";
+                    if (removeBtn) {
+                        removeBtn.style.display = i === 0 ? "none" : "";
+                        removeBtn.setAttribute("aria-label", "Remove Account " + (i + 1));
+                    }
                 }
             }
 


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`s to the "Remove" buttons in the repeating account cards of the email credential setup form.
🎯 Why: To ensure screen reader users have clear context (e.g., "Remove Account 2") rather than hearing multiple generic "Remove" buttons when managing their email accounts.
📸 Before/After: Visual UI is unaffected; the improvement is in the DOM attributes for assistive technology.
♿ Accessibility: Preserves accessibility context for screen readers in dynamic, repeatable list UI components.

---
*PR created automatically by Jules for task [3207422191043517639](https://jules.google.com/task/3207422191043517639) started by @n24q02m*