### PR TITLE
⚡ Bolt: [PERF] Parallelize IMAP connection tests to reduce setup latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-16 - [PERF] Parallelize IMAP connection tests
+**Learning:** Sequential `await` calls in loops for independent network operations (like validating multiple IMAP credentials during server startup) introduce unnecessary latency that scales linearly with the number of accounts.
+**Action:** Use `Promise.all` with `Array.prototype.map` to concurrently execute independent I/O-bound tasks. Retain sequential error reporting by finding the first encountered error in the results array to preserve original behavior.

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -145,11 +145,21 @@ export async function startHttp(): Promise<void> {
 
     // Validate every IMAP/SMTP (password) account via real IMAP login first
     // so credential errors are surfaced before we touch Microsoft OAuth.
-    for (const account of imapAccounts) {
-      const result = await testImapConnection(account)
-      if (result !== null) return result
-      console.error(`[${SERVER_NAME}] IMAP login OK for ${account.email}`)
-    }
+    // ⚡ Bolt: Parallelize independent IMAP connection validations to minimize
+    // server setup latency when multiple accounts are configured.
+    const imapResults = await Promise.all(
+      imapAccounts.map(async (account) => {
+        const result = await testImapConnection(account)
+        if (result === null) {
+          console.error(`[${SERVER_NAME}] IMAP login OK for ${account.email}`)
+        }
+        return result
+      })
+    )
+
+    // Return the first error encountered, if any, to preserve original behavior.
+    const firstError = imapResults.find((r) => r !== null)
+    if (firstError) return firstError
 
     // Persist credentials (including Outlook email-only entries) so a server
     // restart picks them up without re-running the form. Background OAuth


### PR DESCRIPTION
**💡 What:** Replaced a sequential `for...await` loop with concurrent execution using `Promise.all` in `testImapConnection` during the HTTP transport startup phase. 

**🎯 Why:** To reduce startup and setup latency. Previously, if multiple IMAP accounts were configured, the server would test their connections one by one. The total latency scaled linearly with the number of accounts. Parallelizing these independent network requests significantly decreases the time it takes to validate credentials and start the server.

**📊 Impact:** Startup time for IMAP connection validation changes from O(N) to O(1) (bounded by the slowest connection time), leading to measurably faster setup for users with multiple configured accounts.

**🧪 Measurement:** Run `bun run test` to verify no regressions in credential validation behavior. Visual verification during startup with multiple accounts will show a single delay instead of sequential delays.

---
*PR created automatically by Jules for task [13440178657845031863](https://jules.google.com/task/13440178657845031863) started by @n24q02m*