### PR TITLE
fix: precompile IMAP search regex patterns as module constants

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -108,6 +108,29 @@ async function withConnection<T>(account: AccountConfig, fn: (client: ImapFlow) 
  *   "UNREAD FROM boss SINCE 2026-03-01"    -> { seen: false, from: 'boss', since: Date }
  *   "meeting notes"                         -> { subject: 'meeting notes' }
  */
+// Pre-compile static RegExp patterns as module-level constants so
+// buildSearchCriteria does not recompile them per call.
+const FLAG_MATCHERS: ReadonlyArray<{ pattern: RegExp; key: string; value: boolean }> = [
+  { pattern: /\bUNFLAGGED\b/i, key: 'flagged', value: false },
+  { pattern: /\bUNSTARRED\b/i, key: 'flagged', value: false },
+  { pattern: /\bUNREAD\b/i, key: 'seen', value: false },
+  { pattern: /\bUNSEEN\b/i, key: 'seen', value: false },
+  { pattern: /\bFLAGGED\b/i, key: 'flagged', value: true },
+  { pattern: /\bSTARRED\b/i, key: 'flagged', value: true },
+  { pattern: /\bREAD\b/i, key: 'seen', value: true },
+  { pattern: /\bSEEN\b/i, key: 'seen', value: true }
+]
+
+const DATE_MATCHERS = {
+  SINCE: { valid: /\bSINCE\s+(\d{4}-\d{2}-\d{2})\b/i, invalid: /\bSINCE\s+\S/i },
+  BEFORE: { valid: /\bBEFORE\s+(\d{4}-\d{2}-\d{2})\b/i, invalid: /\bBEFORE\s+\S/i }
+} as const
+
+const KV_MATCHERS = {
+  FROM: /\bFROM\s+("[^"]+"|'[^']+'|\S+)/i,
+  TO: /\bTO\s+("[^"]+"|'[^']+'|\S+)/i
+} as const
+
 function buildSearchCriteria(query: string): any {
   const trimmed = query.trim()
   if (!trimmed) return {}
@@ -120,19 +143,7 @@ function buildSearchCriteria(query: string): any {
 
   // 1. Extract standalone flag keywords (no arguments).
   //    Check longer prefixes first to avoid partial matches (UNFLAGGED before FLAGGED, etc.)
-  const flagMap: [string, string, boolean][] = [
-    ['UNFLAGGED', 'flagged', false],
-    ['UNSTARRED', 'flagged', false],
-    ['UNREAD', 'seen', false],
-    ['UNSEEN', 'seen', false],
-    ['FLAGGED', 'flagged', true],
-    ['STARRED', 'flagged', true],
-    ['READ', 'seen', true],
-    ['SEEN', 'seen', true]
-  ]
-
-  for (const [keyword, key, value] of flagMap) {
-    const pattern = new RegExp(`\\b${keyword}\\b`, 'i')
+  for (const { pattern, key, value } of FLAG_MATCHERS) {
     if (pattern.test(remaining)) {
       criteria[key] = value
       remaining = remaining.replace(pattern, ' ').trim()
@@ -141,11 +152,12 @@ function buildSearchCriteria(query: string): any {
 
   // 2. Extract date clauses: SINCE YYYY-MM-DD, BEFORE YYYY-MM-DD
   for (const keyword of ['SINCE', 'BEFORE'] as const) {
-    const dateMatch = remaining.match(new RegExp(`\\b${keyword}\\s+(\\d{4}-\\d{2}-\\d{2})\\b`, 'i'))
+    const { valid, invalid } = DATE_MATCHERS[keyword]
+    const dateMatch = remaining.match(valid)
     if (dateMatch) {
       criteria[keyword.toLowerCase()] = new Date(dateMatch[1]!)
       remaining = remaining.replace(dateMatch[0], ' ').trim()
-    } else if (new RegExp(`\\b${keyword}\\s+\\S`, 'i').test(remaining)) {
+    } else if (invalid.test(remaining)) {
       throw new EmailMCPError(
         `Invalid date format in ${keyword} query`,
         'VALIDATION_ERROR',
@@ -156,7 +168,7 @@ function buildSearchCriteria(query: string): any {
 
   // 3. Extract FROM / TO (single token or quoted string)
   for (const keyword of ['FROM', 'TO'] as const) {
-    const kvMatch = remaining.match(new RegExp(`\\b${keyword}\\s+("[^"]+"|'[^']+'|\\S+)`, 'i'))
+    const kvMatch = remaining.match(KV_MATCHERS[keyword])
     if (kvMatch) {
       criteria[keyword.toLowerCase()] = kvMatch[1]!.replace(/^["']|["']$/g, '')
       remaining = remaining.replace(kvMatch[0], ' ').trim()


### PR DESCRIPTION
## Summary

- Supersedes #397 (Bolt branch diverged from main — main shipped the OAuth refactor, credential-form.ts removal, http.ts -> oauth-server.ts rename, and many Renovate bumps since the branch was cut).
- Also, the gitattributes LF-fix I added on the Bolt branch is already on main (commit 07f976b, 2026-04-13), so that part was redundant.
- Cherry-picks the valuable perf change: hoist the RegExp objects used by buildSearchCriteria into module-level constants so the function does not recompile them on every IMAP search.

## Test plan

- [x] Pre-commit hooks pass (biome + tsc + vitest + gitleaks)
- [ ] CI green on all three OS matrices (ubuntu/macos/windows)

Closes #397.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>