### PR TITLE
fix: sync docs with Phase M completion reality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ JULES.md
 # Generated files
 *_e2e_result.json
 docs/superpowers/
+
+# Test coverage artifacts
+coverage.xml
+htmlcov/
+.coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ import { searchEmails, readEmail } from '../helpers/imap-client.js'
 
 ### Architecture Pattern
 
-- **Composite/Mega Tool**: Each domain (messages, folders, attachments, send) is one function
+- **Composite/Mega Tool**: Each domain (messages, folders, attachments, send, setup) is one function
 - Input: `{ action, ...params }`, dispatch via `switch(input.action)`
 - Every composite tool exports: 1 async function + 1 interface
 - Signature: `async function toolName(accounts: AccountConfig[], input: TypedInput): Promise<any>`
@@ -117,7 +117,7 @@ src/
   docs/                       # Markdown docs served as MCP resources
   tools/
     registry.ts               # Tool registration + routing
-    composite/                 # One file per domain (messages, folders, attachments, send)
+    composite/                 # One file per domain (messages, folders, attachments, send, setup)
     helpers/                   # errors, config, html-utils, imap-client, smtp-client
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - better-email-mcp
 
 MCP Server cho Email (IMAP/SMTP). TypeScript, Node.js >= 24, bun, ESM.
-5 composite tools, 15 actions. Multi-account, App Passwords, auto-discovery.
+6 composite tools, 20 actions (messages, folders, attachments, send, setup, help). Multi-account, App Passwords, auto-discovery.
 
 ## Commands
 
@@ -54,7 +54,7 @@ src/
   docs/                          # Markdown docs phuc vu qua MCP resources
   tools/
     registry.ts                  # Tool registration + routing
-    composite/                   # 1 file per domain: messages, folders, attachments, send
+    composite/                   # 1 file per domain: messages, folders, attachments, send, setup
     helpers/                     # errors, config, html-utils, imap-client, smtp-client
 ```
 


### PR DESCRIPTION
## Summary

Updates CLAUDE.md and AGENTS.md to reflect the current 6-tool (20-action) architecture after Phase L/M:

- CLAUDE.md: "5 composite tools, 15 actions" -> "6 composite tools, 20 actions (messages, folders, attachments, send, setup, help)"
- CLAUDE.md: `composite/` listing now includes `setup`
- AGENTS.md: same corrections

## Drift fixed

- Previous docs described the pre-Phase-L state, before the `setup` composite tool was added for the browser-relay credential flow.
- README.md was already accurate; only CLAUDE/AGENTS needed sync.

## Test plan

- [ ] Review CLAUDE.md + AGENTS.md vs current src/tools/composite/*.ts
- [ ] No other stale version pins or legacy transport references found in this repo