### PR TITLE
🎨 Palette: Add contextual ARIA labels to dynamic form buttons

### DIFF
--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -338,7 +338,10 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     var titleEl = cards[i].querySelector(".account-title");
                     if (titleEl) titleEl.textContent = "Account " + (i + 1);
                     var removeBtn = cards[i].querySelector(".remove-btn");
-                    if (removeBtn) removeBtn.style.display = i === 0 ? "none" : "";
+                    if (removeBtn) {
+                        removeBtn.style.display = i === 0 ? "none" : "";
+                        removeBtn.setAttribute("aria-label", "Remove Account " + (i + 1));
+                    }
                 }
             }
 
@@ -403,6 +406,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                 removeBtn.type = "button";
                 removeBtn.className = "remove-btn";
                 removeBtn.textContent = "Remove";
+                removeBtn.setAttribute("aria-label", "Remove Account " + (idx + 1));
                 removeBtn.addEventListener("click", function () {
                     card.remove();
                     updateAccountNumbers();


### PR DESCRIPTION
💡 What: Added dynamically calculated, contextual `aria-label`s to the generic "Remove" action buttons inside the repeatable `createAccountCard` component of the email setup form.

🎯 Why: When rendering generic action buttons (like "Remove") inside a repeatable list (like "Account 1", "Account 2"), simply using the visible text "Remove" lacks sufficient context for screen reader users. Furthermore, if a middle item is removed and the visible items re-number, static ARIA labels become out of sync. Dynamically updating these labels based on the new list order ensures screen reader users always know exactly which account they are removing.

📸 Before/After:
Before: `<button class="remove-btn">Remove</button>`
After: `<button class="remove-btn" aria-label="Remove Account 1">Remove</button>` (dynamically updates when accounts are removed/added).

♿ Accessibility: Significantly improves keyboard and screen-reader accessibility for the dynamic account setup form. Screen readers will now announce "Remove Account 1, button" instead of just "Remove, button", avoiding ambiguity.

---
*PR created automatically by Jules for task [3600432728536595652](https://jules.google.com/task/3600432728536595652) started by @n24q02m*