### PR TITLE
🎨 Palette: Add aria-busy to connect button for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-19 - Accessible Loading States for Buttons
+**Learning:** For asynchronous submission buttons, simply disabling them and changing text (e.g. to "Connecting...") is not fully accessible. Screen readers benefit significantly from the `aria-busy` attribute, which provides essential processing state feedback to assistive technologies.
+**Action:** Always combine native `disabled` attributes with `aria-busy="true"` on submit buttons when awaiting server responses, and `removeAttribute("aria-busy")` or set it to false when the request is complete, regardless of success or failure.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -566,6 +566,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
                 submitBtn.disabled = true;
+                submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.textContent = "Connecting...";
 
                 fetch(submitUrl, {
@@ -577,15 +578,18 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                         return resp.json().then(function (data) {
                             if (data.ok) {
                                 if (data.next_step && data.next_step.type === "oauth_device_code") {
+                                    submitBtn.removeAttribute("aria-busy");
                                     submitBtn.textContent = "Awaiting Microsoft...";
                                     renderOAuthDeviceCode(data.next_step);
                                 } else {
                                     showStatus("success", data.message || "Setup complete! You can close this tab.");
+                                    submitBtn.removeAttribute("aria-busy");
                                     submitBtn.textContent = "Connected";
                                 }
                             } else {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
                                 submitBtn.disabled = false;
+                                submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                             }
                         });
@@ -593,6 +597,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
                         submitBtn.disabled = false;
+                        submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     });
             });


### PR DESCRIPTION
💡 What: Added `aria-busy="true"` to the submit button while connecting, and removed it on success/error.
🎯 Why: Simply disabling a button is not fully accessible. Screen readers benefit significantly from the `aria-busy` attribute, which provides essential processing state feedback to assistive technologies.
📸 Before/After: Visuals look identical (button says "Connecting..." and is disabled), but the underlying DOM now sets `aria-busy` for screen readers.
♿ Accessibility: Improved screen reader feedback during asynchronous form submission.

---
*PR created automatically by Jules for task [13225949452944441814](https://jules.google.com/task/13225949452944441814) started by @n24q02m*