### PR TITLE
🎨 Palette: Add data-loss confirmation and improve text contrast

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,9 @@
+## 2024-05-14 - Data Loss Prevention & Dark Mode Contrast
+
+**Learning:**
+1. Dynamically added form elements in multi-step flows are prone to accidental clicks leading to complete data loss for that section.
+2. Standard "grey" shades like `#666` used for secondary text in dark mode (background `#1a1a1a` or `#0f0f0f`) often fail WCAG AA contrast ratio requirements (4.5:1), making them inaccessible to users with low vision.
+
+**Action:**
+1. Always add a confirmation step (e.g., `confirm()`) before removing dynamically generated form segments if they contain user-entered data.
+2. Use lighter greys like `#9ca3af` for secondary text against dark backgrounds to ensure adequate contrast.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -81,7 +81,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
         .server-name { font-size: 1.375rem; font-weight: 600; color: #fff; margin-bottom: 0.375rem; }
         .server-id {
             font-size: 0.8125rem;
-            color: #666;
+            color: #9ca3af;
             font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
             margin-bottom: 0.5rem;
         }
@@ -132,9 +132,9 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
         .optional-badge {
             font-size: 0.6875rem;
             font-weight: 400;
-            color: #666;
+            color: #9ca3af;
             background-color: rgba(255, 255, 255, 0.04);
-            border: 1px solid #333;
+            border: 1px solid #4b5563;
             border-radius: 4px;
             padding: 0.1rem 0.4rem;
         }
@@ -154,7 +154,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
             box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
         }
         .field-input::placeholder { color: #555; }
-        .help-text { font-size: 0.8125rem; color: #666; margin-top: 0.375rem; }
+        .help-text { font-size: 0.8125rem; color: #9ca3af; margin-top: 0.375rem; }
         .help-text a { color: #6c9bd2; text-decoration: none; }
         .help-text a:hover { text-decoration: underline; }
         .notice {
@@ -409,6 +409,17 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                 removeBtn.textContent = "Remove";
                 removeBtn.setAttribute("aria-label", "Remove Account " + (idx + 1));
                 removeBtn.addEventListener("click", function () {
+                    var inputs = card.querySelectorAll("input");
+                    var hasData = false;
+                    for (var i = 0; i < inputs.length; i++) {
+                        if (inputs[i].value.trim() !== "") {
+                            hasData = true;
+                            break;
+                        }
+                    }
+                    if (hasData && !window.confirm("This account has unsaved data. Are you sure you want to remove it?")) {
+                        return;
+                    }
                     card.remove();
                     updateAccountNumbers();
                 });


### PR DESCRIPTION
💡 What: Added a confirmation dialog before removing dynamically generated account forms if they contain unsaved data. Improved the text contrast of secondary labels and optional badges in the UI by replacing color `#666` with `#9ca3af` and the border color from `#333` to `#4b5563`.
🎯 Why: Prevents accidental data loss when a user mistakenly clicks the "Remove" button on an account they have spent time filling out. Improves accessibility for users with low vision by satisfying WCAG AA contrast ratio requirements for dark mode themes.
📸 Before/After: Visual changes to text color on the setup form. The "Remove" button now pops a `confirm()` prompt before deleting an element with input data.
♿ Accessibility: Increased the contrast of secondary elements against the dark mode background to ensure they are legible.

---
*PR created automatically by Jules for task [2977163474414377559](https://jules.google.com/task/2977163474414377559) started by @n24q02m*