### PR TITLE
⚡ Bolt: [performance improvement] Fast-fail IMAP validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-22 - [Fast-fail IMAP validation]
+**Learning:** In `validateImapAccounts`, using `Promise.all` mapping over `testImapConnection` will wait for all connection tests to complete before resolving, even if an early failure occurs (e.g. an incorrect password vs a 15-second timeout). This delays the return of the error to the user interface.
+**Action:** Implement a "fail-fast" pattern by checking for a non-null result (failure) inside the map callback and `throw`ing the error object immediately. This triggers `Promise.all`'s short-circuit behavior, catching the thrown object and immediately resolving/returning it.

--- a/src/spawn-setup.ts
+++ b/src/spawn-setup.ts
@@ -71,16 +71,23 @@ async function testImapConnection(account: AccountConfig): Promise<NextStep | nu
 
 /** Validate every IMAP (password) account in parallel. */
 async function validateImapAccounts(imapAccounts: AccountConfig[]): Promise<NextStep | null> {
-  const results = await Promise.all(
-    imapAccounts.map(async (account) => {
-      const result = await testImapConnection(account)
-      if (result === null) {
+  try {
+    await Promise.all(
+      imapAccounts.map(async (account) => {
+        const result = await testImapConnection(account)
+        if (result !== null) {
+          throw result // Fail fast: short-circuit Promise.all
+        }
         console.error(`[${SERVER_NAME}] IMAP login OK for ${account.email}`)
-      }
-      return result
-    })
-  )
-  return results.find((r) => r !== null) ?? null
+      })
+    )
+    return null
+  } catch (error: any) {
+    if (error && typeof error === 'object' && 'type' in error) {
+      return error as NextStep
+    }
+    throw error
+  }
 }
 
 /** Initiate Microsoft Device Code flow for the first Outlook account pending auth. */


### PR DESCRIPTION
💡 What: Modified `validateImapAccounts` in `src/spawn-setup.ts` to implement a fail-fast pattern using `Promise.all` rejection.
🎯 Why: If one IMAP connection test failed immediately (e.g. bad password), the system previously waited for all other concurrent tests to finish or timeout (up to 15s) before returning the error to the UI.
📊 Impact: Reduces validation error feedback time from up to ~15s down to <1s for immediate failures, vastly improving UX during setup.
🔬 Measurement: Configured with one valid account and one invalid account, the error is now returned instantly.

---
*PR created automatically by Jules for task [7403341602234330287](https://jules.google.com/task/7403341602234330287) started by @n24q02m*