### PR TITLE
🎨 Palette: Improve accessibility with help text ARIA links and color contrast

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,9 @@
 **Action:**
 1. Always add a confirmation step (e.g., `confirm()`) before removing dynamically generated form segments if they contain user-entered data.
 2. Use lighter greys like `#9ca3af` for secondary text against dark backgrounds to ensure adequate contrast.
+
+## 2024-05-15 - ARIA connections for generated elements
+
+**Learning:** When building dynamic forms with vanilla JS, helper text elements are often generated sequentially alongside inputs but lack semantic connection, causing screen readers to miss crucial instructions (like "Leave empty for auto-detection").
+
+**Action:** Always generate a deterministic `id` for helper text elements and bind it to the associated input using `aria-describedby` immediately during creation to ensure robust accessibility.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -85,7 +85,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
             font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
             margin-bottom: 0.5rem;
         }
-        .server-description { font-size: 0.9rem; color: #999; margin-top: 0.5rem; }
+        .server-description { font-size: 0.9rem; color: #9ca3af; margin-top: 0.5rem; }
         .form-title {
             font-size: 0.875rem;
             font-weight: 500;
@@ -153,7 +153,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
             border-color: #4a6fa5;
             box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
         }
-        .field-input::placeholder { color: #555; }
+        .field-input::placeholder { color: #9ca3af; }
         .help-text { font-size: 0.8125rem; color: #9ca3af; margin-top: 0.375rem; }
         .help-text a { color: #6c9bd2; text-decoration: none; }
         .help-text a:hover { text-decoration: underline; }
@@ -316,7 +316,9 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
 
                 if (helpText) {
                     var help = document.createElement("p");
+                    help.id = "help-" + key + "_" + idx;
                     help.className = "help-text";
+                    input.setAttribute("aria-describedby", help.id);
                     if (helpUrl) {
                         var a = document.createElement("a");
                         a.setAttribute("href", helpUrl);


### PR DESCRIPTION
💡 What:
- Updated the hardcoded color for helper text and placeholders from standard greys (`#999`, `#555`) to a lighter shade (`#9ca3af`).
- Programmatically assigned unique `id`s to dynamically generated helper text paragraphs in the multi-account setup form.
- Bound these helper texts to their corresponding input elements using `aria-describedby`.

🎯 Why:
- The standard dark grey shades often fail to meet the WCAG AA contrast ratio of 4.5:1 against the dark background (`#1a1a1a`), making them difficult for users with low vision to read.
- Previously, screen readers would not automatically announce the helper text (e.g., "Leave empty for auto-detection") when users focused on specific inputs because the semantic link was missing. 

📸 Before/After:
*Before:* Placeholders and secondary text were a dark, low-contrast grey. Inputs with help text lacked `aria-describedby`.
*After:* Placeholders and secondary text use `#9ca3af` for improved contrast. Inputs like "IMAP Host" now dynamically link to their helper instructions via `aria-describedby="help-imap_0"`.

♿ Accessibility:
- Significantly improves WCAG AA contrast compliance for secondary text elements in dark mode.
- Enhances form navigation for visually impaired users by ensuring contextually important helper text is announced immediately upon input focus.

---
*PR created automatically by Jules for task [15645341543272644707](https://jules.google.com/task/15645341543272644707) started by @n24q02m*