### PR TITLE
fix: force fresh Outlook device-code on every form submit

### DIFF
--- a/src/spawn-setup.ts
+++ b/src/spawn-setup.ts
@@ -180,6 +180,15 @@ export function buildRunLocalServerOptions(args: SpawnCredentialFormArgs): RunLo
     const imapAccounts: AccountConfig[] = []
     for (const account of accounts) {
       if (isOutlookDomain(account.email) || account.authType === 'oauth2') {
+        // Force fresh device-code flow for every form submit by clearing any
+        // cached tokens that ``parseCredentials`` may have populated via
+        // ``loadStoredTokens``. Without this, ``initiateOutlookOAuth`` filters
+        // out accounts with ``.oauth2`` set and silently returns ``null`` →
+        // the form shows "Setup complete" without ever displaying the Microsoft
+        // device-code step, which is the UX bug reported 2026-04-24.
+        // ``initiateOutlookDeviceCode`` persists the new tokens so subsequent
+        // ``loadConfig()`` calls read fresh tokens as usual.
+        account.oauth2 = undefined
         outlookAccounts.push(account)
       } else {
         imapAccounts.push(account)

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -281,6 +281,46 @@ describe('http transport', () => {
       })
     })
 
+    it('forces fresh device-code flow even when parseCredentials returns cached oauth2 tokens', async () => {
+      // Regression for 2026-04-24 UX bug: ``parseSingleCredential`` calls
+      // ``loadStoredTokens`` and populates ``account.oauth2`` when a previous
+      // session saved tokens. Without the force-refresh, ``initiateOutlookOAuth``
+      // filters these accounts out via ``!a.oauth2`` and silently returns null,
+      // so the form shows "Setup complete" without ever displaying the Microsoft
+      // device-code step. ``onCredentialsSaved`` must clear cached tokens on
+      // every form submit so the user always sees + completes the device-code UI.
+      const mockAccounts = [
+        {
+          email: 'test@outlook.com',
+          imap: {},
+          authType: 'oauth2',
+          // Simulate cached tokens from a previous session.
+          oauth2: {
+            accessToken: 'stale-access',
+            refreshToken: 'stale-refresh',
+            expiresAt: 0,
+            clientId: 'stale-client'
+          }
+        }
+      ]
+      vi.mocked(parseCredentials).mockResolvedValue(mockAccounts as any)
+      vi.mocked(isOutlookDomain).mockReturnValue(true)
+      vi.mocked(initiateOutlookDeviceCode).mockResolvedValue({
+        verificationUri: 'https://microsoft.com/devicelogin',
+        userCode: 'ABCD-EFGH'
+      } as any)
+
+      const result = await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
+
+      expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function))
+      expect(result).toEqual({
+        type: 'oauth_device_code',
+        verification_url: 'https://microsoft.com/devicelogin',
+        user_code: 'ABCD-EFGH',
+        email: 'test@outlook.com'
+      })
+    })
+
     it('logs error if writeConfig fails but continues', async () => {
       const mockAccounts = [{ email: 'test@gmail.com', imap: {}, authType: 'password' }]
       vi.mocked(parseCredentials).mockResolvedValue(mockAccounts as any)


### PR DESCRIPTION
## Summary

- Clear cached `account.oauth2` tokens at the start of the Outlook-vs-IMAP split in `onCredentialsSaved` so `initiateOutlookOAuth` always triggers the Microsoft device-code step on form submit. Previously, tokens persisted in `~/.better-email-mcp/tokens.json` from an earlier session silently bypassed the flow and the browser jumped straight to "Setup complete" — the UX bug surfaced during the 2026-04-24 E2E run.
- Bundles the already-merged mcp-core 1.7.5 bump (consolidated branch).
- Adds a regression test that exercises the exact shape returned by `parseCredentials` when tokens are cached.

## Test plan

- [x] `bun run test` → 544/544 pass locally
- [x] `bun run check` → biome + tsc --noEmit pass
- [ ] After merge + deploy, rerun config #3 E2E (`scratch/e2e_oauth_client.py https://better-email-mcp.n24q02m.com`) and verify the form shows the Microsoft device-code page when an Outlook account is entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)