### PR TITLE
🎨 Palette: Fix data loss during dynamic email domain changes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,9 @@
 **Learning:** When building dynamic forms with vanilla JS, helper text elements are often generated sequentially alongside inputs but lack semantic connection, causing screen readers to miss crucial instructions (like "Leave empty for auto-detection").
 
 **Action:** Always generate a deterministic `id` for helper text elements and bind it to the associated input using `aria-describedby` immediately during creation to ensure robust accessibility.
+
+## 2025-02-12 - Dynamic Form State Preservation
+
+**Learning:** When dynamically rebuilding form sections based on user input (e.g., domain auto-detection), any data already entered into the targeted DOM elements will be lost if the inputs are destroyed and recreated without explicit state preservation.
+
+**Action:** Capture the current value of the targeted inputs before rebuilding the DOM elements and reapply the captured state to the newly created inputs.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -348,7 +348,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                 }
             }
 
-            function renderDomainSpecificFields(extraContainer, idx, domain) {
+            function renderDomainSpecificFields(extraContainer, idx, domain, state) {
                 clearChildren(extraContainer);
                 if (!domain) return;
 
@@ -356,6 +356,8 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     var notice = document.createElement("div");
                     notice.className = "notice";
                     notice.dataset.role = "oauth-notice";
+                    notice.setAttribute("role", "status");
+                    notice.setAttribute("aria-live", "polite");
                     notice.textContent =
                         "Outlook/Hotmail/Live requires OAuth2. This will be handled automatically by the server after you submit -- a Microsoft sign-in URL + code will appear here.";
                     extraContainer.appendChild(notice);
@@ -374,12 +376,15 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                         info.helpText,
                         info.helpUrl
                     );
+                    if (state && state.password) pw.input.value = state.password;
                     extraContainer.appendChild(pw.group);
                     return;
                 }
 
                 var pwCustom = createFieldGroup(idx, "password", "Password", "password", "", true, "", "");
+                if (state && state.password) pwCustom.input.value = state.password;
                 extraContainer.appendChild(pwCustom.group);
+
                 var imap = createFieldGroup(
                     idx,
                     "imap",
@@ -390,6 +395,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     "Optional. Leave empty for auto-detection.",
                     ""
                 );
+                if (state && state.imap) imap.input.value = state.imap;
                 extraContainer.appendChild(imap.group);
             }
 
@@ -436,11 +442,18 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                 extra.dataset.role = "extra";
                 card.appendChild(extra);
 
+                var state = { password: "", imap: "" };
+
                 emailField.input.addEventListener("input", function () {
+                    var pwNode = extra.querySelector('input[data-role="password"]');
+                    if (pwNode) state.password = pwNode.value;
+                    var imapNode = extra.querySelector('input[data-role="imap"]');
+                    if (imapNode) state.imap = imapNode.value;
+
                     var val = emailField.input.value;
                     var at = val.indexOf("@");
                     var domain = at >= 0 ? val.slice(at + 1).trim().toLowerCase() : "";
-                    renderDomainSpecificFields(extra, idx, domain);
+                    renderDomainSpecificFields(extra, idx, domain, state);
                 });
 
                 return card;


### PR DESCRIPTION
💡 **What:** 
* Preserved the password and imap host state when the email domain changes in `src/credential-form.ts`
* Added `role="status"` and `aria-live="polite"` to the dynamic Outlook OAuth notice.

🎯 **Why:** 
When typing an email like `test@example.com` users often type a password first, then change their email to `test@gmail.com`. The domain change triggered a complete DOM rebuild of the "extra" fields section, destroying the `input[type="password"]` and causing the user to silently lose their password. Additionally, when the auto-detect injects the Outlook notice, screen readers would not announce the change.

📸 **Before/After:**
* Before: Typing a password and then changing the email domain wiped the password field.
* After: State is explicitly cached and restored after the DOM is rebuilt.

♿ **Accessibility:** 
Added `role="status"` and `aria-live="polite"` to the dynamically injected Outlook notice so screen readers announce it when it appears.

---
*PR created automatically by Jules for task [6824027241058195471](https://jules.google.com/task/6824027241058195471) started by @n24q02m*