### PR TITLE
🎨 Palette: Dynamic Notification Accessibility & Contrast

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,9 @@
 **Learning:** When building dynamic forms with vanilla JS, helper text elements are often generated sequentially alongside inputs but lack semantic connection, causing screen readers to miss crucial instructions (like "Leave empty for auto-detection").
 
 **Action:** Always generate a deterministic `id` for helper text elements and bind it to the associated input using `aria-describedby` immediately during creation to ensure robust accessibility.
+
+## 2024-05-16 - Dynamic Notification Accessibility & Contrast
+
+**Learning:** When generating dynamic form elements that act as notifications (like an OAuth notice that appears when a user types a specific email domain), screen readers won't announce the new content automatically. Furthermore, secondary text using `#888` on a dark background fails WCAG AA contrast guidelines.
+
+**Action:** Always apply `role="status"` and `aria-live="polite"` to dynamic notification containers so screen readers announce their appearance. Use `#9ca3af` instead of `#888` for secondary text to ensure sufficient contrast.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -356,6 +356,8 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     var notice = document.createElement("div");
                     notice.className = "notice";
                     notice.dataset.role = "oauth-notice";
+                    notice.setAttribute("role", "status");
+                    notice.setAttribute("aria-live", "polite");
                     notice.textContent =
                         "Outlook/Hotmail/Live requires OAuth2. This will be handled automatically by the server after you submit -- a Microsoft sign-in URL + code will appear here.";
                     extraContainer.appendChild(notice);
@@ -522,7 +524,7 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
 
                 var waiting = document.createElement("span");
                 waiting.id = "outlook-waiting";
-                waiting.style.color = "#888";
+                waiting.style.color = "#9ca3af";
                 waiting.textContent = "Waiting for Microsoft authorization...";
                 statusBox.appendChild(waiting);
 


### PR DESCRIPTION
💡 What: Added `role="status"` and `aria-live="polite"` to the dynamic OAuth notice in the multi-account credential form, and improved the color contrast of the "Waiting for Microsoft authorization..." status text from `#888` to `#9ca3af`.
🎯 Why: Without ARIA live regions, dynamically injected notifications aren't announced by screen readers, hiding important workflow instructions. The `#888` color failed WCAG AA contrast ratio requirements against the dark background, making it hard to read.
📸 Before/After: The "Waiting for Microsoft authorization..." text is now visibly brighter and legible on dark backgrounds.
♿ Accessibility: Ensures the OAuth notification is announced to screen readers when it appears, and improves contrast for users with low vision.

---
*PR created automatically by Jules for task [12056494944793766718](https://jules.google.com/task/12056494944793766718) started by @n24q02m*