### PR TITLE
🎨 Palette: Improve dynamic notice accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,9 @@
 **Learning:** When building dynamic forms with vanilla JS, helper text elements are often generated sequentially alongside inputs but lack semantic connection, causing screen readers to miss crucial instructions (like "Leave empty for auto-detection").
 
 **Action:** Always generate a deterministic `id` for helper text elements and bind it to the associated input using `aria-describedby` immediately during creation to ensure robust accessibility.
+
+## 2024-05-16 - Dynamic Notification Accessibility
+
+**Learning:** When generating dynamic notifications (like the domain-specific OAuth notices in `src/credential-form.ts`) that appear without explicit user interaction (e.g. typing triggering a UI update), screen readers often ignore the new element.
+
+**Action:** Always apply `role="status"` and `aria-live="polite"` to dynamically generated notification elements to ensure they are immediately and appropriately announced by assistive technologies.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -356,6 +356,8 @@ export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: {
                     var notice = document.createElement("div");
                     notice.className = "notice";
                     notice.dataset.role = "oauth-notice";
+                    notice.setAttribute("role", "status");
+                    notice.setAttribute("aria-live", "polite");
                     notice.textContent =
                         "Outlook/Hotmail/Live requires OAuth2. This will be handled automatically by the server after you submit -- a Microsoft sign-in URL + code will appear here.";
                     extraContainer.appendChild(notice);


### PR DESCRIPTION
💡 What: Adds `role="status"` and `aria-live="polite"` to the dynamic OAuth notification block in the credential setup form.
🎯 Why: When elements appear dynamically without explicit user interaction (like triggering via auto-detection logic while typing), screen readers often silently ignore the DOM update. Adding these ARIA attributes ensures the important context (that OAuth will be handled automatically) is immediately announced.
📸 Before/After: Not a visual change.
♿ Accessibility: Ensures assistive technologies immediately read out the dynamic Microsoft OAuth2 notice.

---
*PR created automatically by Jules for task [15562123100829349350](https://jules.google.com/task/15562123100829349350) started by @n24q02m*