### PR TITLE
feat: accept optional prefill kwarg in renderEmailCredentialForm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,25 @@ Chuyển giữa remote-relay ↔ local-relay qua `MCP_MODE` env var. Default = r
 3. **Config storage path**: TS server dung `$APPDATA\mcp\Config\config.enc` (khac Python servers `$LOCALAPPDATA\mcp\config.enc`). Khi debug/test, clean ca 2 paths + `~/.better-email-mcp/tokens.json` de reset state.
 
 4. **Outlook token email key in remote-relay**: `saveOutlookTokens` fallback to `OUTLOOK_EMAIL` env hoac `'outlook-device-code'` khi Microsoft token response khong include email field (device code mặc định không trả email). Workaround: set `OUTLOOK_EMAIL` env var khi self-host. Long-term fix: request `openid email profile` scopes + decode id_token trong onTokenReceived.
+
+## E2E
+
+Driven by `mcp-core/scripts/e2e/` (matrix-locked, 15 configs). Run a single config from this repo via `make e2e` (proxy) or directly:
+
+```
+cd ../mcp-core && uv run --project scripts/e2e python -m e2e.driver <config-id>
+```
+
+Configs for this repo: `email-gmail`, `email-outlook`.
+
+``email-outlook`` is t2-interaction (Microsoft device-code, 900s timeout); user clicks ``microsoft.com/devicelogin``.
+
+Tier policy:
+
+- **T0** (precommit + CI on PR / main push) - runs without upstream identity. Skret keys not required.
+- **T2 non-interaction** (`make e2e-config CONFIG=<id>` locally) - driver pre-fills relay form from skret AWS SSM `/better-email-mcp/prod` (`ap-southeast-1`). No user gate.
+- **T2 interaction** - driver fills relay form, then prints upstream user-gate URL; user signs in / types OTP at provider. Driver enforces per-flow timeouts (device-code 900s, oauth-redirect 300s, browser-form 600s) and emits `[poll] elapsed=Xs remaining=Ys status=<body>` every 30s. On timeout, container logs + last `setup-status` are saved to `<tmp>/e2e-diag/` BEFORE teardown for post-mortem.
+
+Multi-user remote mode (deployment property; not a separate config) requires `MCP_DCR_SERVER_SECRET` in the same skret namespace - driver refuses to start the container without it when `PUBLIC_URL` is set.
+
+References: `mcp-core/scripts/e2e/matrix.yaml`, `~/.claude/skills/mcp-dev/references/e2e-full-matrix.md` (harness-readiness gate), `~/.claude/skills/mcp-dev/references/secrets-skret.md` (per-server credential layout), `~/.claude/skills/mcp-dev/references/multi-user-pattern.md` (per-JWT-sub isolation).

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -40,7 +40,10 @@ function escapeHtml(value: unknown): string {
  * comma-separated `email1:pass1,email2:pass2:imap_host` format. The
  * server-side onCredentialsSaved callback parses this back into accounts.
  */
-export function renderEmailCredentialForm(_schema: RelayConfigSchema, options: { submitUrl: string }): string {
+export function renderEmailCredentialForm(
+  _schema: RelayConfigSchema,
+  options: { submitUrl: string; prefill?: Record<string, string> }
+): string {
   const displayName = escapeHtml(_schema.displayName ?? _schema.server ?? 'Email MCP')
   const server = escapeHtml(_schema.server ?? 'better-email-mcp')
   const description = escapeHtml(


### PR DESCRIPTION
## Summary

mcp-core's ``customCredentialFormHtml`` callable now passes ``prefill?: Record<string, string>``. Email's flow doesn't currently use prefill (credentials go straight to the device-code path via ``acquire_jwt`` POST), but matching the signature keeps TypeScript happy when bumping mcp-core.

## Test plan

- [x] biome + tsc clean
- [x] 60 vitest cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)