### PR TITLE
🎨 Palette: [UX improvement] Add continuous visual feedback to OAuth wait state and improve contrast

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,9 @@
 **Learning:** When dynamically rebuilding form sections based on user input (e.g., domain auto-detection), any data already entered into the targeted DOM elements will be lost if the inputs are destroyed and recreated without explicit state preservation.
 
 **Action:** Capture the current value of the targeted inputs before rebuilding the DOM elements and reapply the captured state to the newly created inputs.
+
+## 2025-02-13 - Visual Feedback During Long-Polling Flows
+
+**Learning:** When an interface is waiting for an external authorization flow to complete (e.g., Microsoft OAuth device code polling), a static "Waiting..." text is easily perceived as a frozen or crashed state, causing user frustration and premature abandonment. In dark mode, `#888` text provides insufficient contrast to read clearly.
+
+**Action:** Add subtle, continuous visual feedback (like a `.pulse` opacity animation) to elements representing indefinite wait states to reassure the user that the background process is active. Ensure waiting text contrast is WCAG compliant (e.g., `#9ca3af` on dark backgrounds).

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -215,6 +215,11 @@ export function renderEmailCredentialForm(
             border: 1px solid rgba(248, 113, 113, 0.3);
             color: #f87171;
         }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+        .pulse { animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
     </style>
 </head>
 <body>
@@ -538,7 +543,8 @@ export function renderEmailCredentialForm(
 
                 var waiting = document.createElement("span");
                 waiting.id = "outlook-waiting";
-                waiting.style.color = "#888";
+                waiting.className = "pulse";
+                waiting.style.color = "#9ca3af";
                 waiting.textContent = "Waiting for Microsoft authorization...";
                 statusBox.appendChild(waiting);
 


### PR DESCRIPTION
💡 **What:** Added a `.pulse` CSS animation and improved the text color (from `#888` to `#9ca3af`) for the "Waiting for Microsoft authorization..." element during the Outlook OAuth long-polling flow.
🎯 **Why:** To prevent users from perceiving the application as frozen or crashed during indefinite wait states and to ensure the waiting text is accessible with adequate contrast against dark backgrounds.
📸 **Before/After:**
- *Before:* The "Waiting..." text was static and had an `#888` color which was difficult to read on dark mode.
- *After:* The text pulses slowly with a clearer `#9ca3af` color, providing reassurance that the background authorization process is active and making the text readable.
♿ **Accessibility:** Improved the contrast ratio for the waiting text to ensure compliance with WCAG standards for users with low vision.

---
*PR created automatically by Jules for task [7179818878814381654](https://jules.google.com/task/7179818878814381654) started by @n24q02m*