### PR TITLE
fix: document MCP_MODE remote-relay vs local-relay in setup docs

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -104,7 +104,10 @@ Other package runners (`bun x`, `pnpm dlx`, `yarn dlx`) also work in place of `n
 
 ## Method 4: HTTP Remote (Multi-User)
 
-For multi-user mode with OAuth 2.1 PKCE authentication. Users provide their own credentials through the OAuth flow.
+The server has two HTTP relay modes selected via `MCP_MODE`:
+
+- **`remote-relay` (default)** — delegated Microsoft device-code OAuth for Outlook/Hotmail/Live. The server initiates the OAuth flow on Microsoft's `/devicecode` endpoint and the user signs in upstream. Required env: `OUTLOOK_CLIENT_ID` (Azure app client ID; the bundled public client at `oauth2.ts:88` is used as the fallback). Optional env: `OUTLOOK_EMAIL` (workaround for the Microsoft device-code response sometimes lacking the email field). Refresh tokens persist at `~/.better-email-mcp/tokens.json` (single-user) or `~/.better-email-mcp/tokens/<sub>.json` (multi-user, keyed by JWT sub).
+- **`local-relay`** — user pastes `email:app-password` strings into a local `/authorize` form. Outlook/Hotmail/Live accounts are rejected in this mode with a hint to switch to `remote-relay`; Gmail / Yahoo / iCloud / custom IMAP all work because they use App Passwords.
 
 ### Using a hosted instance
 
@@ -119,17 +122,21 @@ Add to your MCP client config:
   }
 }
 ```
+The hosted instance runs `remote-relay` mode, so the first call surfaces a Microsoft device-code link in your client.
 
 ### Self-hosting
 
 1. Run the server in HTTP mode:
    ```bash
    docker run -p 8080:8080 \
-     -e TRANSPORT_MODE=http \
+     -e MCP_MODE=remote-relay \
      -e PUBLIC_URL=https://your-domain.com \
      -e DCR_SERVER_SECRET=$(openssl rand -hex 32) \
+     -e OUTLOOK_CLIENT_ID=<your-azure-app-client-id> \
      n24q02m/better-email-mcp:latest
    ```
+   Set `MCP_MODE=local-relay` instead if you want the paste-form flow (Gmail/Yahoo/iCloud only).
+   `TRANSPORT_MODE=http` is still accepted for backward compatibility but `MCP_MODE` is preferred.
 
 2. Point clients to your server URL:
    ```json

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -137,11 +137,13 @@ Users provide their own email credentials through the OAuth flow.
 | Variable | Required | Default | Description |
 |:---------|:---------|:--------|:------------|
 | `EMAIL_CREDENTIALS` | Yes (stdio) | -- | Email credentials. Format: `user@gmail.com:app-password`. Multi-account: comma-separated. Custom IMAP: `user@custom.com:pass:imap.custom.com`. |
-| `TRANSPORT_MODE` | No | `stdio` | Set to `http` for remote multi-user mode. |
+| `MCP_MODE` | No | `remote-relay` (when `TRANSPORT_MODE=http`) | Selects the HTTP relay flavour: `remote-relay` (default — delegated Microsoft device-code for Outlook/Hotmail/Live; per-JWT-sub tokens; deployed at `better-email-mcp.n24q02m.com`) or `local-relay` (paste-form for App-Password providers; Outlook is rejected with a hint to switch back). |
+| `TRANSPORT_MODE` | No | `stdio` | Legacy alias still honoured — set to `http` to enable HTTP transport (then pick `MCP_MODE`). |
 | `PUBLIC_URL` | Yes (http) | -- | Server's public URL for OAuth redirects (http mode only). |
 | `DCR_SERVER_SECRET` | Yes (http) | -- | HMAC secret for stateless client registration (http mode only). |
 | `PORT` | No | `8080` | Server port (http mode only). |
-| `OUTLOOK_CLIENT_ID` | No | -- | Custom Azure AD client ID for self-hosted Outlook OAuth2. |
+| `OUTLOOK_CLIENT_ID` | No | bundled public Azure client | Custom Azure AD client ID for self-hosted Outlook OAuth2. |
+| `OUTLOOK_EMAIL` | No | -- | Workaround when the Microsoft device-code response omits the email field — set this to the Outlook account email so token persistence keys correctly (`tokens/<email>.json`). |
 
 ## Authentication
 


### PR DESCRIPTION
setup-manual.md Method 4 and setup-with-agent.md env-var table both stopped at `TRANSPORT_MODE=http` and didn't expose the post-Phase-L2 `MCP_MODE` split (`remote-relay` default vs `local-relay`). Adds explicit mode descriptions, the OUTLOOK_EMAIL workaround row, and ties wording back to CLAUDE.md#Modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)