### PR TITLE
fix: migrate plugin.json to deployed HTTP remote endpoint

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,8 +9,8 @@
   "homepage": "https://github.com/n24q02m/better-email-mcp",
   "mcpServers": {
     "better-email-mcp": {
-      "command": "npx",
-      "args": ["-y", "@n24q02m/better-email-mcp"]
+      "type": "http",
+      "url": "https://better-email-mcp.n24q02m.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Migrate plugin manifest to deployed HTTP remote endpoint `https://better-email-mcp.n24q02m.com/mcp` (parity with notion remote-oauth pattern).
- Local stdio spawn was a pre-deploy artifact. The deployed instance is the canonical default per mode matrix.
- Multi-user OAuth + delegated Microsoft device-code flow already deployed and serving `/health` 200.

## Test plan

- [ ] CI green
- [ ] After release: Claude Code `/mcp` shows `plugin:better-email-mcp:better-email-mcp` connected via HTTP
- [ ] Trigger OAuth flow, complete Microsoft device-code login, verify per-JWT-sub credential storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)