### PR TITLE
🎨 Palette: Add spinner to Connect button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,9 @@
 **Learning:** When an interface is waiting for an external authorization flow to complete (e.g., Microsoft OAuth device code polling), a static "Waiting..." text is easily perceived as a frozen or crashed state, causing user frustration and premature abandonment. In dark mode, `#888` text provides insufficient contrast to read clearly.
 
 **Action:** Add subtle, continuous visual feedback (like a `.pulse` opacity animation) to elements representing indefinite wait states to reassure the user that the background process is active. Ensure waiting text contrast is WCAG compliant (e.g., `#9ca3af` on dark backgrounds).
+
+## 2025-02-14 - Async Operation Visual Feedback
+
+**Learning:** During potentially long-running async operations (like network requests or OAuth polling), simply changing button text (e.g., to "Connecting...") or disabling the button isn't always enough visual feedback. Users may still wonder if the system is hung, especially if the text change is subtle.
+
+**Action:** Always include an animated visual indicator (like a CSS spinner with `aria-hidden="true"`) inside the submission button alongside the status text during asynchronous operations to clearly communicate that background processing is actively occurring.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -220,6 +220,19 @@ export function renderEmailCredentialForm(
             50% { opacity: 0.5; }
         }
         .pulse { animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .spinner {
+            display: inline-block;
+            width: 1.125rem;
+            height: 1.125rem;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            border-top-color: #fff;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            margin-right: 0.5rem;
+            vertical-align: text-bottom;
+        }
+
     </style>
 </head>
 <body>
@@ -619,7 +632,7 @@ export function renderEmailCredentialForm(
 
                 submitBtn.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
-                submitBtn.textContent = "Connecting...";
+                submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
 
                 fetch(submitUrl, {
                     method: "POST",
@@ -636,7 +649,7 @@ export function renderEmailCredentialForm(
                                     pendingRedirectUrl = data.redirect_url;
                                 }
                                 if (data.next_step && data.next_step.type === "oauth_device_code") {
-                                    submitBtn.textContent = "Awaiting Microsoft...";
+                                    submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
                                     submitBtn.removeAttribute("aria-busy");
                                     renderOAuthDeviceCode(data.next_step);
                                 } else if (pendingRedirectUrl) {


### PR DESCRIPTION
💡 **What:** Added a visual CSS spinner to the "Connect" button during async operations (Connecting, Awaiting Microsoft).
🎯 **Why:** To provide clear visual feedback that the system is processing, preventing user frustration during potentially slow operations like OAuth device code polling.
📸 **Before/After:** The button now shows a spinner inside it when the state is "Connecting..." or "Awaiting Microsoft...".
♿ **Accessibility:** Added `aria-hidden="true"` to the spinner so screen readers do not read it aloud, complementing the existing `aria-busy` state.

---
*PR created automatically by Jules for task [12684447932422296726](https://jules.google.com/task/12684447932422296726) started by @n24q02m*