### PR TITLE
fix: switch plugin.json to stdio proxy for local relay testing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,8 +9,9 @@
   "homepage": "https://github.com/n24q02m/better-email-mcp",
   "mcpServers": {
     "better-email-mcp": {
-      "type": "http",
-      "url": "https://better-email-mcp.n24q02m.com/mcp"
+      "command": "npx",
+      "args": ["-y", "@n24q02m/better-email-mcp"],
+      "env": { "MCP_TRANSPORT": "stdio" }
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.9.0",
+        "@n24q02m/mcp-core": "^1.10.0",
         "html-to-text": "^9.0.5",
         "imapflow": "^1.3.2",
         "mailparser": "^3.9.8",
@@ -130,7 +130,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.9.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-11D15xnhbNk9ZfcXomnBzGli8n85nYAL6T7M30knNV9XcrY2QXHmRnAcwuZERTCnG3PuLQF4FS+7DQqdqrsotA=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.10.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-5CSIsdFOumSL6Y0OGpsyl78FxqSo13lbrAJn8YRcfXLMTvVGak0iyKPkBkxsfUMW50fXkueFQHZepaLAipCySA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.9.0",
+    "@n24q02m/mcp-core": "^1.10.0",
     "html-to-text": "^9.0.5",
     "imapflow": "^1.3.2",
     "mailparser": "^3.9.8",


### PR DESCRIPTION
## Summary

- Switch `plugin.json` from `type: http` -> `stdio` (`command: npx -y @n24q02m/better-email-mcp`)
- Local plugin install now spawns stdio daemon that exercises `runLocalServer` relay form (paste IMAP/SMTP creds locally)
- Runtime default for deployed server unchanged (still http remote-relay at better-email-mcp.n24q02m.com)
- Per spec `2026-04-29-transparent-bridge-v2-and-backlog-cascade.md` Wave 4

## Test plan

- [x] gitleaks + biome + json check pass
- [ ] After merge: install via Claude Code marketplace + verify stdio daemon spawns local relay form