### PR TITLE
fix: register config__open_relay tool (Transparent Bridge Wave 3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.10.0",
+        "@n24q02m/mcp-core": "^1.11.1",
         "html-to-text": "^9.0.5",
         "imapflow": "^1.3.2",
         "mailparser": "^3.9.8",
@@ -130,7 +130,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.10.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-5CSIsdFOumSL6Y0OGpsyl78FxqSo13lbrAJn8YRcfXLMTvVGak0iyKPkBkxsfUMW50fXkueFQHZepaLAipCySA=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.11.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-++qPIQv7t/mSmds8HzsUAQ4p2AQ/5/Vfp2juWU7A0nyC4WYxVfjDH+Gk5mSed7nNDpcA723LvPXfPcTyOKD5xg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.10.0",
+    "@n24q02m/mcp-core": "^1.11.1",
     "html-to-text": "^9.0.5",
     "imapflow": "^1.3.2",
     "mailparser": "^3.9.8",

--- a/src/tools/registry-call-tool.test.ts
+++ b/src/tools/registry-call-tool.test.ts
@@ -61,7 +61,9 @@ describe('CallToolRequestSchema handler coverage', () => {
 
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toContain("Unknown tool: message. Did you mean 'messages'?")
-    expect(result.content[0].text).toContain('Available tools: messages, folders, attachments, send, config, help')
+    expect(result.content[0].text).toContain(
+      'Available tools: messages, folders, attachments, send, config, config__open_relay, help'
+    )
   })
 
   it('should successfully call a tool and wrap the result', async () => {

--- a/src/tools/registry-open-relay.test.ts
+++ b/src/tools/registry-open-relay.test.ts
@@ -1,0 +1,111 @@
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock buildOpenRelayHandler so the test does not spin up the real daemon
+// helpers (smart-stdio, browser) which require actual filesystem + child
+// processes. The handler we substitute returns a deterministic OpenRelayResult.
+const mockOpenRelayResult = {
+  url: 'http://127.0.0.1:51234/authorize?session=abc',
+  browserOpened: true,
+  status: 'unconfigured' as const
+}
+
+vi.mock('@n24q02m/mcp-core', () => ({
+  buildOpenRelayHandler: vi.fn(() => vi.fn(async () => mockOpenRelayResult))
+}))
+
+// Mock composite tools (avoid IMAP/SMTP side effects)
+vi.mock('./composite/attachments.js', () => ({ attachments: vi.fn() }))
+vi.mock('./composite/folders.js', () => ({ folders: vi.fn() }))
+vi.mock('./composite/messages.js', () => ({ messages: vi.fn(), clearArchiveFolderCache: vi.fn() }))
+vi.mock('./composite/send.js', () => ({ send: vi.fn() }))
+vi.mock('./composite/config.js', () => ({ handleConfig: vi.fn() }))
+
+// Default credential-state mock: server starts unconfigured. Individual tests
+// can override via vi.mocked(...).mockReturnValue(...).
+vi.mock('../credential-state.js', () => ({
+  getState: vi.fn(() => 'awaiting_setup'),
+  getSetupUrl: vi.fn(() => null),
+  triggerRelaySetup: vi.fn()
+}))
+
+import { registerTools } from './registry.js'
+
+describe('config__open_relay tool registration', () => {
+  let mockServer: any
+  let listToolsHandler: any
+  let callToolHandler: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockServer = {
+      setRequestHandler: vi.fn((schema, handler) => {
+        if (schema === ListToolsRequestSchema) {
+          listToolsHandler = handler
+        }
+        if (schema === CallToolRequestSchema) {
+          callToolHandler = handler
+        }
+      })
+    }
+    registerTools(mockServer, [])
+  })
+
+  it('TOOLS list includes config__open_relay descriptor', async () => {
+    const listed = await listToolsHandler({})
+    const names = listed.tools.map((t: { name: string }) => t.name)
+    expect(names).toContain('config__open_relay')
+
+    const tool = listed.tools.find((t: { name: string }) => t.name === 'config__open_relay')
+    expect(tool).toBeDefined()
+    expect(tool.inputSchema).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false
+    })
+    expect(tool.annotations.openWorldHint).toBe(true)
+  })
+
+  it('CallTool dispatch returns wrapped JSON with url, browserOpened, status', async () => {
+    const result = await callToolHandler({
+      params: {
+        name: 'config__open_relay',
+        arguments: {}
+      }
+    })
+
+    expect(result.isError).toBeUndefined()
+    expect(result.content).toHaveLength(1)
+    expect(result.content[0].type).toBe('text')
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed).toEqual(mockOpenRelayResult)
+    expect(parsed).toHaveProperty('url')
+    expect(parsed).toHaveProperty('browserOpened')
+    expect(parsed).toHaveProperty('status')
+  })
+
+  it('config__open_relay works when no accounts are configured (credential guard exempt)', async () => {
+    // Re-register with explicit empty accounts to assert guard is bypassed.
+    const freshServer = {
+      setRequestHandler: vi.fn((schema, handler) => {
+        if (schema === CallToolRequestSchema) {
+          callToolHandler = handler
+        }
+      })
+    }
+    registerTools(freshServer as any, [])
+
+    const result = await callToolHandler({
+      params: {
+        name: 'config__open_relay',
+        arguments: {}
+      }
+    })
+
+    // Must NOT return setup-instructions error; must hit our handler.
+    expect(result.isError).toBeUndefined()
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.url).toBe(mockOpenRelayResult.url)
+  })
+})

--- a/src/tools/registry-unknown-tool.test.ts
+++ b/src/tools/registry-unknown-tool.test.ts
@@ -45,6 +45,8 @@ describe('registerTools', () => {
     expect(result.content).toHaveLength(1)
     expect(result.content[0].text).toContain('Unknown tool: unknown_tool_name')
     // Verify it lists available tools
-    expect(result.content[0].text).toContain('Available tools: messages, folders, attachments, send, config, help')
+    expect(result.content[0].text).toContain(
+      'Available tools: messages, folders, attachments, send, config, config__open_relay, help'
+    )
   })
 })

--- a/src/tools/registry.logic.test.ts
+++ b/src/tools/registry.logic.test.ts
@@ -85,7 +85,7 @@ function createMockServerWithHandlers() {
 }
 
 describe('ListToolsRequestSchema handler', () => {
-  it('should return exactly 6 tools with correct names', async () => {
+  it('should return exactly 7 tools with correct names', async () => {
     const { getHandler } = createMockServerWithHandlers()
     const handler = getHandler(ListToolsRequestSchema)
 
@@ -93,9 +93,9 @@ describe('ListToolsRequestSchema handler', () => {
 
     const result = await handler({})
 
-    expect(result.tools).toHaveLength(6)
+    expect(result.tools).toHaveLength(7)
     const names = result.tools.map((t: any) => t.name)
-    expect(names).toEqual(['messages', 'folders', 'attachments', 'send', 'config', 'help'])
+    expect(names).toEqual(['messages', 'folders', 'attachments', 'send', 'config', 'config__open_relay', 'help'])
   })
 })
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -17,7 +17,9 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema
 } from '@modelcontextprotocol/sdk/types.js'
+import { buildOpenRelayHandler } from '@n24q02m/mcp-core'
 import { getSetupUrl, getState, triggerRelaySetup } from '../credential-state.js'
+import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AttachmentsInput, attachments } from './composite/attachments.js'
 import { type ConfigInput, handleConfig } from './composite/config.js'
 import { type FoldersInput, folders } from './composite/folders.js'
@@ -209,6 +211,19 @@ const TOOLS = [
     }
   },
   {
+    name: 'config__open_relay',
+    description:
+      'Open the relay configuration form for better-email-mcp in the user browser. Returns the relay URL, whether the browser launched, and the current credential state. Auto-respawns the daemon if it has died.',
+    annotations: {
+      title: 'Open Relay',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    },
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
     name: 'help',
     description: 'Get full documentation for a tool. Use when compressed descriptions are insufficient.',
     annotations: {
@@ -281,6 +296,7 @@ const AVAILABLE_TOOLS_STRING = VALID_TOOL_NAMES.join(', ')
 export function registerTools(server: Server, initialAccounts: AccountConfig[]) {
   // Mutable reference: updated via hot-reload when relay credentials arrive after startup
   let accounts = initialAccounts
+  const openRelayHandler = buildOpenRelayHandler('better-email-mcp', RELAY_SCHEMA)
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: TOOLS
   }))
@@ -324,6 +340,16 @@ export function registerTools(server: Server, initialAccounts: AccountConfig[]) 
     }
 
     try {
+      // config__open_relay is handled directly via buildOpenRelayHandler — it does
+      // not depend on configured accounts, takes no args, and returns its own JSON
+      // shape (url, browserOpened, status, etc.).
+      if (name === 'config__open_relay') {
+        const result = await openRelayHandler()
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+        }
+      }
+
       const handler = TOOL_HANDLERS[name]
       if (!handler) {
         const closest = findClosestMatch(name, VALID_TOOL_NAMES)
@@ -336,10 +362,11 @@ export function registerTools(server: Server, initialAccounts: AccountConfig[]) 
       }
 
       // Credential guard: when not configured, return setup instructions.
-      // Help and setup tools are always available (docs don't need credentials,
-      // setup manages the credential lifecycle itself).
+      // Help, config, and config__open_relay tools are always available (docs don't
+      // need credentials; config and config__open_relay manage the credential
+      // lifecycle itself).
       // The relay session is triggered lazily on first non-exempt tool call.
-      if (name !== 'help' && name !== 'config' && accounts.length === 0) {
+      if (name !== 'help' && name !== 'config' && name !== 'config__open_relay' && accounts.length === 0) {
         const credState = getState()
         if (credState === 'configured') {
           // Hot-reload: relay delivered credentials after startup — reload accounts


### PR DESCRIPTION
## Summary
- Register `config__open_relay` so an LLM can re-trigger the relay form via a callable MCP tool after the daemon is already running.
- Bump `@n24q02m/mcp-core` to `^1.11.1` (root re-export of `buildOpenRelayHandler` landed there).
- Wire `buildOpenRelayHandler('better-email-mcp', RELAY_SCHEMA)` into the existing `TOOLS` array + `CallToolRequestSchema` dispatcher (this server uses the low-level `Server` class, so the FastMCP-style `registerOpenRelayTool` helper is not applicable).
- The new tool is exempt from the credential guard so it works when `accounts.length === 0`.

## Test plan
- [x] `bun run test` — 547/547 pass (3 pre-existing tool-count assertions updated 6 -> 7)
- [x] `bun run check` — biome + tsc clean
- [x] New `src/tools/registry-open-relay.test.ts` smoke test asserts: descriptor present in `ListTools`, dispatch returns `{ url, browserOpened, status }` wrapped as `{ content: [{ type: 'text', text: <json> }] }`, works with empty accounts list (credential guard exempt)
- [x] Verified `typeof buildOpenRelayHandler === 'function'` from root re-export of `@n24q02m/mcp-core@1.11.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)