### PR TITLE
fix: revert eagerRelaySchema usage (D18 rollback)

### DIFF
--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -65,17 +65,4 @@ describe('initServer', () => {
     expect(startHttpMock).toHaveBeenCalled()
     expect(runSmartStdioProxyMock).not.toHaveBeenCalled()
   })
-
-  it('passes RELAY_SCHEMA as eagerRelaySchema to runSmartStdioProxy in stdio mode (D18.3)', async () => {
-    process.argv = [process.argv[0], 'main.js', '--stdio']
-    const { initServer } = await import('./init-server.js')
-    await initServer()
-
-    expect(runSmartStdioProxyMock).toHaveBeenCalledOnce()
-    const options = runSmartStdioProxyMock.mock.calls[0]![2]!
-    expect(options.eagerRelaySchema).toBeDefined()
-    expect(options.eagerRelaySchema.fields).toEqual(
-      expect.arrayContaining([expect.objectContaining({ key: 'EMAIL_CREDENTIALS' })])
-    )
-  })
 })

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -52,12 +52,9 @@ export async function initServer() {
     process.argv.includes('--stdio') || process.env.MCP_TRANSPORT === 'stdio' || process.env.TRANSPORT_MODE === 'stdio'
 
   if (isStdio) {
-    const { RELAY_SCHEMA } = await import('./relay-schema.js')
     const daemonCmd = [process.execPath, process.argv[1]!]
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const exitCode = await runSmartStdioProxy('better-email-mcp', daemonCmd, {
-      env: { TRANSPORT_MODE: 'http', MCP_MODE: 'local-relay' },
-      eagerRelaySchema: RELAY_SCHEMA as any
+      env: { TRANSPORT_MODE: 'http', MCP_MODE: 'local-relay' }
     })
     process.exit(exitCode)
     return


### PR DESCRIPTION
Drop eagerRelaySchema arg per mcp-core 1.11.4 D18 rollback. See mcp-core PR #134.

Daemon-side runLocalServer auto-opens browser when unconfigured (mcp-core PR #116, already shipped). Bridge-side eager block was redundant + caused 2-3 tabs per spawn + bridge respawn loop = infinite spam (P0 regression user reported 2026-04-29 session rollback-d18-plugin-daemon).

Tests: 547/547 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)