### PR TITLE
fix: rebuild against mcp-core 1.11.5 fork-bomb fix

### DIFF
--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -65,3 +65,4 @@ export async function initServer() {
   const { startHttp } = await import('./transports/http.js')
   await startHttp()
 }
+// Rebuild target: mcp-core 1.11.5 (P0 fork-bomb fix)


### PR DESCRIPTION
Bump bundle to include mcp-core 1.11.5 env-strip fix (mcp-core PR #135). Resolves P0 fork-bomb when re-enabling email plugin in Claude Code (22+ recursive bridges spawn from MCP_TRANSPORT=stdio inheritance).