### PR TITLE
🎨 Palette: [UX improvement] Add required field indicators and status announcements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,8 @@
 **Learning:** During potentially long-running async operations (like network requests or OAuth polling), simply changing button text (e.g., to "Connecting...") or disabling the button isn't always enough visual feedback. Users may still wonder if the system is hung, especially if the text change is subtle.
 
 **Action:** Always include an animated visual indicator (like a CSS spinner with `aria-hidden="true"`) inside the submission button alongside the status text during asynchronous operations to clearly communicate that background processing is actively occurring.
+
+## 2025-02-15 - Required Field Indicators and Aria-Hidden
+
+**Learning:** When generating dynamic forms, marking optional fields is helpful, but relying purely on the absence of an "Optional" badge for required fields is ambiguous for sighted users. However, injecting a literal `*` without `aria-hidden="true"` causes screen readers to redundantly announce "star" or "asterisk" when the input itself is already marked `required`.
+**Action:** Always include a visual required indicator (like `*`) in red (with sufficient contrast) for sighted users, but explicitly hide it from screen readers using `aria-hidden="true"` to prevent double-announcements when the native input `required` attribute already handles accessibility semantics.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -253,7 +253,7 @@ export function renderEmailCredentialForm(
 
                 <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
 
-                <div class="status-box" id="status-box" role="alert"></div>
+                <div class="status-box" id="status-box" role="status" aria-live="polite"></div>
             </form>
         </div>
     </div>
@@ -318,6 +318,13 @@ export function renderEmailCredentialForm(
                     badge.textContent = "Optional";
                     labelEl.appendChild(document.createTextNode(" "));
                     labelEl.appendChild(badge);
+                } else {
+                    var reqSpan = document.createElement("span");
+                    reqSpan.style.color = "#f87171";
+                    reqSpan.style.marginLeft = "0.25rem";
+                    reqSpan.setAttribute("aria-hidden", "true");
+                    reqSpan.textContent = "*";
+                    labelEl.appendChild(reqSpan);
                 }
                 group.appendChild(labelEl);
 


### PR DESCRIPTION
💡 What:
Added a visual red asterisk (`*`) to the right of required field labels in the credential form and updated the `status-box` container from an assertive `role="alert"` to a non-interruptive `role="status"` with `aria-live="polite"`.

🎯 Why:
1. Sighted users had to guess which fields were required because only "Optional" fields were explicitly marked. The red asterisk provides immediate clarity.
2. The `role="alert"` attribute is intended for critical, time-sensitive errors and interrupts screen readers abruptly. Using `role="status"` is the correct accessible pattern for standard form submission feedback like "Connecting..." or "Awaiting Microsoft...".

📸 Before/After:
Before: Labels like "Email Address" had no visual cue that they were required.
After: "Email Address *" with the asterisk in red.

♿ Accessibility:
The injected `*` indicator is wrapped in a `span` with `aria-hidden="true"`. Because the underlying `input` already has the `required` attribute, this prevents screen readers from redundantly announcing "star" or "asterisk" while still providing the visual affordance to sighted users. The status box now waits for the user to pause before politely announcing submission progress.

---
*PR created automatically by Jules for task [2599483102165949318](https://jules.google.com/task/2599483102165949318) started by @n24q02m*