### PR TITLE
feat(auth): migrate to in-memory cred store (TC-NearZK)

### DIFF
--- a/src/auth/in-memory-cred-store.test.ts
+++ b/src/auth/in-memory-cred-store.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { InMemoryCredStore } from './in-memory-cred-store.js'
+
+describe('InMemoryCredStore', () => {
+  let store: InMemoryCredStore
+
+  beforeEach(() => {
+    store = new InMemoryCredStore()
+  })
+
+  test('save and load round-trip', async () => {
+    await store.save('sub-a', { token: 'tok-a' })
+    expect(await store.load('sub-a')).toEqual({ token: 'tok-a' })
+  })
+
+  test('per-sub isolation', async () => {
+    await store.save('sub-a', { token: 'tok-a' })
+    await store.save('sub-b', { token: 'tok-b' })
+    expect(await store.load('sub-a')).toEqual({ token: 'tok-a' })
+    expect(await store.load('sub-b')).toEqual({ token: 'tok-b' })
+  })
+
+  test('credentials lost on restart (in-memory only)', async () => {
+    const store1 = new InMemoryCredStore()
+    await store1.save('sub-a', { token: 'tok' })
+    expect(await store1.load('sub-a')).toEqual({ token: 'tok' })
+
+    const store2 = new InMemoryCredStore() // simulate restart
+    expect(await store2.load('sub-a')).toBeNull()
+  })
+
+  test('clear specific sub', async () => {
+    await store.save('sub-a', { token: 'tok-a' })
+    await store.save('sub-b', { token: 'tok-b' })
+    await store.clear('sub-a')
+    expect(await store.load('sub-a')).toBeNull()
+    expect(await store.load('sub-b')).toEqual({ token: 'tok-b' })
+  })
+
+  test('list subs returns all known', async () => {
+    await store.save('sub-a', { x: 1 })
+    await store.save('sub-b', { x: 2 })
+    const subs = await store.listSubs()
+    expect(new Set(subs)).toEqual(new Set(['sub-a', 'sub-b']))
+  })
+})

--- a/src/auth/in-memory-cred-store.ts
+++ b/src/auth/in-memory-cred-store.ts
@@ -1,0 +1,36 @@
+/**
+ * Per-user credential store with in-memory storage only (TC-NearZK).
+ *
+ * Replaces deprecated per-user-credential-store.ts (disk-encrypted
+ * AES-GCM + PBKDF2) for HTTP multi-user mode. v1.0+ aligns with Notion's
+ * in-memory pattern: server has access during request lifetime; restart
+ * clears all credentials, users re-OAuth.
+ *
+ * Trust model: server admin (n24q02m operator) can dump live memory via
+ * debugger but no persistent file = no FS-dump compromise + no admin
+ * recovery from disk.
+ */
+export interface CredentialPayload {
+  [key: string]: unknown
+}
+
+export class InMemoryCredStore {
+  private store = new Map<string, CredentialPayload>()
+
+  async save(sub: string, creds: CredentialPayload): Promise<void> {
+    this.store.set(sub, { ...creds })
+  }
+
+  async load(sub: string): Promise<CredentialPayload | null> {
+    const value = this.store.get(sub)
+    return value ?? null
+  }
+
+  async clear(sub: string): Promise<void> {
+    this.store.delete(sub)
+  }
+
+  async listSubs(): Promise<string[]> {
+    return [...this.store.keys()]
+  }
+}

--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -1,4 +1,13 @@
 /**
+ * @deprecated v1.0.0 -- disk-encrypted AES-GCM+PBKDF2 storage replaced by
+ * `InMemoryCredStore` (TC-NearZK trust class). Module retained for one
+ * minor release as migration shim; production callers (`spawn-setup.ts` +
+ * `transports/http.ts`) now use `credStore` from `spawn-setup.ts`.
+ * Removed in v2.0.0.
+ *
+ * See ~/projects/.superpower/mcp-core/specs/2026-04-30-trust-model-alignment.md
+ * § 4.D3 + § 5.A8.
+ *
  * Per-user encrypted credential storage.
  *
  * Stores email credentials per user in separate encrypted files:

--- a/src/spawn-setup.ts
+++ b/src/spawn-setup.ts
@@ -19,7 +19,7 @@ import type { NextStep, RelayConfigSchema, RunLocalServerOptions, SubjectContext
 import { writeConfig } from '@n24q02m/mcp-core'
 import { ImapFlow } from 'imapflow'
 
-import { storeUserCredentials } from './auth/per-user-credential-store.js'
+import { InMemoryCredStore } from './auth/in-memory-cred-store.js'
 import { renderEmailCredentialForm } from './credential-form.js'
 import {
   getMarkSetupComplete as getCredentialMarkSetupComplete,
@@ -29,6 +29,9 @@ import {
 import { RELAY_SCHEMA } from './relay-schema.js'
 import { type AccountConfig, parseCredentials } from './tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain } from './tools/helpers/oauth2.js'
+
+/** Module-singleton in-memory credential store for remote-relay multi-user mode. */
+export const credStore = new InMemoryCredStore()
 
 const SERVER_NAME = 'better-email-mcp'
 const IMAP_CONNECT_TIMEOUT_MS = 15_000
@@ -201,21 +204,23 @@ export function buildRunLocalServerOptions(args: SpawnCredentialFormArgs): RunLo
     // Persistence strategy depends on mode:
     //
     // - ``remote-relay`` is the multi-user path served on a public URL. The
-    //   JWT ``sub`` passed in via ``context`` keys a per-user encrypted
-    //   credential file (``storeUserCredentials``). We deliberately do NOT
-    //   write to the shared ``config.enc`` or set ``process.env.EMAIL_CREDENTIALS``
-    //   -- doing so would leak user A's mailboxes to every other caller of the
-    //   same container, which is the 2026-04-21 security incident.
+    //   JWT ``sub`` passed in via ``context`` keys a per-user in-memory
+    //   credential entry (``credStore.save``). We deliberately do NOT write to
+    //   the shared ``config.enc`` or set ``process.env.EMAIL_CREDENTIALS`` --
+    //   doing so would leak user A's mailboxes to every other caller of the same
+    //   container, which is the 2026-04-21 security incident.
+    //   In-memory (TC-NearZK): no persistent FS dump; credentials survive only
+    //   for the process lifetime. Users re-authenticate after a restart.
     // - ``local-relay`` + ``stdio`` are single-user (one host per person).
     //   Keep the existing shared-config path so tools can read
     //   ``process.env.EMAIL_CREDENTIALS`` the way they always have, and the
     //   encrypted ``config.enc`` survives restarts.
     if (mode === 'remote-relay') {
       try {
-        await storeUserCredentials(context.sub, accounts)
+        await credStore.save(context.sub, { accounts })
       } catch (err) {
         console.error(
-          `[${SERVER_NAME}] Failed to persist per-user credentials for sub=${context.sub}: ${(err as Error).message}`
+          `[${SERVER_NAME}] Failed to save per-user credentials for sub=${context.sub}: ${(err as Error).message}`
         )
         return { type: 'error', text: 'Failed to save credentials. Please retry.' }
       }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -23,8 +23,8 @@
  * primitive in mcp-core issues a static ``sub='local-user'`` for all
  * sessions. Follow-up: mcp-core v1.5+ will generate a per-session UUID
  * subject and thread it through to ``onCredentialsSaved``; this module
- * will switch the remote-relay branch to call ``storeUserCredentials(sub,
- * accounts)`` without any UI change.
+ * calls ``credStore.save(sub, { accounts })`` in ``spawn-setup.ts`` and reads
+ * back via ``credStore.load(sub)`` here.
  *
  * The shared ``runLocalServer`` options (``onCredentialsSaved``,
  * ``customCredentialFormHtml``, ``setupCompleteHook``) live in
@@ -42,10 +42,9 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { runLocalServer } from '@n24q02m/mcp-core'
 
-import { loadUserCredentials } from '../auth/per-user-credential-store.js'
 import { subjectContext } from '../auth/subject-context.js'
 import { resolveCredentialState } from '../credential-state.js'
-import { buildRunLocalServerOptions } from '../spawn-setup.js'
+import { buildRunLocalServerOptions, credStore } from '../spawn-setup.js'
 import { type AccountConfig, loadConfig } from '../tools/helpers/config.js'
 import { registerTools } from '../tools/registry.js'
 
@@ -114,7 +113,8 @@ export async function startHttp(): Promise<void> {
               await next()
               return
             }
-            const accounts = (await loadUserCredentials(sub)) ?? []
+            const payload = await credStore.load(sub)
+            const accounts = (payload?.accounts as AccountConfig[] | undefined) ?? []
             await subjectContext.run({ sub, accounts }, next)
           }
         }


### PR DESCRIPTION
Per spec § 4.D3 + § 5.A8. Drops disk persistence (AES-GCM+PBKDF2); aligns with Notion in-memory pattern (TC-NearZK). Users re-authenticate after server restart.