### PR TITLE
🎨 Palette: [UX improvement] Add required indicators to form fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,9 @@
 **Learning:** During potentially long-running async operations (like network requests or OAuth polling), simply changing button text (e.g., to "Connecting...") or disabling the button isn't always enough visual feedback. Users may still wonder if the system is hung, especially if the text change is subtle.
 
 **Action:** Always include an animated visual indicator (like a CSS spinner with `aria-hidden="true"`) inside the submission button alongside the status text during asynchronous operations to clearly communicate that background processing is actively occurring.
+
+## 2025-02-15 - Required Form Field Indicators
+
+**Learning:** When adding visual indicators (like `*`) for required form fields to assist sighted users, screen readers may redundantly announce "star" or "asterisk" in addition to "required" if the native input is already marked with the `required` attribute.
+
+**Action:** Always apply `aria-hidden="true"` to decorative required indicator elements (like asterisks) to prevent redundant screen reader announcements when the native form control handles the accessibility state.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -312,7 +312,15 @@ export function renderEmailCredentialForm(
                 labelEl.className = "field-label";
                 labelEl.setAttribute("for", "field-" + key + "_" + idx);
                 labelEl.textContent = label;
-                if (!required) {
+
+                if (required) {
+                    var asterisk = document.createElement("span");
+                    asterisk.textContent = "*";
+                    asterisk.setAttribute("aria-hidden", "true");
+                    asterisk.style.color = "#f87171";
+                    asterisk.style.marginLeft = "0.25rem";
+                    labelEl.appendChild(asterisk);
+                } else {
                     var badge = document.createElement("span");
                     badge.className = "optional-badge";
                     badge.textContent = "Optional";


### PR DESCRIPTION
💡 What:
Added a visual required indicator (`*`) to form fields that are marked as required in the credentials setup form.

🎯 Why:
To help sighted users easily identify which fields are mandatory without having to guess or rely solely on validation errors upon submission.

📸 Before/After:
Before: Required fields visually looked identical to optional fields (except optional fields had an "Optional" badge).
After: Required fields now clearly show a red asterisk next to the label (e.g., "Email Address *").

♿ Accessibility:
Added `aria-hidden="true"` to the decorative asterisk element. This ensures that screen readers do not redundantly announce "star" or "asterisk" in addition to "required", since the underlying native input is already marked with the `required` attribute.

---
*PR created automatically by Jules for task [9663168346582100429](https://jules.google.com/task/9663168346582100429) started by @n24q02m*