### PR TITLE
fix: stdio missing-cred check accept EMAIL_CREDENTIALS (match loader)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.27.0-beta.2",
+  "version": "1.27.0-beta.3",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 <!-- version list -->
 
+## v1.27.0-beta.3 (2026-05-02)
+
+### Bug Fixes
+
+- Setup docs + README reflect stdio-pure architecture
+  ([#532](https://github.com/n24q02m/better-email-mcp/pull/532),
+  [`e378ad5`](https://github.com/n24q02m/better-email-mcp/commit/e378ad503a9df9070f4b67e04d093eb995edaf4f))
+
+- **deps**: Update dependency html-to-text to v10
+  ([#525](https://github.com/n24q02m/better-email-mcp/pull/525),
+  [`d504be9`](https://github.com/n24q02m/better-email-mcp/commit/d504be927069a0d078ef775e6146e1f0dd1f6ead))
+
+### Chores
+
+- **deps**: Lock file maintenance ([#519](https://github.com/n24q02m/better-email-mcp/pull/519),
+  [`f1a94dd`](https://github.com/n24q02m/better-email-mcp/commit/f1a94ddacff010f8993601ce09077d255dbd250a))
+
+- **deps**: Update dawidd6/action-send-mail action to v17
+  ([#518](https://github.com/n24q02m/better-email-mcp/pull/518),
+  [`279fdb7`](https://github.com/n24q02m/better-email-mcp/commit/279fdb76c70231906977da92df5da3bff50e2f71))
+
+### Features
+
+- Stdio-pure + http-multi-user (drop daemon-bridge)
+  ([#531](https://github.com/n24q02m/better-email-mcp/pull/531),
+  [`ba6bb5a`](https://github.com/n24q02m/better-email-mcp/commit/ba6bb5a1ac764e9346f26c1ab0fd9e28a8c3afbc))
+
+
 ## v1.27.0-beta.2 (2026-04-30)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "codex",
     "opencode"
   ],
-  "version": "1.27.0-beta.2",
+  "version": "1.27.0-beta.3",
   "license": "MIT",
   "type": "module",
   "publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.27.0-beta.2",
+  "version": "1.27.0-beta.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.27.0-beta.2",
+      "version": "1.27.0-beta.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -48,7 +48,7 @@ describe('initServer', () => {
     process.argv = [...originalArgv]
     delete process.env.MCP_TRANSPORT
     delete process.env.TRANSPORT_MODE
-    delete process.env.EMAIL_PROVIDER
+    delete process.env.EMAIL_CREDENTIALS
     delete process.env.EMAIL_USER
     delete process.env.EMAIL_APP_PASSWORD
     // process.exit is mocked to throw so we can detect calls without
@@ -90,10 +90,8 @@ describe('initServer', () => {
     expect(connectMock).not.toHaveBeenCalled()
   })
 
-  it('starts stdio transport by default when all env vars set', async () => {
-    process.env.EMAIL_PROVIDER = 'gmail'
-    process.env.EMAIL_USER = 'user@example.com'
-    process.env.EMAIL_APP_PASSWORD = 'app-pass'
+  it('starts stdio transport by default when EMAIL_CREDENTIALS set', async () => {
+    process.env.EMAIL_CREDENTIALS = 'user@example.com:app-pass'
     const { initServer } = await import('./init-server.js')
     await initServer()
     expect(ServerCtorMock).toHaveBeenCalledWith(
@@ -107,30 +105,25 @@ describe('initServer', () => {
     expect(exitSpy).not.toHaveBeenCalled()
   })
 
-  it('exits with code 1 and writes missing env vars to stderr when all 3 are missing', async () => {
+  it('exits with code 1 when neither EMAIL_CREDENTIALS nor EMAIL_USER+APP_PASSWORD set', async () => {
     const { initServer } = await import('./init-server.js')
     await expect(initServer()).rejects.toThrow('process.exit(1)')
 
     expect(exitSpy).toHaveBeenCalledWith(1)
     const stderrOutput = stderrSpy.mock.calls.map((c: any) => String(c[0])).join('')
     expect(stderrOutput).toContain('Missing required env vars for stdio mode')
-    expect(stderrOutput).toContain('EMAIL_PROVIDER')
+    expect(stderrOutput).toContain('EMAIL_CREDENTIALS')
     expect(stderrOutput).toContain('EMAIL_USER')
     expect(stderrOutput).toContain('EMAIL_APP_PASSWORD')
     expect(connectMock).not.toHaveBeenCalled()
   })
 
-  it('exits with code 1 listing only missing env vars when some are set', async () => {
-    process.env.EMAIL_PROVIDER = 'gmail'
-    // EMAIL_USER + EMAIL_APP_PASSWORD missing
+  it('starts stdio when EMAIL_USER + EMAIL_APP_PASSWORD set (without EMAIL_CREDENTIALS)', async () => {
+    process.env.EMAIL_USER = 'user@example.com'
+    process.env.EMAIL_APP_PASSWORD = 'app-pass'
     const { initServer } = await import('./init-server.js')
-    await expect(initServer()).rejects.toThrow('process.exit(1)')
-
-    expect(exitSpy).toHaveBeenCalledWith(1)
-    const stderrOutput = stderrSpy.mock.calls.map((c: any) => String(c[0])).join('')
-    expect(stderrOutput).toContain('EMAIL_USER')
-    expect(stderrOutput).toContain('EMAIL_APP_PASSWORD')
-    // EMAIL_PROVIDER is set, so it should NOT be in the missing list
-    expect(stderrOutput).not.toMatch(/Missing required env vars for stdio mode:[^\n]*EMAIL_PROVIDER/)
+    await initServer()
+    expect(connectMock).toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -58,17 +58,25 @@ export async function initServer() {
     return
   }
 
-  // Default: stdio mode. Requires EMAIL_PROVIDER + EMAIL_USER + EMAIL_APP_PASSWORD.
-  const missing: string[] = []
-  if (!process.env.EMAIL_PROVIDER) missing.push('EMAIL_PROVIDER')
-  if (!process.env.EMAIL_USER) missing.push('EMAIL_USER')
-  if (!process.env.EMAIL_APP_PASSWORD) missing.push('EMAIL_APP_PASSWORD')
-  if (missing.length > 0) {
-    const msg = `[${SERVER_NAME}] Missing required env vars for stdio mode: ${missing.join(', ')}
+  // Default: stdio mode. credential-state.ts:loadCredsFromEnv accepts EITHER:
+  //   (a) EMAIL_CREDENTIALS directly ("user:app-password" or multi-account
+  //       "user1:pass1,user2:pass2"), OR
+  //   (b) EMAIL_USER + EMAIL_APP_PASSWORD pair (merged into EMAIL_CREDENTIALS at boot).
+  // Match handler to loader semantics.
+  const hasCredentials = !!process.env.EMAIL_CREDENTIALS
+  const hasUserAppPair = !!(process.env.EMAIL_USER && process.env.EMAIL_APP_PASSWORD)
+  if (!hasCredentials && !hasUserAppPair) {
+    const msg = `[${SERVER_NAME}] Missing required env vars for stdio mode.
+
+stdio mode reads credentials from EITHER:
+  - EMAIL_CREDENTIALS (combined "user:app-password" or "user1:pass1,user2:pass2"), OR
+  - EMAIL_USER + EMAIL_APP_PASSWORD pair (merged at boot)
 
 Options:
-  1. Set env vars in plugin config:
-     {"command": "npx", "args": [...], "env": {"EMAIL_PROVIDER": "gmail", "EMAIL_USER": "...", "EMAIL_APP_PASSWORD": "..."}}
+  1. Set env in plugin config:
+     {"command": "npx", "args": [...], "env": {"EMAIL_CREDENTIALS": "user:app-password"}}
+     OR
+     {"command": "npx", "args": [...], "env": {"EMAIL_USER": "...", "EMAIL_APP_PASSWORD": "..."}}
 
   2. Switch to HTTP mode (browser-based setup with bundled Outlook OAuth):
      See docs/setup-manual.md "Method 5: Self-Hosting HTTP Mode"


### PR DESCRIPTION
Phase 1.3.B handler bug — required env vars didn't match loader semantics.