### PR TITLE
🎨 Palette: [UX improvement] Add visual required indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,8 @@
 **Learning:** During potentially long-running async operations (like network requests or OAuth polling), simply changing button text (e.g., to "Connecting...") or disabling the button isn't always enough visual feedback. Users may still wonder if the system is hung, especially if the text change is subtle.
 
 **Action:** Always include an animated visual indicator (like a CSS spinner with `aria-hidden="true"`) inside the submission button alongside the status text during asynchronous operations to clearly communicate that background processing is actively occurring.
+
+## 2026-05-02 - Visual Required Indicators & Accessibility
+
+**Learning:** When adding visual indicators (like `*`) to form fields to assist sighted users in identifying required inputs, screen readers may announce the asterisk redundantly if the native input is already marked with the `required` attribute.
+**Action:** Always use `aria-hidden="true"` on the visual indicator element (e.g., `<span aria-hidden="true">*</span>`) to prevent redundant screen reader announcements while still providing clear visual cues for sighted users.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -141,6 +141,10 @@ export function renderEmailCredentialForm(
             border-radius: 4px;
             padding: 0.1rem 0.4rem;
         }
+        .required-indicator {
+            color: #f87171;
+            margin-left: 0.25rem;
+        }
         .field-input {
             width: 100%;
             background-color: #0d0d0d;
@@ -312,7 +316,13 @@ export function renderEmailCredentialForm(
                 labelEl.className = "field-label";
                 labelEl.setAttribute("for", "field-" + key + "_" + idx);
                 labelEl.textContent = label;
-                if (!required) {
+                if (required) {
+                    var reqBadge = document.createElement("span");
+                    reqBadge.className = "required-indicator";
+                    reqBadge.setAttribute("aria-hidden", "true");
+                    reqBadge.textContent = "*";
+                    labelEl.appendChild(reqBadge);
+                } else {
                     var badge = document.createElement("span");
                     badge.className = "optional-badge";
                     badge.textContent = "Optional";


### PR DESCRIPTION
**💡 What:** Added a clear visual indicator (a red asterisk `*`) to form field labels that are marked as required. The indicator is hidden from screen readers using `aria-hidden="true"`.
**🎯 Why:** Sighted users need immediate visual feedback on which fields are mandatory. Without an indicator, users might skip required fields and encounter validation errors. However, since the native `<input>` elements already use the `required` attribute (which screen readers naturally announce), adding a literal text asterisk without `aria-hidden` would result in redundant and annoying "asterisk" announcements.
**📸 Before/After:** Fields like "Email" or "Password" previously relied solely on the HTML5 `required` attribute. Now, they explicitly show "Test Label *" for sighted users.
**♿ Accessibility:** The asterisk explicitly uses `aria-hidden="true"` so that the visual cue is purely decorative for assistive technologies, avoiding duplicated state announcements while significantly improving form scannability for sighted users.

---
*PR created automatically by Jules for task [14961925303691968180](https://jules.google.com/task/14961925303691968180) started by @n24q02m*