### PR TITLE
fix: wire setup_complete_hook for outlook device-code OAuth

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -2,7 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { runHttpServer, writeConfig } from '@n24q02m/mcp-core'
 import { ImapFlow } from 'imapflow'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
-import { resolveCredentialState, setState } from '../credential-state.js'
+import { getMarkSetupComplete, resolveCredentialState, setState } from '../credential-state.js'
 import { loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
@@ -238,7 +238,18 @@ describe('http transport', () => {
       })
     })
 
-    it('handles Outlook OAuth2 completion', async () => {
+    it('handles Outlook OAuth2 completion and flips setup-status outlook key to complete', async () => {
+      // Regression for 2026-05-03 bug: form's polling JS at
+      // src/credential-form.ts:564 checks ``s.outlook === "complete"`` but
+      // ``setMarkSetupComplete`` was wired without the producer side ever
+      // calling ``markSetupCompleteFn("outlook")`` after Microsoft token save
+      // → form spinner stuck on "Waiting for Microsoft authorization..."
+      // forever even though tokens were persisted to disk.
+      //
+      // Fix: device-code ``onComplete`` callback in ``initiateOutlookOAuth``
+      // must invoke ``getMarkSetupComplete()?.("outlook")`` AFTER ``saveTokens``
+      // returns (mcp-core's default ``mark_setup_complete()`` uses key
+      // "gdrive" -- email plugin must explicitly pass "outlook").
       const mockAccounts = [{ email: 'test@outlook.com', imap: {}, authType: 'oauth2' }]
       vi.mocked(parseCredentials).mockResolvedValue(mockAccounts as any)
       vi.mocked(isOutlookDomain).mockReturnValue(true)
@@ -252,11 +263,41 @@ describe('http transport', () => {
         } as any)
       })
 
+      const markComplete = vi.fn()
+      vi.mocked(getMarkSetupComplete).mockReturnValue(markComplete)
+
       await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
-      // Trigger completion
+      // Trigger completion (background poll fires this after Microsoft returns
+      // tokens and ``saveTokens`` persists them).
       await completionCallback()
 
+      expect(setState).toHaveBeenCalledWith('configured')
+      expect(markComplete).toHaveBeenCalledWith('outlook')
+    })
+
+    it('does not throw when setMarkSetupComplete hook is null on Outlook completion', async () => {
+      // Defensive: hook may not have been wired yet (early bootstrap or
+      // tests). Completion callback must still update setState without
+      // raising even if ``getMarkSetupComplete()`` returns null.
+      const mockAccounts = [{ email: 'test@outlook.com', imap: {}, authType: 'oauth2' }]
+      vi.mocked(parseCredentials).mockResolvedValue(mockAccounts as any)
+      vi.mocked(isOutlookDomain).mockReturnValue(true)
+
+      let completionCallback: any
+      vi.mocked(initiateOutlookDeviceCode).mockImplementation((_email, callback) => {
+        completionCallback = callback
+        return Promise.resolve({
+          verificationUri: 'uri',
+          userCode: 'code'
+        } as any)
+      })
+
+      vi.mocked(getMarkSetupComplete).mockReturnValue(null)
+
+      await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
+
+      expect(() => completionCallback()).not.toThrow()
       expect(setState).toHaveBeenCalledWith('configured')
     })
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -25,7 +25,13 @@ import { ImapFlow } from 'imapflow'
 import { InMemoryCredStore } from '../auth/in-memory-cred-store.js'
 import { subjectContext } from '../auth/subject-context.js'
 import { renderEmailCredentialForm } from '../credential-form.js'
-import { resolveCredentialState, setMarkSetupComplete, setSetupUrl, setState } from '../credential-state.js'
+import {
+  getMarkSetupComplete,
+  resolveCredentialState,
+  setMarkSetupComplete,
+  setSetupUrl,
+  setState
+} from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
@@ -103,6 +109,16 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[]): Promise<N
   try {
     const device = await initiateOutlookDeviceCode(first.email, () => {
       setState('configured')
+      // Flip GET /setup-status outlook key to "complete" so the credential
+      // form's poll (src/credential-form.ts:564 ``s.outlook === "complete"``)
+      // stops spinning and follows the OAuth redirect_url. Without this the
+      // hook fires only on form-side `mark_setup_complete()` paths (gdrive
+      // default key) — Outlook device-code completion never matches.
+      try {
+        getMarkSetupComplete()?.('outlook')
+      } catch {
+        // Best-effort: never let a failed setup-status flip break OAuth.
+      }
       console.error(`[${SERVER_NAME}] Outlook OAuth2 completed for ${first.email}`)
     })
     setState('setup_in_progress')


### PR DESCRIPTION
## Summary

Outlook device-code OAuth completion never flipped the credential form's polling key from `awaiting` to `complete`, so the form spinner stalled on "Waiting for Microsoft authorization..." forever even after tokens were persisted to disk.

**Root cause**: `setMarkSetupComplete` was wired into mcp-core's `setupCompleteHook` (http.ts:221), but the producer side — the `onComplete` callback in `initiateOutlookOAuth` — only called `setState('configured')` and never invoked `markSetupCompleteFn('outlook')`. mcp-core's default `mark_setup_complete()` uses key `gdrive`; the email plugin must explicitly pass `outlook` to match the form poll at `src/credential-form.ts:564` (`s.outlook === "complete"`).

**Fix**: in the device-code completion callback (`src/transports/http.ts:104`), call `getMarkSetupComplete()?.("outlook")` immediately after `setState('configured')`, wrapped in a try/catch so a hook miss never breaks OAuth.

## Bug evidence

- Container log: `[better-email-mcp] Outlook OAuth2 completed for n24q02m@outlook.com` (token saved)
- Form polling JS at `src/credential-form.ts:564` checks `s.outlook === "complete"` → never matched
- `grep -rn "setMarkSetupComplete\|markSetupCompleteFn" src/` showed define + setter wired, but no producer call with key `"outlook"`

## Test plan

- [x] Extended `handles Outlook OAuth2 completion` test to assert `markComplete` is called with `"outlook"` after token save
- [x] Added defensive test `does not throw when setMarkSetupComplete hook is null on Outlook completion`
- [x] All 551 tests pass (`bun run test`)
- [x] `biome check` + `tsc --noEmit` clean (`bun run check`)
- [x] Pre-commit hooks pass (gitleaks, biome, tsc, vitest, prefix-enforce)
- [ ] Post-merge: BETA cuts new image; redeploy `oci-better-email-mcp`; manual Outlook device-code completion → `GET /setup-status` returns `{"outlook":"complete"}`