### PR TITLE
🎨 Palette: Add visual indicator for required form fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,9 @@
 **Learning:** During potentially long-running async operations (like network requests or OAuth polling), simply changing button text (e.g., to "Connecting...") or disabling the button isn't always enough visual feedback. Users may still wonder if the system is hung, especially if the text change is subtle.
 
 **Action:** Always include an animated visual indicator (like a CSS spinner with `aria-hidden="true"`) inside the submission button alongside the status text during asynchronous operations to clearly communicate that background processing is actively occurring.
+
+## 2025-02-15 - Required Field Visual Indicators
+
+**Learning:** Sighted users often struggle to identify required fields in dynamic forms if they are only marked with native `required` attributes, which are invisible until submission. Adding visual indicators (like `*`) helps, but if not implemented carefully, screen readers will announce "star" or "asterisk" alongside the label, creating redundant noise since the native input already communicates its required state.
+
+**Action:** When adding visual indicators for required fields, always use `aria-hidden="true"` on the indicator element to prevent redundant screen reader announcements while providing clear visual guidance for sighted users.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -141,6 +141,10 @@ export function renderEmailCredentialForm(
             border-radius: 4px;
             padding: 0.1rem 0.4rem;
         }
+        .required-indicator {
+            color: #f87171;
+            margin-left: 0.2rem;
+        }
         .field-input {
             width: 100%;
             background-color: #0d0d0d;
@@ -318,6 +322,12 @@ export function renderEmailCredentialForm(
                     badge.textContent = "Optional";
                     labelEl.appendChild(document.createTextNode(" "));
                     labelEl.appendChild(badge);
+                } else {
+                    var reqIndicator = document.createElement("span");
+                    reqIndicator.className = "required-indicator";
+                    reqIndicator.setAttribute("aria-hidden", "true");
+                    reqIndicator.textContent = "*";
+                    labelEl.appendChild(reqIndicator);
                 }
                 group.appendChild(labelEl);
 


### PR DESCRIPTION
💡 **What:** Added a red asterisk (`*`) visual indicator to required form fields in the credentials form.

🎯 **Why:** To help sighted users clearly distinguish required fields from optional ones before attempting to submit the form, which reduces confusion and improves completion rates.

📸 **Before/After:** The "Email Address" and "Password" fields now display a red asterisk, while the "IMAP Host" field retains its "Optional" badge.

♿ **Accessibility:** The newly added `*` span explicitly sets `aria-hidden="true"`. This ensures that screen readers, which already announce the field's native `required` attribute, do not redundantly read out "star" or "asterisk", keeping the auditory experience clean.

---
*PR created automatically by Jules for task [12474528138277229403](https://jules.google.com/task/12474528138277229403) started by @n24q02m*