### PR TITLE
fix: consolidate setup docs body to 3 methods (drop legacy Method 4/5)

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -4,7 +4,7 @@
 > The previous "Zero-Config Relay" auto-spawn pattern has been removed.
 > If you relied on the relay form, please:
 > 1. Set env vars in plugin config (Method 1), OR
-> 2. Switch to HTTP mode (Method 4 hosted / Method 5 self-host) for browser-based setup.
+> 2. Switch to HTTP mode (Method 3 (Docker HTTP — Hosted or Self-host)) for browser-based setup.
 
 ## Method overview
 
@@ -59,60 +59,7 @@ Plugin install runs in **stdio mode** with credentials from env vars.
    Multi-account: use `EMAIL_CREDENTIALS` instead with comma-separated `user:pass[:imap.host]` entries.
 4. Restart Claude Code.
 
-## Method 2: npx (Any MCP Client)
-
-Stdio mode via `npx`. Add to your MCP client configuration:
-
-**Claude Code** -- `.claude/settings.json` or `~/.claude/settings.json`:
-```json
-{
-  "mcpServers": {
-    "better-email-mcp": {
-      "command": "npx",
-      "args": ["-y", "@n24q02m/better-email-mcp"],
-      "env": {
-        "EMAIL_PROVIDER": "gmail",
-        "EMAIL_USER": "you@gmail.com",
-        "EMAIL_APP_PASSWORD": "abcd efgh ijkl mnop"
-      }
-    }
-  }
-}
-```
-
-**Codex CLI** -- `~/.codex/config.toml`:
-```toml
-[mcp_servers.better-email-mcp]
-command = "npx"
-args = ["-y", "@n24q02m/better-email-mcp"]
-
-[mcp_servers.better-email-mcp.env]
-EMAIL_PROVIDER = "gmail"
-EMAIL_USER = "you@gmail.com"
-EMAIL_APP_PASSWORD = "abcd efgh ijkl mnop"
-```
-
-**OpenCode** -- `opencode.json`:
-```json
-{
-  "mcpServers": {
-    "better-email-mcp": {
-      "command": "npx",
-      "args": ["-y", "@n24q02m/better-email-mcp"],
-      "env": {
-        "EMAIL_PROVIDER": "gmail",
-        "EMAIL_USER": "you@gmail.com",
-        "EMAIL_APP_PASSWORD": "abcd efgh ijkl mnop"
-      }
-    }
-  }
-}
-```
-
-Replace credentials with your actual values, then restart your MCP client.
-Other package runners (`bun x`, `pnpm dlx`, `yarn dlx`) also work in place of `npx -y`.
-
-## Method 3: Docker (stdio)
+## Method 2: Docker stdio (fallback)
 
 1. Pull the image:
    ```bash
@@ -155,7 +102,9 @@ Stdio mode is the default and works for single-user local development. Consider 
 - **Multi-user / team sharing** — per-JWT-sub credential isolation; one deployment serves the team
 - **Always-on persistent process** — required for webhooks, scheduled inbox scans, or long-running agents
 
-## Method 4: HTTP Hosted (Multi-User)
+## Method 3: Docker HTTP (recommended)
+
+### 3.1. Hosted (n24q02m.com)
 
 Use the n24q02m-hosted instance:
 
@@ -172,7 +121,7 @@ Use the n24q02m-hosted instance:
 
 On first call the server initiates the **OAuth flow**. Outlook/Hotmail/Live accounts get a Microsoft device-code link (powered by the bundled public Outlook OAuth client `d56f8c71-9f7c-43f4-9934-be29cb6e77b0` — Thunderbird-pattern public client per Google/Microsoft installed-app convention; no user-side Azure app registration needed). Gmail / Yahoo / iCloud / custom IMAP accounts use the relay paste form.
 
-## Method 5: Self-Hosting HTTP Mode
+### 3.2. Self-host with docker-compose
 
 Single multi-user mode (relay form for App-Password providers + bundled Outlook OAuth):
 
@@ -214,24 +163,6 @@ Point clients to your server URL:
 ```
 
 The server runs in single multi-user mode: per-JWT-sub credential isolation, OAuth 2.1 + Dynamic Client Registration. The first request from each user triggers either a Microsoft device-code link (Outlook) or a paste form (Gmail/Yahoo/iCloud/custom IMAP).
-
-## Method 6: Build from Source
-
-1. Clone and build:
-   ```bash
-   git clone https://github.com/n24q02m/better-email-mcp.git
-   cd better-email-mcp
-   bun install
-   bun run build
-   ```
-
-2. Run the dev server (stdio):
-   ```bash
-   EMAIL_PROVIDER=gmail \
-   EMAIL_USER=you@gmail.com \
-   EMAIL_APP_PASSWORD="abcd efgh ijkl mnop" \
-     bun run dev
-   ```
 
 ## Credential Setup (Stdio mode)
 
@@ -311,7 +242,7 @@ EMAIL_IMAP_HOST=imap.custom.com
 ### Outlook in stdio mode
 
 - Stdio mode requires an Outlook **App Password** (Account Settings → Security → Advanced security options → App passwords). The OAuth2 device-code flow is HTTP-mode-only.
-- For OAuth2 (no App Password), switch to HTTP mode (Method 4 hosted or Method 5 self-host).
+- For OAuth2 (no App Password), switch to HTTP mode (Method 3 Docker HTTP (Hosted or Self-host)).
 
 ### Outlook OAuth not starting (HTTP mode)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -4,7 +4,7 @@
 > The previous "Zero-Config Relay" auto-spawn pattern has been removed.
 > If you relied on the relay form, please:
 > 1. Set env vars in plugin config (Option 1), OR
-> 2. Switch to HTTP mode (Option 4 hosted / Option 5 self-host) for browser-based setup.
+> 2. Switch to HTTP mode (Option 3 (Docker HTTP — Hosted or Self-host)) for browser-based setup.
 
 > Give this file to your AI agent to automatically set up better-email-mcp.
 
@@ -47,73 +47,7 @@ After install, set credentials in `~/.claude/settings.local.json` (or `.claude/s
 
 Restart Claude Code after editing. For multi-account setups, use `EMAIL_CREDENTIALS` instead (see below).
 
-## Option 2: MCP Direct (npx + env vars)
-
-### Claude Code (settings.json)
-
-Add to `.claude/settings.json` or `~/.claude/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "better-email-mcp": {
-      "command": "npx",
-      "args": ["-y", "@n24q02m/better-email-mcp"],
-      "env": {
-        "EMAIL_PROVIDER": "gmail",
-        "EMAIL_USER": "you@gmail.com",
-        "EMAIL_APP_PASSWORD": "abcd efgh ijkl mnop"
-      }
-    }
-  }
-}
-```
-
-For multiple accounts (legacy compact format):
-```json
-{
-  "env": {
-    "EMAIL_CREDENTIALS": "user1@gmail.com:pass1,user2@outlook.com:pass2"
-  }
-}
-```
-
-### Codex CLI (config.toml)
-
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.better-email-mcp]
-command = "npx"
-args = ["-y", "@n24q02m/better-email-mcp"]
-
-[mcp_servers.better-email-mcp.env]
-EMAIL_PROVIDER = "gmail"
-EMAIL_USER = "you@gmail.com"
-EMAIL_APP_PASSWORD = "abcd efgh ijkl mnop"
-```
-
-### OpenCode (opencode.json)
-
-Add to `opencode.json` in your project root:
-
-```json
-{
-  "mcpServers": {
-    "better-email-mcp": {
-      "command": "npx",
-      "args": ["-y", "@n24q02m/better-email-mcp"],
-      "env": {
-        "EMAIL_PROVIDER": "gmail",
-        "EMAIL_USER": "you@gmail.com",
-        "EMAIL_APP_PASSWORD": "abcd efgh ijkl mnop"
-      }
-    }
-  }
-}
-```
-
-## Option 3: Docker (stdio)
+## Option 2: Docker stdio (fallback)
 
 ```json
 {
@@ -145,7 +79,9 @@ Stdio mode is the default and works for single-user local development. Switch to
 - **Multi-user / team sharing** — per-JWT-sub credential isolation; one deployment serves the team
 - **Always-on persistent process** — required for webhooks, scheduled inbox scans, or long-running agents
 
-## Option 4: HTTP Hosted (Multi-User)
+## Option 3: Docker HTTP (recommended)
+
+### 3.1. Hosted (n24q02m.com)
 
 Multi-user mode with OAuth 2.1 + bundled Outlook OAuth (no local credentials needed):
 
@@ -185,7 +121,7 @@ url = "https://better-email-mcp.n24q02m.com/mcp"
 
 The first request from each user triggers either a Microsoft device-code link (Outlook) or a paste form (Gmail/Yahoo/iCloud/custom IMAP). Outlook OAuth uses the bundled public Azure client (`d56f8c71-9f7c-43f4-9934-be29cb6e77b0`, Thunderbird-pattern) — no user-side Azure app registration needed.
 
-## Option 5: Self-Hosting HTTP Mode
+### 3.2. Self-host with docker-compose
 
 Run your own multi-user instance:
 


### PR DESCRIPTION
Consolidate setup docs body to match Method overview (3 methods total). Drops legacy Method 4 (HTTP Hosted) and Method 5 (HTTP Self-host) standalone sections, merges into Method 3 with 3.1 (Hosted) and 3.2 (Self-host) subheadings. Drops Method 2 (npx/uvx Direct, redundant with Method 1) and Method 6 (Build from Source, out of scope). Renames Method 3 (Docker stdio) to Method 2 (fallback). Body now matches the overview matrix exactly.