### PR TITLE
feat: declare userConfig schema and document install prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,15 @@
   "name": "better-email-mcp",
   "description": "Email management via IMAP/SMTP — multi-account",
   "version": "1.27.0",
+  "userConfig": {
+    "EMAIL_CREDENTIALS": {
+      "type": "string",
+      "title": "Email credentials",
+      "description": "Format: user@gmail.com:app-password (multi: user1@x:p1,user2@y:p2)",
+      "sensitive": true,
+      "required": true
+    }
+  },
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -11,7 +20,10 @@
     "better-email-mcp": {
       "command": "npx",
       "args": ["--yes", "@n24q02m/better-email-mcp@latest"],
-      "env": { "MCP_TRANSPORT": "stdio" }
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "EMAIL_CREDENTIALS": "${user_config.EMAIL_CREDENTIALS}"
+      }
     }
   }
 }

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -34,30 +34,30 @@ App Passwords are required for App-Password providers (NOT your regular password
 
 ## Method 1: Claude Code Plugin (Recommended)
 
-Plugin install runs in **stdio mode** with credentials from env vars.
+Plugin install runs in **stdio mode** with credentials provided via the `userConfig` install prompt.
 
-1. Open Claude Code in your terminal
-2. Run:
+### Step 0: Credential prompt
+
+When you run `/plugin install better-email-mcp@n24q02m-plugins`, Claude Code prompts for the value declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Format |
+|:------|:---------|:----------|:-------|
+| `EMAIL_CREDENTIALS` | Yes | Yes | `user@gmail.com:app-password`. Multi-account: `user1@x:p1,user2@y:p2`. Custom IMAP host: `user@custom.com:password:imap.custom.com` |
+
+The sensitive value is stored in the system keychain (or `~/.claude/.credentials.json` fallback) and persists across `/plugin update`. Claude Code substitutes the value into `mcpServers.better-email-mcp.env.EMAIL_CREDENTIALS` via `${user_config.EMAIL_CREDENTIALS}` -- you do not edit `env` manually.
+
+### Steps
+
+1. Prepare an App Password for each account (see "Create App Passwords" above).
+2. Open Claude Code in your terminal.
+3. Install the plugin (Claude Code prompts for `EMAIL_CREDENTIALS`):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install better-email-mcp@n24q02m-plugins
    ```
-3. Configure credentials in `~/.claude/settings.local.json` (or `.claude/settings.json` per-project):
-   ```json
-   {
-     "mcpServers": {
-       "better-email-mcp": {
-         "env": {
-           "EMAIL_PROVIDER": "gmail",
-           "EMAIL_USER": "you@gmail.com",
-           "EMAIL_APP_PASSWORD": "abcd efgh ijkl mnop"
-         }
-       }
-     }
-   }
-   ```
-   Multi-account: use `EMAIL_CREDENTIALS` instead with comma-separated `user:pass[:imap.host]` entries.
-4. Restart Claude Code.
+4. Restart Claude Code -- the plugin auto-loads with your credentials injected.
+
+> **HTTP transport (Method 3)** is a separate install path. The `userConfig` prompt only covers stdio Method 1; HTTP self-host still requires manual `mcpServers` config per Method 3 below.
 
 ## Method 2: Docker stdio (fallback)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -20,32 +20,28 @@ This plugin supports 3 install methods. Pick the one that matches your use case:
 
 All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
 
-## Option 1: Claude Code Plugin (Recommended -- stdio + env vars)
+## Option 1: Claude Code Plugin (Recommended -- stdio + userConfig prompt)
+
+### Step 0: Credential prompt
+
+When the install command runs, Claude Code prompts for the field declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Format |
+|:------|:---------|:----------|:-------|
+| `EMAIL_CREDENTIALS` | Yes | Yes | `user@gmail.com:app-password` (single) or `user1@x:p1,user2@y:p2` (multi). Custom IMAP host: append `:imap.host`. |
+
+The plugin manifest substitutes the value into `mcpServers.better-email-mcp.env.EMAIL_CREDENTIALS` via `${user_config.EMAIL_CREDENTIALS}`. Sensitive values are kept in the system keychain and persist across `/plugin update` -- you do not edit `env` manually.
+
+### Steps
 
 ```bash
 /plugin marketplace add n24q02m/claude-plugins
 /plugin install better-email-mcp@n24q02m-plugins
 ```
 
-This installs the server with skills: `/inbox-review`, `/follow-up`.
+Paste your `EMAIL_CREDENTIALS` value when prompted. This installs the server with skills: `/inbox-review`, `/follow-up`. Restart Claude Code -- the plugin auto-loads with your credentials.
 
-After install, set credentials in `~/.claude/settings.local.json` (or `.claude/settings.json` per-project):
-
-```json
-{
-  "mcpServers": {
-    "better-email-mcp": {
-      "env": {
-        "EMAIL_PROVIDER": "gmail",
-        "EMAIL_USER": "you@gmail.com",
-        "EMAIL_APP_PASSWORD": "abcd efgh ijkl mnop"
-      }
-    }
-  }
-}
-```
-
-Restart Claude Code after editing. For multi-account setups, use `EMAIL_CREDENTIALS` instead (see below).
+> **HTTP transport (Option 3)** is a separate install path; the `userConfig` prompt does not apply, and you manually configure `mcpServers` for HTTP per Option 3 below.
 
 ## Option 2: Docker stdio (fallback)
 


### PR DESCRIPTION
## Summary

- Add `userConfig.EMAIL_CREDENTIALS` (sensitive, required) so `/plugin install` prompts for IMAP/SMTP credentials at install time.
- Substitute via `${user_config.EMAIL_CREDENTIALS}` into `mcpServers.better-email-mcp.env`. Format: single (`user@gmail.com:app-password`), multi-account (comma-separated), or custom IMAP host (`user:pass:imap.host`).
- Update `setup-manual.md` and `setup-with-agent.md` Method 1 with Step 0 prompt section.

## Test plan
- [ ] CI green
- [ ] `/plugin install` prompts for `EMAIL_CREDENTIALS`
- [ ] Tools succeed with credentials injected via substitution

Generated with [Claude Code](https://claude.com/claude-code)