### PR TITLE
🎨 Palette: Add visual required indicator with aria-hidden for forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,9 @@
 **Learning:** During potentially long-running async operations (like network requests or OAuth polling), simply changing button text (e.g., to "Connecting...") or disabling the button isn't always enough visual feedback. Users may still wonder if the system is hung, especially if the text change is subtle.
 
 **Action:** Always include an animated visual indicator (like a CSS spinner with `aria-hidden="true"`) inside the submission button alongside the status text during asynchronous operations to clearly communicate that background processing is actively occurring.
+
+## 2025-02-15 - Required Field Visual Indicators
+
+**Learning:** When adding visual indicators (like `*`) to mark required form fields for sighted users, screen readers will often read these out loudly (e.g., "star" or "asterisk") in addition to native `required` attribute announcements, causing a noisy and redundant experience.
+
+**Action:** Always use `aria-hidden="true"` on non-text or visual-only indicators for required fields to prevent redundant announcements if the native input is already appropriately marked `required`.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -141,6 +141,7 @@ export function renderEmailCredentialForm(
             border-radius: 4px;
             padding: 0.1rem 0.4rem;
         }
+        .required-mark { color: #f87171; margin-left: 0.2rem; }
         .field-input {
             width: 100%;
             background-color: #0d0d0d;
@@ -318,6 +319,12 @@ export function renderEmailCredentialForm(
                     badge.textContent = "Optional";
                     labelEl.appendChild(document.createTextNode(" "));
                     labelEl.appendChild(badge);
+                } else {
+                    var reqMark = document.createElement("span");
+                    reqMark.className = "required-mark";
+                    reqMark.setAttribute("aria-hidden", "true");
+                    reqMark.textContent = "*";
+                    labelEl.appendChild(reqMark);
                 }
                 group.appendChild(labelEl);
 


### PR DESCRIPTION
💡 What: Added a red asterisk (`*`) to the label of required form fields to explicitly denote them, while hiding the asterisk from screen readers using `aria-hidden="true"`.

🎯 Why: Sighted users benefit from immediate visual cues indicating which fields are mandatory. However, screen readers already announce fields marked with the native `required` attribute. By hiding the asterisk, we prevent screen readers from redundantly announcing "star" or "asterisk", keeping the audible experience clean while improving the visual experience.

📸 Before/After:
Before: The "Email Address" and "Password" fields lacked visual indication they were mandatory.
After: Both fields have a red asterisk next to their labels.

♿ Accessibility: Added `aria-hidden="true"` to prevent redundant screen reader announcements while providing crucial visual affordance for sighted users.

---
*PR created automatically by Jules for task [12573335301751529224](https://jules.google.com/task/12573335301751529224) started by @n24q02m*