### PR TITLE
feat: document userConfig credential prompts per plugin

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -36,15 +36,13 @@ App Passwords are required for App-Password providers (NOT your regular password
 
 Plugin install runs in **stdio mode** with credentials provided via the `userConfig` install prompt.
 
-### Step 0: Credential prompt
+### Credential prompts at install
 
-When you run `/plugin install better-email-mcp@n24q02m-plugins`, Claude Code prompts for the value declared in `plugin.json` `userConfig`:
+When you run `/plugin install`, Claude Code prompts you for the following credentials (declared in `userConfig` per CC docs). Sensitive values are stored in your system keychain and persist across `/plugin update`:
 
-| Field | Required | Sensitive | Format |
-|:------|:---------|:----------|:-------|
-| `EMAIL_CREDENTIALS` | Yes | Yes | `user@gmail.com:app-password`. Multi-account: `user1@x:p1,user2@y:p2`. Custom IMAP host: `user@custom.com:password:imap.custom.com` |
-
-The sensitive value is stored in the system keychain (or `~/.claude/.credentials.json` fallback) and persists across `/plugin update`. Claude Code substitutes the value into `mcpServers.better-email-mcp.env.EMAIL_CREDENTIALS` via `${user_config.EMAIL_CREDENTIALS}` -- you do not edit `env` manually.
+| Field | Required | Where to obtain |
+|---|---|---|
+| `EMAIL_CREDENTIALS` | Required | Format: `user@gmail.com:app-password` (multi: comma-separated) |
 
 ### Steps
 
@@ -56,8 +54,6 @@ The sensitive value is stored in the system keychain (or `~/.claude/.credentials
    /plugin install better-email-mcp@n24q02m-plugins
    ```
 4. Restart Claude Code -- the plugin auto-loads with your credentials injected.
-
-> **HTTP transport (Method 3)** is a separate install path. The `userConfig` prompt only covers stdio Method 1; HTTP self-host still requires manual `mcpServers` config per Method 3 below.
 
 ## Method 2: Docker stdio (fallback)
 
@@ -103,6 +99,8 @@ Stdio mode is the default and works for single-user local development. Consider 
 - **Always-on persistent process** — required for webhooks, scheduled inbox scans, or long-running agents
 
 ## Method 3: Docker HTTP (recommended)
+
+> **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 
 ### 3.1. Hosted (n24q02m.com)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -22,15 +22,13 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 ## Option 1: Claude Code Plugin (Recommended -- stdio + userConfig prompt)
 
-### Step 0: Credential prompt
+### Credential prompts at install
 
-When the install command runs, Claude Code prompts for the field declared in `plugin.json` `userConfig`:
+When you run `/plugin install`, Claude Code prompts you for the following credentials (declared in `userConfig` per CC docs). Sensitive values are stored in your system keychain and persist across `/plugin update`:
 
-| Field | Required | Sensitive | Format |
-|:------|:---------|:----------|:-------|
-| `EMAIL_CREDENTIALS` | Yes | Yes | `user@gmail.com:app-password` (single) or `user1@x:p1,user2@y:p2` (multi). Custom IMAP host: append `:imap.host`. |
-
-The plugin manifest substitutes the value into `mcpServers.better-email-mcp.env.EMAIL_CREDENTIALS` via `${user_config.EMAIL_CREDENTIALS}`. Sensitive values are kept in the system keychain and persist across `/plugin update` -- you do not edit `env` manually.
+| Field | Required | Where to obtain |
+|---|---|---|
+| `EMAIL_CREDENTIALS` | Required | Format: `user@gmail.com:app-password` (multi: comma-separated) |
 
 ### Steps
 
@@ -40,8 +38,6 @@ The plugin manifest substitutes the value into `mcpServers.better-email-mcp.env.
 ```
 
 Paste your `EMAIL_CREDENTIALS` value when prompted. This installs the server with skills: `/inbox-review`, `/follow-up`. Restart Claude Code -- the plugin auto-loads with your credentials.
-
-> **HTTP transport (Option 3)** is a separate install path; the `userConfig` prompt does not apply, and you manually configure `mcpServers` for HTTP per Option 3 below.
 
 ## Option 2: Docker stdio (fallback)
 
@@ -76,6 +72,8 @@ Stdio mode is the default and works for single-user local development. Switch to
 - **Always-on persistent process** — required for webhooks, scheduled inbox scans, or long-running agents
 
 ## Option 3: Docker HTTP (recommended)
+
+> **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 
 ### 3.1. Hosted (n24q02m.com)
 


### PR DESCRIPTION
## Summary
- Replace ad-hoc `Step 0: Credential prompt` paragraph in `docs/setup-manual.md` + `docs/setup-with-agent.md` with a canonical `Credential prompts at install` table per spec V9.
- Table columns: `Field | Required | Where to obtain` — lists every key declared in `plugin.json` `userConfig` together with the upstream URL or value-format hint.
- Add a 2-sentence note inside Method 3 / Option 3 (HTTP recommended) clarifying that HTTP transport is selected by overriding `mcpServers` in client settings, not via `userConfig` (which only feeds stdio mode).
- Drops the legacy `> **HTTP transport (Method 3)** is a separate install path` blockquote at the end of Method 1 / Option 1 since the new credential block + Method 3 note now carry that pointer.

## Test plan
- [x] `plugin.json` userConfig keys match the documented table 1:1
- [x] pre-commit passes (lint, type, JSON, diacritics, secret scan)
- [ ] CI green
- [ ] Marketplace install UX prompts match the documented fields

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>