### PR TITLE
feat: clarify Method 1/2/3 mutually exclusive (CC scope-by-endpoint)

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -18,6 +18,8 @@ This plugin supports 3 install methods. Pick the one that matches your use case:
 
 All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
 
+> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 2 (Docker stdio override) OR Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace. Both load simultaneously and create duplicate entries in `/mcp` dialog (plugin's stdio + your override). Plugin matching is by **endpoint** (URL or command string) per CC docs, not by name — and `npx`/`uvx` ≠ `docker` ≠ HTTP URL, so all three are distinct endpoints. Trade-off: choosing Method 2 or Method 3 means you lose this plugin's skills/agents/hooks/commands. For full plugin features, use Method 1 (default plugin install) with `userConfig` credentials prompted at install time.
+
 ## Prerequisites
 
 - **Node.js** >= 24.14.1
@@ -55,7 +57,13 @@ When you run `/plugin install`, Claude Code prompts you for the following creden
    ```
 4. Restart Claude Code -- the plugin auto-loads with your credentials injected.
 
+> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use Method 2 (Docker stdio) or Method 3 (HTTP) below, DO NOT `/plugin install` this plugin — pick Method 2 or Method 3 instead. All three methods are mutually exclusive (see Method overview).
+
 ## Method 2: Docker stdio (fallback)
+
+> **⚠️ Before adding the Docker stdio override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-email-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's `npx`/`uvx` stdio + your `docker run` stdio) will load simultaneously since plugin matches by endpoint (command string), not by name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. Use Method 1 instead if you want full plugin features.
 
 1. Pull the image:
    ```bash
@@ -99,6 +107,10 @@ Stdio mode is the default and works for single-user local development. Consider 
 - **Always-on persistent process** — required for webhooks, scheduled inbox scans, or long-running agents
 
 ## Method 3: Docker HTTP (recommended)
+
+> **⚠️ Before adding the HTTP override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-email-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's stdio + your HTTP override) will load simultaneously since plugin matches by endpoint, not name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. For example, the `better-email-mcp:inbox-review` skill will no longer be available. Use Method 1 instead if you want full plugin features.
 
 > **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -20,6 +20,8 @@ This plugin supports 3 install methods. Pick the one that matches your use case:
 
 All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
 
+> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 2 (Docker stdio override) OR Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace. Both load simultaneously and create duplicate entries in `/mcp` dialog (plugin's stdio + your override). Plugin matching is by **endpoint** (URL or command string) per CC docs, not by name — and `npx`/`uvx` ≠ `docker` ≠ HTTP URL, so all three are distinct endpoints. Trade-off: choosing Method 2 or Method 3 means you lose this plugin's skills/agents/hooks/commands. For full plugin features, use Method 1 (default plugin install) with `userConfig` credentials prompted at install time.
+
 ## Option 1: Claude Code Plugin (Recommended -- stdio + userConfig prompt)
 
 ### Credential prompts at install
@@ -39,7 +41,13 @@ When you run `/plugin install`, Claude Code prompts you for the following creden
 
 Paste your `EMAIL_CREDENTIALS` value when prompted. This installs the server with skills: `/inbox-review`, `/follow-up`. Restart Claude Code -- the plugin auto-loads with your credentials.
 
+> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use Option 2 (Docker stdio) or Option 3 (HTTP) below, DO NOT `/plugin install` this plugin — pick Option 2 or Option 3 instead. All three methods are mutually exclusive (see Method overview).
+
 ## Option 2: Docker stdio (fallback)
+
+> **⚠️ Before adding the Docker stdio override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-email-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's `npx`/`uvx` stdio + your `docker run` stdio) will load simultaneously since plugin matches by endpoint (command string), not by name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. Use Option 1 instead if you want full plugin features.
 
 ```json
 {
@@ -72,6 +80,10 @@ Stdio mode is the default and works for single-user local development. Switch to
 - **Always-on persistent process** — required for webhooks, scheduled inbox scans, or long-running agents
 
 ## Option 3: Docker HTTP (recommended)
+
+> **⚠️ Before adding the HTTP override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-email-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's stdio + your HTTP override) will load simultaneously since plugin matches by endpoint, not name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. For example, the `better-email-mcp:inbox-review` skill will no longer be available. Use Option 1 instead if you want full plugin features.
 
 > **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 


### PR DESCRIPTION
## Summary

- Plugin matching is by **endpoint** (URL or command string) per CC docs, not name. `npx`/`uvx` (plugin install) vs `docker` (Method 2) vs HTTP URL (Method 3) are three distinct endpoints, so stacking any combination loads duplicate entries in `/mcp` dialog.
- Document mutual exclusivity in 4 places of `setup-manual.md` + `setup-with-agent.md`:
  - Method overview: warning callout under priority table
  - Method 1: trade-off note pointing to Method 2 + Method 3
  - Method 2: uninstall-first warning + skill loss trade-off
  - Method 3: uninstall-first warning + skill loss trade-off

## Test plan

- [x] Read both updated docs end-to-end for prose flow
- [x] Pre-commit hooks pass
- [ ] CI green before admin merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)