### PR TITLE
🎨 Palette: Add required field indicators to form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,9 @@
 **Learning:** During potentially long-running async operations (like network requests or OAuth polling), simply changing button text (e.g., to "Connecting...") or disabling the button isn't always enough visual feedback. Users may still wonder if the system is hung, especially if the text change is subtle.
 
 **Action:** Always include an animated visual indicator (like a CSS spinner with `aria-hidden="true"`) inside the submission button alongside the status text during asynchronous operations to clearly communicate that background processing is actively occurring.
+
+## 2025-02-15 - Required Field Indicators for Screen Readers
+
+**Learning:** When adding visual indicators (like `*`) for required form fields to assist sighted users, screen readers might redundantly announce "star" or "asterisk" alongside the native `required` attribute.
+
+**Action:** Always apply `aria-hidden="true"` to visual required indicators to keep the screen reader experience clean and native.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -141,6 +141,10 @@ export function renderEmailCredentialForm(
             border-radius: 4px;
             padding: 0.1rem 0.4rem;
         }
+        .required-indicator {
+            color: #f87171;
+            margin-left: 0.25rem;
+        }
         .field-input {
             width: 100%;
             background-color: #0d0d0d;
@@ -318,6 +322,12 @@ export function renderEmailCredentialForm(
                     badge.textContent = "Optional";
                     labelEl.appendChild(document.createTextNode(" "));
                     labelEl.appendChild(badge);
+                } else {
+                    var reqInd = document.createElement("span");
+                    reqInd.className = "required-indicator";
+                    reqInd.setAttribute("aria-hidden", "true");
+                    reqInd.textContent = "*";
+                    labelEl.appendChild(reqInd);
                 }
                 group.appendChild(labelEl);
 


### PR DESCRIPTION
💡 What:
Added a red asterisk `*` indicator next to form field labels that are marked as required.

🎯 Why:
To provide immediate visual feedback to sighted users about which fields must be filled out before submitting the form. Previously, users had to infer required fields or rely on HTML5 validation popups upon submission.

📸 Before/After:
Before: The "Email Address" label had no visual indicator that it was required.
After: The "Email Address" label now displays as `Email Address *` with the asterisk styled in red (`#f87171`) for high visibility.

♿ Accessibility:
The asterisk element has `aria-hidden="true"` applied to it. Since the native `<input>` elements already use the `required` HTML attribute, screen readers natively announce the field as required. The `aria-hidden` attribute ensures screen readers don't redundantly announce "star" or "asterisk" in addition to the native required state.

---
*PR created automatically by Jules for task [16149900416728076909](https://jules.google.com/task/16149900416728076909) started by @n24q02m*