### PR TITLE
🎨 Palette: Improve password manager support and semantics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,9 @@
 **Learning:** When adding visual indicators (like `*`) for required form fields to assist sighted users, screen readers might redundantly announce "star" or "asterisk" alongside the native `required` attribute.
 
 **Action:** Always apply `aria-hidden="true"` to visual required indicators to keep the screen reader experience clean and native.
+
+## 2025-02-16 - Password Manager Compatibility & Semantics
+
+**Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
+
+**Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -240,7 +240,7 @@ export function renderEmailCredentialForm(
     </style>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <div class="card">
             <div class="server-header">
                 <h1 class="server-name">${displayName}</h1>
@@ -260,7 +260,7 @@ export function renderEmailCredentialForm(
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
         </div>
-    </div>
+    </main>
 
     <script>
         (function () {
@@ -336,7 +336,7 @@ export function renderEmailCredentialForm(
                 input.className = "field-input";
                 input.setAttribute("type", type);
                 input.setAttribute("name", key + "_" + idx);
-                input.setAttribute("autocomplete", "off");
+                input.setAttribute("autocomplete", type === "email" ? "email" : (type === "password" ? "current-password" : "off"));
                 input.setAttribute("autocorrect", "off");
                 input.setAttribute("autocapitalize", "off");
                 input.setAttribute("spellcheck", "false");


### PR DESCRIPTION
💡 What: Replaced the generic `<div class="container">` with a semantic `<main class="container">` landmark, and dynamically assigned `autocomplete` attributes (`email` and `current-password`) to generated form inputs instead of unconditionally setting them to `off`.
🎯 Why: To provide a clear primary landmark for screen readers, and to allow password managers to correctly identify, fill, and save credentials in the form, thereby reducing user friction.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improves compliance with WCAG 1.3.5 (Identify Input Purpose) by using appropriate `autocomplete` tokens, and improves document structure with the `<main>` tag.

---
*PR created automatically by Jules for task [7730410304222661595](https://jules.google.com/task/7730410304222661595) started by @n24q02m*