### PR TITLE
[FIX] Deep Nesting in Credential Form

### DIFF
--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -651,34 +651,41 @@ export function renderEmailCredentialForm(
                 })
                     .then(function (resp) {
                         return resp.json().then(function (data) {
-                            if (data.ok) {
-                                // Stash the OAuth redirect target so follow-up async steps
-                                // (device code poll, future OTP) can navigate to it when
-                                // they complete instead of orphaning the client callback.
-                                if (typeof data.redirect_url === "string" && data.redirect_url.length > 0) {
-                                    pendingRedirectUrl = data.redirect_url;
-                                }
-                                if (data.next_step && data.next_step.type === "oauth_device_code") {
-                                    submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
-                                    submitBtn.removeAttribute("aria-busy");
-                                    renderOAuthDeviceCode(data.next_step);
-                                } else if (pendingRedirectUrl) {
-                                    // No interactive next step — follow the OAuth redirect now.
-                                    showStatus("success", "Credentials saved. Redirecting...");
-                                    submitBtn.textContent = "Connected";
-                                    submitBtn.removeAttribute("aria-busy");
-                                    window.location.replace(pendingRedirectUrl);
-                                } else {
-                                    showStatus("success", data.message || "Setup complete! You can close this tab.");
-                                    submitBtn.textContent = "Connected";
-                                    submitBtn.removeAttribute("aria-busy");
-                                }
-                            } else {
+                            if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
                                 submitBtn.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
+                                return;
                             }
+
+                            // Stash the OAuth redirect target so follow-up async steps
+                            // (device code poll, future OTP) can navigate to it when
+                            // they complete instead of orphaning the client callback.
+                            if (typeof data.redirect_url === "string" && data.redirect_url.length > 0) {
+                                pendingRedirectUrl = data.redirect_url;
+                            }
+
+                            if (data.next_step && data.next_step.type === "oauth_device_code") {
+                                submitBtn.innerHTML =
+                                    '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
+                                submitBtn.removeAttribute("aria-busy");
+                                renderOAuthDeviceCode(data.next_step);
+                                return;
+                            }
+
+                            if (pendingRedirectUrl) {
+                                // No interactive next step — follow the OAuth redirect now.
+                                showStatus("success", "Credentials saved. Redirecting...");
+                                submitBtn.textContent = "Connected";
+                                submitBtn.removeAttribute("aria-busy");
+                                window.location.replace(pendingRedirectUrl);
+                                return;
+                            }
+
+                            showStatus("success", data.message || "Setup complete! You can close this tab.");
+                            submitBtn.textContent = "Connected";
+                            submitBtn.removeAttribute("aria-busy");
                         });
                     })
                     .catch(function (err) {


### PR DESCRIPTION
Refactored the fetch response handler in the embedded JavaScript within src/credential-form.ts to use early returns, reducing nesting and improving readability. The previous implementation used a deeply nested if-else structure which was difficult to maintain within a template literal. Existing unit tests for the credential form were run and passed.

---
*PR created automatically by Jules for task [1028775167296044897](https://jules.google.com/task/1028775167296044897) started by @n24q02m*