### PR TITLE
[CLEANUP] Use of 'any' Type: enhanceError

### DIFF
--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -147,9 +147,10 @@ describe('enhanceError', () => {
   it('sanitizes error details (no password leakage)', () => {
     const result = enhanceError({ message: 'generic', password: 'secret123', status: 500 })
     // details should not contain password
-    if (result.details) {
-      expect(result.details.password).toBeUndefined()
-      expect(result.details.status).toBe(500)
+    const details = result.details as Record<string, unknown>
+    if (details) {
+      expect(details.password).toBeUndefined()
+      expect(details.status).toBe(500)
     }
   })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -3,12 +3,22 @@
  * AI-friendly error messages and suggestions for email operations
  */
 
+interface RawError {
+  message?: string
+  name?: string
+  code?: string | number
+  status?: number
+  responseCode?: number
+  authenticationFailed?: boolean
+  [key: string]: unknown
+}
+
 export class EmailMCPError extends Error {
   constructor(
     message: string,
     public code: string,
     public suggestion?: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message)
     this.name = 'EmailMCPError'
@@ -28,17 +38,18 @@ export class EmailMCPError extends Error {
 /**
  * Sanitize error object to remove sensitive information (passwords, tokens)
  */
-function sanitizeErrorDetails(error: any): any {
+function sanitizeErrorDetails(error: unknown): Record<string, unknown> | unknown {
   if (!error || typeof error !== 'object') return error
 
-  const safe: any = {
-    message: error.message,
-    name: error.name,
-    code: error.code
+  const raw = error as RawError
+  const safe: Record<string, unknown> = {
+    message: raw.message,
+    name: raw.name,
+    code: raw.code
   }
 
-  if (error.status) safe.status = error.status
-  if (error.responseCode) safe.responseCode = error.responseCode
+  if (raw.status) safe.status = raw.status
+  if (raw.responseCode) safe.responseCode = raw.responseCode
 
   return safe
 }
@@ -46,18 +57,19 @@ function sanitizeErrorDetails(error: any): any {
 /**
  * Enhance email-related errors with helpful context
  */
-export function enhanceError(error: any): EmailMCPError {
+export function enhanceError(error: unknown): EmailMCPError {
   if (error instanceof EmailMCPError) {
     return error
   }
 
-  const message = error.message || 'Unknown error occurred'
+  const raw = error as RawError
+  const message = raw.message || 'Unknown error occurred'
 
   // IMAP authentication errors
   if (
     message.includes('Invalid credentials') ||
     message.includes('AUTHENTICATIONFAILED') ||
-    error.authenticationFailed
+    raw.authenticationFailed
   ) {
     return new EmailMCPError(
       'Email authentication failed',
@@ -94,8 +106,8 @@ export function enhanceError(error: any): EmailMCPError {
   }
 
   // SMTP errors
-  if (error.responseCode) {
-    return handleSmtpError(error)
+  if (raw.responseCode) {
+    return handleSmtpError(raw)
   }
 
   // Configuration errors
@@ -119,7 +131,7 @@ export function enhanceError(error: any): EmailMCPError {
 /**
  * Handle SMTP-specific errors
  */
-function handleSmtpError(error: any): EmailMCPError {
+function handleSmtpError(error: RawError): EmailMCPError {
   const code = error.responseCode
 
   switch (code) {
@@ -257,10 +269,10 @@ export function suggestFixes(error: EmailMCPError): string[] {
 /**
  * Wrap async function with error handling
  */
-export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(
-  fn: T
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+export function withErrorHandling<Args extends unknown[], Return>(
+  fn: (...args: Args) => Promise<Return>
+): (...args: Args) => Promise<Return> {
+  return async (...args: Args): Promise<Return> => {
     try {
       return await fn(...args)
     } catch (error) {

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -66,11 +66,7 @@ export function enhanceError(error: unknown): EmailMCPError {
   const message = raw.message || 'Unknown error occurred'
 
   // IMAP authentication errors
-  if (
-    message.includes('Invalid credentials') ||
-    message.includes('AUTHENTICATIONFAILED') ||
-    raw.authenticationFailed
-  ) {
+  if (message.includes('Invalid credentials') || message.includes('AUTHENTICATIONFAILED') || raw.authenticationFailed) {
     return new EmailMCPError(
       'Email authentication failed',
       'AUTH_FAILED',


### PR DESCRIPTION
This PR refactors the error handling utilities in `src/tools/helpers/errors.ts` to improve type safety by replacing the `any` type with a dedicated `RawError` interface and the `unknown` type.

Key changes:
- Introduced `RawError` interface to describe common error properties.
- Updated `enhanceError`, `handleSmtpError`, and `sanitizeErrorDetails` to use `unknown` or `RawError` for input parameters.
- Improved `withErrorHandling` utility with proper generics (`Args extends unknown[]`, `Return`) instead of `any`.
- Verified changes with existing unit tests in `src/tools/helpers/errors.test.ts`.

These changes reduce the risk of runtime errors by enforcing better type checking during error processing.

---
*PR created automatically by Jules for task [682079259237523535](https://jules.google.com/task/682079259237523535) started by @n24q02m*