### PR TITLE
[TEST] Untested fallback error when reading tokens.json

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -165,6 +165,12 @@ describe('loadStoredTokens', () => {
 
     expect(await loadStoredTokens('user@outlook.com')).toBeNull()
   })
+
+  it('returns null on non-ENOENT read error', async () => {
+    mockReadFile.mockRejectedValue({ code: 'EACCES' })
+
+    expect(await loadStoredTokens('user@outlook.com')).toBeNull()
+  })
 })
 
 // ============================================================================


### PR DESCRIPTION
This PR adds a test case to src/tools/helpers/oauth2.test.ts to cover the fallback error handling when reading tokens.json. It mocks readFile to reject with a non-ENOENT error (e.g., EACCES) and verifies that loadStoredTokens returns null as expected. This addresses the untested catch block in loadStoredTokens.

---
*PR created automatically by Jules for task [2815190977033103569](https://jules.google.com/task/2815190977033103569) started by @n24q02m*