### PR TITLE
[FIX] Credentials Stored in Environment Variables

### DIFF
--- a/src/auth/subject-context.ts
+++ b/src/auth/subject-context.ts
@@ -9,7 +9,7 @@
  * store (``per-user-credential-store.ts``).
  *
  * Local-relay + stdio do NOT use this — they're explicitly single-user and
- * read from ``process.env.EMAIL_CREDENTIALS`` / the closure resolved at
+ * read from the credential state / the closure resolved at
  * server startup. The module still exports ``subjectContext`` unconditionally
  * so the serverFactory can safely call ``getStore()`` in any mode (returns
  * ``undefined`` outside an active scope ⇒ callers fall back to the closure).

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -102,7 +102,7 @@ describe('credential-state', () => {
       process.env.EMAIL_APP_PASSWORD = 'app-pass-123'
       const result = await mod.resolveCredentialState()
       expect(result).toBe('configured')
-      expect(process.env.EMAIL_CREDENTIALS).toBe('user@gmail.com:app-pass-123')
+      expect(mod.getCredentials()).toBe('user@gmail.com:app-pass-123')
     })
 
     it('returns configured when config file has credentials', async () => {
@@ -115,7 +115,7 @@ describe('credential-state', () => {
 
       const result = await mod.resolveCredentialState()
       expect(result).toBe('configured')
-      expect(process.env.EMAIL_CREDENTIALS).toBe('user@test.com:pass')
+      expect(mod.getCredentials()).toBe('user@test.com:pass')
     })
 
     it('returns configured when saved OAuth tokens exist', async () => {
@@ -124,7 +124,7 @@ describe('credential-state', () => {
 
       const result = await mod.resolveCredentialState()
       expect(result).toBe('configured')
-      expect(process.env.EMAIL_CREDENTIALS).toBe('user@outlook.com:oauth2')
+      expect(mod.getCredentials()).toBe('user@outlook.com:oauth2')
     })
 
     it('returns awaiting_setup when nothing found', async () => {

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -29,6 +29,16 @@ export type CredentialState = 'awaiting_setup' | 'setup_in_progress' | 'configur
 let state: CredentialState = 'awaiting_setup'
 let setupUrl: string | null = null
 
+let resolvedCredentials: string | null = null
+
+export function getCredentials(): string | null {
+  return resolvedCredentials ?? process.env.EMAIL_CREDENTIALS ?? null
+}
+
+export function setCredentials(creds: string | null): void {
+  resolvedCredentials = creds
+}
+
 // Hook supplied by the HTTP transport layer (mcp-core's local OAuth app)
 // that lets background Outlook OAuth polls flip ``GET /setup-status`` to
 // ``complete`` so the credential form stops spinning.
@@ -67,7 +77,7 @@ export function setSetupUrl(url: string | null): void {
  */
 export async function resolveCredentialState(): Promise<CredentialState> {
   // 1. Check env vars (legacy combined form OR stdio per-field form)
-  if (process.env.EMAIL_CREDENTIALS) {
+  if (getCredentials()) {
     state = 'configured'
     return state
   }
@@ -75,7 +85,7 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   // 1b. stdio per-field env vars (set by plugin config) — synthesize the
   // combined EMAIL_CREDENTIALS string the rest of the codebase expects.
   if (process.env.EMAIL_USER && process.env.EMAIL_APP_PASSWORD) {
-    process.env.EMAIL_CREDENTIALS = `${process.env.EMAIL_USER}:${process.env.EMAIL_APP_PASSWORD}`
+    setCredentials(`${process.env.EMAIL_USER}:${process.env.EMAIL_APP_PASSWORD}`)
     state = 'configured'
     return state
   }
@@ -86,7 +96,7 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     if (result.config !== null) {
       const { formatCredentials } = await import('./relay-setup.js')
       const credentials = formatCredentials(result.config)
-      process.env.EMAIL_CREDENTIALS = credentials
+      setCredentials(credentials)
       console.error(`Email config loaded from ${result.source}`)
       state = 'configured'
       return state
@@ -107,7 +117,7 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     const emails = Object.keys(store).filter((key) => key.includes('@'))
     if (emails.length > 0) {
       const credentials = emails.map((email) => `${email}:oauth2`).join(',')
-      process.env.EMAIL_CREDENTIALS = credentials
+      setCredentials(credentials)
       console.error(`Found saved OAuth2 tokens for: ${emails.join(', ')}`)
       state = 'configured'
       return state
@@ -134,6 +144,7 @@ export async function resetState(): Promise<void> {
   try {
     const { deleteConfig } = await import('@n24q02m/mcp-core')
     await deleteConfig(SERVER_NAME)
+    setCredentials(null)
   } catch {
     // Ignore
   }

--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -28,7 +28,9 @@ vi.mock('./tools/registry.js', () => ({
 }))
 
 vi.mock('./credential-state.js', () => ({
-  resolveCredentialState: resolveCredentialStateMock
+  resolveCredentialState: resolveCredentialStateMock,
+  getCredentials: vi.fn(),
+  setCredentials: vi.fn()
 }))
 
 vi.mock('./tools/helpers/config.js', () => ({

--- a/src/tools/composite/config.test.ts
+++ b/src/tools/composite/config.test.ts
@@ -6,6 +6,8 @@ vi.mock('../../credential-state.js', () => ({
   getState: vi.fn(),
   getSetupUrl: vi.fn(),
   resetState: vi.fn(),
+  getCredentials: vi.fn(),
+  setCredentials: vi.fn(),
   resolveCredentialState: vi.fn()
 }))
 

--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -3,6 +3,7 @@
  * Parses EMAIL_CREDENTIALS env var and auto-discovers IMAP/SMTP settings
  */
 
+import { getCredentials } from '../../credential-state.js'
 import { EmailMCPError } from './errors.js'
 import type { OAuth2Tokens } from './oauth2.js'
 import { isOutlookDomain, loadStoredTokens } from './oauth2.js'
@@ -228,7 +229,7 @@ export async function parseCredentials(envValue: string): Promise<AccountConfig[
  * Load and validate configuration from environment
  */
 export async function loadConfig(): Promise<AccountConfig[]> {
-  const credentials = process.env.EMAIL_CREDENTIALS
+  const credentials = getCredentials()
   if (!credentials) {
     return []
   }

--- a/src/tools/registry-call-tool.test.ts
+++ b/src/tools/registry-call-tool.test.ts
@@ -12,7 +12,9 @@ vi.mock('./composite/config.js', () => ({ handleConfig: vi.fn() }))
 // Mock credential state to return 'configured' so tools execute normally
 vi.mock('../credential-state.js', () => ({
   getState: vi.fn(() => 'configured'),
-  getSetupUrl: vi.fn(() => null)
+  getSetupUrl: vi.fn(() => null),
+  getCredentials: vi.fn(),
+  setCredentials: vi.fn()
 }))
 
 describe('CallToolRequestSchema handler coverage', () => {

--- a/src/tools/registry-error-handler.test.ts
+++ b/src/tools/registry-error-handler.test.ts
@@ -12,7 +12,9 @@ vi.mock('./composite/send.js', () => ({ send: vi.fn() }))
 // Mock credential state to return 'configured' so tools execute normally
 vi.mock('../credential-state.js', () => ({
   getState: vi.fn(() => 'configured'),
-  getSetupUrl: vi.fn(() => null)
+  getSetupUrl: vi.fn(() => null),
+  getCredentials: vi.fn(),
+  setCredentials: vi.fn()
 }))
 
 describe('CallToolRequestSchema handler - error handling', () => {

--- a/src/tools/registry-open-relay.test.ts
+++ b/src/tools/registry-open-relay.test.ts
@@ -25,7 +25,9 @@ vi.mock('./composite/config.js', () => ({ handleConfig: vi.fn() }))
 // can override via vi.mocked(...).mockReturnValue(...).
 vi.mock('../credential-state.js', () => ({
   getState: vi.fn(() => 'awaiting_setup'),
-  getSetupUrl: vi.fn(() => null)
+  getSetupUrl: vi.fn(() => null),
+  getCredentials: vi.fn(),
+  setCredentials: vi.fn()
 }))
 
 import { registerTools } from './registry.js'

--- a/src/tools/registry.logic.test.ts
+++ b/src/tools/registry.logic.test.ts
@@ -16,7 +16,9 @@ vi.mock('./composite/config.js', () => ({ handleConfig: vi.fn() }))
 // Mock credential state to return 'configured' so tools execute normally
 vi.mock('../credential-state.js', () => ({
   getState: vi.fn(() => 'configured'),
-  getSetupUrl: vi.fn(() => null)
+  getSetupUrl: vi.fn(() => null),
+  getCredentials: vi.fn(),
+  setCredentials: vi.fn()
 }))
 
 import { registerTools } from './registry.js'

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -25,6 +25,8 @@ vi.mock('../credential-state.js', () => ({
   resolveCredentialState: vi.fn(),
   setMarkSetupComplete: vi.fn(),
   setState: vi.fn(),
+  getCredentials: vi.fn(),
+  setCredentials: vi.fn(),
   getMarkSetupComplete: vi.fn(),
   setSetupUrl: vi.fn(),
   setCredentials: vi.fn()

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -26,7 +26,8 @@ vi.mock('../credential-state.js', () => ({
   setMarkSetupComplete: vi.fn(),
   setState: vi.fn(),
   getMarkSetupComplete: vi.fn(),
-  setSetupUrl: vi.fn()
+  setSetupUrl: vi.fn(),
+  setCredentials: vi.fn()
 }))
 
 vi.mock('../tools/helpers/config.js', () => ({

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -28,8 +28,7 @@ vi.mock('../credential-state.js', () => ({
   getCredentials: vi.fn(),
   setCredentials: vi.fn(),
   getMarkSetupComplete: vi.fn(),
-  setSetupUrl: vi.fn(),
-  setCredentials: vi.fn()
+  setSetupUrl: vi.fn()
 }))
 
 vi.mock('../tools/helpers/config.js', () => ({

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -28,6 +28,7 @@ import { renderEmailCredentialForm } from '../credential-form.js'
 import {
   getMarkSetupComplete,
   resolveCredentialState,
+  setCredentials,
   setMarkSetupComplete,
   setSetupUrl,
   setState
@@ -216,7 +217,7 @@ function buildOptions(args: {
     } catch (err) {
       console.error(`[${SERVER_NAME}] Failed to persist credentials: ${(err as Error).message}`)
     }
-    process.env.EMAIL_CREDENTIALS = raw
+    setCredentials(raw)
     onAccountsLoaded(accounts)
     console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
 


### PR DESCRIPTION
This PR refactors how email credentials are managed at runtime to improve security. Previously, credentials received via the HTTP /authorize form were written directly to `process.env.EMAIL_CREDENTIALS`, exposing them to the entire process environment.

Key changes:
- **Centralized Credential State**: Introduced `getCredentials()` and `setCredentials()` in `src/credential-state.ts` to store credentials in a module-level variable.
- **Backward Compatibility**: `getCredentials()` still falls back to `process.env.EMAIL_CREDENTIALS` if the internal state is null, ensuring that credentials provided via environment variables at startup still work.
- **Removed Environment Mutations**: Replaced all runtime assignments to `process.env.EMAIL_CREDENTIALS` with `setCredentials()`.
- **Updated Consumers**: Updated `loadConfig` and other modules to read from the credential state instead of directly from the environment.
- **Verified with Tests**: Updated the test suite to use the new accessors and confirmed that all tests pass.

---
*PR created automatically by Jules for task [2542881587374834580](https://jules.google.com/task/2542881587374834580) started by @n24q02m*