### PR TITLE
[CLEANUP] Use of 'any' Type: error handling in catch blocks

### DIFF
--- a/src/auth-cli.ts
+++ b/src/auth-cli.ts
@@ -26,7 +26,7 @@ export async function runAuth(): Promise<void> {
 
   try {
     await deviceCodeAuth(email)
-  } catch (error: any) {
+  } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
     console.error(`\nError: ${message}`)
     process.exit(1)

--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -80,8 +80,8 @@ async function getSecret(): Promise<string> {
 
     try {
       return (await _fs.readFile(_paths.SECRET_PATH, 'utf-8')).trim()
-    } catch (err: any) {
-      if (err.code !== 'ENOENT') throw err
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') throw err
     }
 
     const secret = randomBytes(32).toString('hex')
@@ -161,8 +161,8 @@ export async function loadUserCredentials(userId: string): Promise<AccountConfig
     )
     const parsed = JSON.parse(new TextDecoder().decode(decrypted))
     return parsed.accounts as AccountConfig[]
-  } catch (err: any) {
-    if (err.code === 'ENOENT') return null
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null
     throw err
   }
 }
@@ -178,8 +178,8 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
   let entries: any[]
   try {
     entries = (await _fs.readdir(_paths.DATA_DIR, { withFileTypes: true })) as any
-  } catch (err: any) {
-    if (err.code === 'ENOENT') return result
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return result
     throw err
   }
 
@@ -208,9 +208,9 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
       if (parsed.userId && Array.isArray(parsed.accounts)) {
         result.set(parsed.userId, parsed.accounts)
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       // Skip missing or corrupted entries
-      if (err.code !== 'ENOENT') {
+      if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
         console.error(`Failed to load credentials from ${entry.name}:`, err)
       }
     }

--- a/src/tools/composite/folders.ts
+++ b/src/tools/composite/folders.ts
@@ -44,11 +44,12 @@ async function handleList(accounts: AccountConfig[], input: FoldersInput): Promi
         account_email: account.email,
         folders: folderList
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
       return {
         account_id: account.id,
         account_email: account.email,
-        error: error.message,
+        error: errorMessage,
         folders: []
       }
     }

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -361,19 +361,20 @@ export async function searchEmails(
       }
 
       return summaries
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
       // Include error info but continue with other accounts
       return [
         {
           account_id: account.id,
           account_email: account.email,
           uid: 0,
-          subject: `[ERROR] ${error.message}`,
+          subject: `[ERROR] ${errorMessage}`,
           from: '',
           to: '',
           date: '',
           flags: [],
-          snippet: `Failed to search ${account.email}: ${error.message}`
+          snippet: `Failed to search ${account.email}: ${errorMessage}`
         }
       ]
     }

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -118,8 +118,8 @@ export async function loadStoredTokens(email: string): Promise<OAuth2Tokens | nu
     const store: TokenStore = JSON.parse(data)
     cachedTokenStore = store
     return store[email.toLowerCase()] || null
-  } catch (err: any) {
-    if (err.code !== 'ENOENT') {
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
       // Ignore parse errors or other issues, return null
     }
     return null

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -92,7 +92,7 @@ async function validateImapAccounts(imapAccounts: AccountConfig[]): Promise<Next
       })
     )
     return null
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (error && typeof error === 'object' && 'type' in error) {
       return error as NextStep
     }


### PR DESCRIPTION
This PR replaces the 'any' type in catch blocks across the codebase with 'unknown', following TypeScript best practices.

Key changes:
- Refactored catch blocks in `src/tools/helpers/imap-client.ts`, `src/auth-cli.ts`, `src/tools/composite/folders.ts`, `src/transports/http.ts`, `src/tools/helpers/oauth2.ts`, and `src/auth/per-user-credential-store.ts`.
- Implemented safe error message retrieval using `error instanceof Error ? error.message : String(error)`.
- Added property-existence checks for error objects (e.g., checking for `code` or `type` properties) before access.
- Verified changes with the full test suite and type checks.

---
*PR created automatically by Jules for task [9979550361840167753](https://jules.google.com/task/9979550361840167753) started by @n24q02m*