### PR TITLE
🎨 Palette: [UX improvement] Fix autocomplete accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,9 @@
 **Learning:** When adding visual indicators (like `*`) for required form fields to assist sighted users, screen readers might redundantly announce "star" or "asterisk" alongside the native `required` attribute.
 
 **Action:** Always apply `aria-hidden="true"` to visual required indicators to keep the screen reader experience clean and native.
+
+## 2025-02-16 - Password Manager Compatibility & WCAG 1.3.5
+
+**Learning:** Unconditionally setting `autocomplete="off"` on form inputs (especially for dynamic forms) prevents password managers from working and violates WCAG 1.3.5, which requires identifying the purpose of inputs that collect information about the user.
+
+**Action:** Conditionally apply the `autocomplete` attribute based on the input type. For instance, use `autocomplete="email"` for email fields and `autocomplete="current-password"` for password fields to support password managers and comply with accessibility standards.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -336,7 +336,15 @@ export function renderEmailCredentialForm(
                 input.className = "field-input";
                 input.setAttribute("type", type);
                 input.setAttribute("name", key + "_" + idx);
-                input.setAttribute("autocomplete", "off");
+
+                if (type === "email") {
+                    input.setAttribute("autocomplete", "email");
+                } else if (type === "password") {
+                    input.setAttribute("autocomplete", "current-password");
+                } else {
+                    input.setAttribute("autocomplete", "off");
+                }
+
                 input.setAttribute("autocorrect", "off");
                 input.setAttribute("autocapitalize", "off");
                 input.setAttribute("spellcheck", "false");


### PR DESCRIPTION
💡 What: Modified `src/credential-form.ts` to assign semantic `autocomplete` attributes (`email` for email inputs, `current-password` for password inputs) instead of unconditionally using `autocomplete="off"`. Added a learning to `.jules/palette.md`.
🎯 Why: Unconditionally setting `autocomplete="off"` prevents password managers from working and violates WCAG 1.3.5 (Identify Input Purpose). This fix enables better user experience and compliance.
📸 Before/After: Verified visually via Playwright script capturing the UI rendering properly without any visual breakages.
♿ Accessibility: Addresses WCAG 1.3.5 violation, ensuring the form behaves correctly with assistive technologies and password managers.

---
*PR created automatically by Jules for task [5994389531189278859](https://jules.google.com/task/5994389531189278859) started by @n24q02m*