### PR TITLE
🛡️ Sentinel: [security improvement] Add Content Security Policy to credential form

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** The `openBrowser` function in `src/tools/helpers/oauth2.ts` called `tryOpenBrowser` directly with unvalidated URLs, which could lead to shell injection or malicious browser behavior via crafted URIs (e.g. `javascript:alert(1)`).
 **Learning:** Even internal helper wrappers that call external tools should enforce validation boundaries for untrusted inputs to prevent exploit chains.
 **Prevention:** Always validate URLs using the `isSafeUrl` utility (which enforces protocol allowlists and rejects shell metacharacters) before passing them to OS-level or external browser utilities.
+
+## 2025-02-28 - Missing Content Security Policy
+**Vulnerability:** The HTML form rendered by `src/credential-form.ts` was missing a Content-Security-Policy (CSP) header. Without a CSP, the browser might be susceptible to loading unauthorized external resources or performing unauthorized network requests (like data exfiltration) if an XSS vulnerability were introduced.
+**Learning:** Even statically generated forms using `unsafe-inline` scripts should restrict other origins via CSP to minimize attack surface and prevent data exfiltration.
+**Prevention:** Always include a `Content-Security-Policy` meta tag or HTTP header (e.g. `default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'`) when serving HTML pages to strictly enforce origin boundaries.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -57,6 +57,7 @@ export function renderEmailCredentialForm(
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'" />
     <title>${displayName}</title>
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: The HTML form rendered by `src/credential-form.ts` was missing a Content-Security-Policy (CSP) header. Without a CSP, the browser might be susceptible to loading unauthorized external resources or performing unauthorized network requests (like data exfiltration) if an XSS vulnerability were introduced.
🎯 Impact: Minimizes attack surface and provides defense in depth by strictly enforcing origin boundaries.
🔧 Fix: Included a `<meta>` Content-Security-Policy tag in the HTML `<head>` inside `src/credential-form.ts`.
✅ Verification: Tested visual modification against expected CSP rules via `bun run check` and `bun run test`. Added specific journal entry on this mitigation technique.

---
*PR created automatically by Jules for task [18177690276723557305](https://jules.google.com/task/18177690276723557305) started by @n24q02m*