### PR TITLE
🎨 Palette: Wrap form inputs and buttons in a disabled fieldset during submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,9 @@
 **Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
 
 **Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.
+
+## 2025-02-23 - Form Disable State Experience
+
+**Learning:** Form Disable State Experience: Locking forms during submission processing via `fieldset.disabled` is cleaner and easier than manually toggling disabled states on each individual input/button, but it requires ensuring styling and DOM structure properly support the fieldset behavior. Wrapping elements within a `<fieldset>` and disabling it prevents unintended form actions simultaneously.
+
+**Action:** Use a fieldset wrapper to disable form inputs when you are running async operations.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -251,11 +251,13 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
-                <div id="accounts-container"></div>
+                <fieldset id="form-fieldset" style="border: none; padding: 0; margin: 0;">
+                    <div id="accounts-container"></div>
 
-                <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
+                    <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
 
-                <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                    <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                </fieldset>
 
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
@@ -295,6 +297,7 @@ export function renderEmailCredentialForm(
             var form = document.getElementById("credential-form");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
+            var formFieldset = document.getElementById("form-fieldset");
 
             var accountIndex = 0;
 
@@ -667,7 +670,7 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
-                submitBtn.disabled = true;
+                formFieldset.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
 
@@ -680,7 +683,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
-                                submitBtn.disabled = false;
+                                formFieldset.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                                 return;
@@ -717,7 +720,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
-                        submitBtn.disabled = false;
+                        formFieldset.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     });


### PR DESCRIPTION
💡 What: Wrapped the form's input elements and buttons inside a `<fieldset>` and disabled the fieldset (instead of just the submit button) when the form is submitted.

🎯 Why: During asynchronous operations (e.g., verifying credentials, requesting OAuth connections), locking the entire form prevents users from accidentally typing into fields, clicking "Add Another Account", or causing other unintended interactions that could lead to unexpected behavior or data loss. This provides a much more robust "loading" state.

📸 Before/After: Before, only the "Connect" button was disabled. Now, the entire fieldset (inputs, add button, connect button) is disabled, providing clearer visual and functional feedback. 

♿ Accessibility: Ensures that screen readers correctly interpret the form as inactive/disabled while submission is in-flight, preventing confusion from interactive elements that should temporarily not be used.

---
*PR created automatically by Jules for task [12838195515879832783](https://jules.google.com/task/12838195515879832783) started by @n24q02m*