### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@
 **Vulnerability:** The `openBrowser` function in `src/tools/helpers/oauth2.ts` called `tryOpenBrowser` directly with unvalidated URLs, which could lead to shell injection or malicious browser behavior via crafted URIs (e.g. `javascript:alert(1)`).
 **Learning:** Even internal helper wrappers that call external tools should enforce validation boundaries for untrusted inputs to prevent exploit chains.
 **Prevention:** Always validate URLs using the `isSafeUrl` utility (which enforces protocol allowlists and rejects shell metacharacters) before passing them to OS-level or external browser utilities.
+## 2025-05-02 - Add Content Security Policy to Statically Generated UI Form
+**Vulnerability:** Missing Content-Security-Policy header in dynamically constructed HTML forms (`src/credential-form.ts`).
+**Learning:** Even statically generated HTML (like `renderEmailCredentialForm`) intended for local network / user rendering needs a strict CSP to prevent XSS in case of unescaped content or compromised templates.
+**Prevention:** Statically generated HTML forms should include a strict Content-Security-Policy meta tag as a defense-in-depth measure against XSS and data exfiltration.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -57,6 +57,7 @@ export function renderEmailCredentialForm(
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'" />
     <title>${displayName}</title>
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing Content-Security-Policy header in dynamically constructed HTML forms (`src/credential-form.ts`).
🎯 Why: Prevents XSS in case of unescaped content or compromised templates by restricting script execution and connections.
🛠️ Fix: Added `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'" />` to the `<head>` of the rendered HTML form.
✅ Verification: Verified using `bun run check`, `bun run test`, and `bun run build`.

---
*PR created automatically by Jules for task [4046612480252808590](https://jules.google.com/task/4046612480252808590) started by @n24q02m*