### PR TITLE
🎨 Palette: [UX improvement] cleanly lock form inputs during submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 **Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
 
 **Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.
+
+## 2026-05-11 - [Cleanly lock form inputs during submission]
+**Learning:** Disabling just the submit button during a connection process can leave other form elements active (like Add/Remove buttons or inputs), potentially allowing users to change state mid-flight. Using a `<fieldset>` element to wrap the form and toggling its `disabled` state cleanly locks the entire form at once.
+**Action:** Use `<fieldset disabled>` to disable all form controls simultaneously during async form submissions to improve UI stability.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -251,6 +251,7 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
+                <fieldset id="form-fieldset" style="border: none; padding: 0; margin: 0;">
                 <div id="accounts-container"></div>
 
                 <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
@@ -258,6 +259,7 @@ export function renderEmailCredentialForm(
                 <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
 
                 <div class="status-box" id="status-box" role="alert"></div>
+                </fieldset>
             </form>
         </div>
     </main>
@@ -293,6 +295,7 @@ export function renderEmailCredentialForm(
             var container = document.getElementById("accounts-container");
             var addBtn = document.getElementById("add-account-btn");
             var form = document.getElementById("credential-form");
+            var fieldset = document.getElementById("form-fieldset");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
 
@@ -667,7 +670,7 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
-                submitBtn.disabled = true;
+                fieldset.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
 
@@ -680,7 +683,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
-                                submitBtn.disabled = false;
+                                fieldset.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                                 return;
@@ -717,7 +720,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
-                        submitBtn.disabled = false;
+                        fieldset.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     });


### PR DESCRIPTION
💡 What: Wrapped the form's contents in a `<fieldset>` and toggled `fieldset.disabled` instead of just the submit button's disabled state.
🎯 Why: Previously, during an async connection process, only the submit button was disabled. Users could still change input values, add accounts, or click remove buttons while the request was in flight, potentially leading to weird state mismatches or confusion.
📸 Before/After: Before, secondary buttons and inputs remained interactive. After, the entire form correctly grays out/becomes uninteractable until the request resolves.
♿ Accessibility: A natively disabled `<fieldset>` properly communicates the disabled state of all grouped controls to screen readers and prevents stray keyboard interactions (Tab navigation correctly skips the disabled block).

---
*PR created automatically by Jules for task [697738770809871204](https://jules.google.com/task/697738770809871204) started by @n24q02m*