### PR TITLE
🛡️ Sentinel: [security improvement] Add Content-Security-Policy to credential form

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@
 **Vulnerability:** The `openBrowser` function in `src/tools/helpers/oauth2.ts` called `tryOpenBrowser` directly with unvalidated URLs, which could lead to shell injection or malicious browser behavior via crafted URIs (e.g. `javascript:alert(1)`).
 **Learning:** Even internal helper wrappers that call external tools should enforce validation boundaries for untrusted inputs to prevent exploit chains.
 **Prevention:** Always validate URLs using the `isSafeUrl` utility (which enforces protocol allowlists and rejects shell metacharacters) before passing them to OS-level or external browser utilities.
+## 2024-05-13 - Add Content-Security-Policy to credential form
+**Vulnerability:** The statically generated credential form in `src/credential-form.ts` was missing a `Content-Security-Policy` header/meta tag. This could potentially allow Cross-Site Scripting (XSS) or data exfiltration if an attacker managed to inject malicious scripts into the page context.
+**Learning:** Statically generated HTML forms should include a strict `Content-Security-Policy` meta tag as a defense-in-depth measure against XSS and data exfiltration, even if input appears to be properly escaped.
+**Prevention:** Ensure that all dynamically generated or statically served HTML content includes a robust CSP meta tag defining strict rules for scripts, styles, and external connections (e.g., `default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'`).

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -57,6 +57,7 @@ export function renderEmailCredentialForm(
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'" />
     <title>${displayName}</title>
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The statically generated HTML form in `src/credential-form.ts` lacked a `Content-Security-Policy` header or meta tag. While inputs were properly escaped against XSS within HTML contexts, this omission represents a missed opportunity for defense-in-depth against malicious script execution or data exfiltration.
🎯 Impact: Without CSP, an attacker who successfully bypasses escaping to inject scripts could execute arbitrary JavaScript within the context of the page or exfiltrate sensitive credential data to external endpoints.
🔧 Fix: Added a strict `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'" />` tag to the document `<head>`. This actively prevents external script loading, unauthorized connections, and external framing, mitigating data exfiltration risks.
✅ Verification: Ensure the `Content-Security-Policy` tag is present in the rendered HTML output. Verify the form visually and functionally acts the same when loaded in the browser.

---
*PR created automatically by Jules for task [2198640993846705012](https://jules.google.com/task/2198640993846705012) started by @n24q02m*