### PR TITLE
🎨 Palette: [UX improvement] Lock entire form during submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 **Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
 
 **Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.
+
+## 2024-05-18 - Form Interaction Locking
+**Learning:** When dealing with multi-account forms or forms with complex inputs, disabling only the submit button leaves the form vulnerable to user interference (e.g., adding/removing fields or editing values while the API request processes).
+**Action:** Use a `<fieldset disabled>` to wrap the form contents (inputs, add/remove buttons, submit buttons) and toggle the fieldset's disabled state instead of individually targeting buttons. It's clean, natively prevents all user interactions across descendants, and inherits `:disabled` CSS states properly.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -251,12 +251,13 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
-                <div id="accounts-container"></div>
+                <fieldset id="form-fieldset" style="border: none; padding: 0; margin: 0; min-width: 0;">
+                    <div id="accounts-container"></div>
 
-                <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
+                    <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
 
-                <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
-
+                    <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                </fieldset>
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
         </div>
@@ -293,6 +294,7 @@ export function renderEmailCredentialForm(
             var container = document.getElementById("accounts-container");
             var addBtn = document.getElementById("add-account-btn");
             var form = document.getElementById("credential-form");
+            var formFieldset = document.getElementById("form-fieldset");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
 
@@ -667,7 +669,7 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
-                submitBtn.disabled = true;
+                formFieldset.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
 
@@ -680,7 +682,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
-                                submitBtn.disabled = false;
+                                formFieldset.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                                 return;
@@ -717,7 +719,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
-                        submitBtn.disabled = false;
+                        formFieldset.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     });


### PR DESCRIPTION
💡 What: Wrapped the form's inner components in a `<fieldset>` element and updated the submission logic to toggle `formFieldset.disabled = true/false` instead of just the submit button.

🎯 Why: Disabling only the submit button during an API request left the rest of the form completely interactive. Users could inadvertently add, remove, or modify account fields while a submission was processing, potentially causing race conditions or invalid data states. Using a fieldset elegantly disables all descendant inputs and buttons simultaneously.

📸 Before/After: Visuals remain identical (as the fieldset is unstyled with inline CSS resetting borders/padding). Behaviorally, clicking "Connect" now grays out and locks the text inputs and the "+ Add Another Account" button as well.

♿ Accessibility: Ensures users navigating via keyboard/screen reader aren't permitted to interact with inputs that have temporarily suspended logical validity during submission. Native fieldset disabling inherits all standard browser a11y traits.

---
*PR created automatically by Jules for task [3079668988767465572](https://jules.google.com/task/3079668988767465572) started by @n24q02m*