### PR TITLE
🛡️ Sentinel: Fix XSS in credential form and add CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@
 **Vulnerability:** The `openBrowser` function in `src/tools/helpers/oauth2.ts` called `tryOpenBrowser` directly with unvalidated URLs, which could lead to shell injection or malicious browser behavior via crafted URIs (e.g. `javascript:alert(1)`).
 **Learning:** Even internal helper wrappers that call external tools should enforce validation boundaries for untrusted inputs to prevent exploit chains.
 **Prevention:** Always validate URLs using the `isSafeUrl` utility (which enforces protocol allowlists and rejects shell metacharacters) before passing them to OS-level or external browser utilities.
+## 2025-02-20 - Add CSP and secure submitUrl injection to HTTP credential form
+**Vulnerability:** The `src/credential-form.ts` rendered an inline script tag passing the `submitUrl` configuration without proper encoding (relying on `escapeHtml` which does not escape for JSON/JS context and causes double encoding or XSS). Additionally, the HTML form did not have a Content Security Policy (CSP).
+**Learning:** For server-side rendering of inline script parameters, `JSON.stringify` should be used alongside string replacement for `<` (`.replace(/</g, '\\u003c')`) to prevent XSS string breakout. Statically rendered pages should also assert defense-in-depth with CSP meta tags to restrict execution sources.
+**Prevention:** Always use `JSON.stringify` and `</script>` breakout mitigations for JS interpolation, and inject strong `default-src 'none'` CSP tags for static template outputs.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -50,13 +50,13 @@ export function renderEmailCredentialForm(
     _schema.description ??
       'Configure one or more email accounts (Gmail, Yahoo, iCloud, Outlook/Hotmail/Live, or custom IMAP). Outlook accounts use OAuth2 and are handled automatically by the server.'
   )
-  const submitUrl = escapeHtml(options.submitUrl)
 
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'" />
     <title>${displayName}</title>
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -264,7 +264,7 @@ export function renderEmailCredentialForm(
 
     <script>
         (function () {
-            var submitUrl = "${submitUrl}";
+            var submitUrl = ${JSON.stringify(options.submitUrl).replace(/</g, '\\u003c')};
 
             var OAUTH_DOMAINS = ["outlook.com", "hotmail.com", "live.com"];
             var APP_PASSWORD_DOMAINS = {


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The credential form rendered an inline `<script>` tag by dynamically interpolating the `submitUrl` variable using HTML escaping (`escapeHtml`). This technique was flawed for JavaScript contexts, as it could allow context breakout (e.g., closing the script block) or introduce query parameter corruption (by transforming `&` to `&amp;`). Additionally, the credential form lacked a Content Security Policy (CSP), omitting a critical defense layer against potential XSS and data exfiltration.

🎯 Why: To ensure that injected dynamic values cannot break out of inline scripts or execute unauthorized commands. Implementing a strict CSP mitigates the impact of potential vulnerabilities by restricting script execution and connections.

🛠️ Fix: 
- Replaced the `escapeHtml` interpolation of `submitUrl` with robust `JSON.stringify` logic, adding `.replace(/</g, '\\u003c')` to prevent script breakout attacks.
- Added a strict CSP `<meta>` tag (`default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'`) to the `<head>` of the HTML form.

✅ Verification: 
- Ran `bun run check` and `bun run test` (all passed).
- Verified the frontend visually using a Playwright script mapping `http://localhost:8080/` to test form rendering under the new CSP rules.

---
*PR created automatically by Jules for task [7311201401739029961](https://jules.google.com/task/7311201401739029961) started by @n24q02m*