### PR TITLE
⚡ Bolt: [performance improvement] Cache bigrams for static options in findClosestMatch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2024-05-07 - Avoid Unbounded Promise.all() on CPU-Heavy Operations
 **Learning:** Using `Promise.all(items.map(...))` to execute CPU-intensive tasks (like `mailparser.simpleParser` for parsing emails) blocks the event loop and can cause memory spikes in high-concurrency situations, despite JavaScript's asynchronous nature.
 **Action:** Use a concurrency-limited mapper like `mapLimit` to balance throughput and event loop responsiveness for intensive parallel workloads.
+
+## 2024-10-31 - Cache Option Bigrams in Fuzzy Matching
+**Learning:** In utility functions performing string distance calculations (like bigram overlapping) against static/semi-static lists, repeatedly generating sets from the same target strings on every invocation causes unnecessary allocation overhead.
+**Action:** Implemented a module-level `Map` to cache the bigram `Set`s generated for `validOptions` in `findClosestMatch`. This prevents recreating Sets and slicing strings for constant known options (like tool names) across successive function calls.

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -159,6 +159,8 @@ function handleSmtpError(error: unknown): EmailMCPError {
   }
 }
 
+const validOptionBigramCache = new Map<string, Set<string>>()
+
 /**
  * Find the closest matching string from a list of valid options.
  * Uses bigram similarity for fuzzy matching.
@@ -182,8 +184,12 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
       return option
     }
 
-    const optionBigrams = new Set<string>()
-    for (let i = 0; i < optionLower.length - 1; i++) optionBigrams.add(optionLower.slice(i, i + 2))
+    let optionBigrams = validOptionBigramCache.get(optionLower)
+    if (!optionBigrams) {
+      optionBigrams = new Set<string>()
+      for (let i = 0; i < optionLower.length - 1; i++) optionBigrams.add(optionLower.slice(i, i + 2))
+      validOptionBigramCache.set(optionLower, optionBigrams)
+    }
 
     let overlap = 0
     for (const b of inputBigrams) {


### PR DESCRIPTION
💡 What: Implement a module-level cache (`validOptionBigramCache`) for string bigram sets in the `findClosestMatch` utility function.
🎯 Why: When calculating string distance (e.g., matching a typo against valid tool names), the function previously re-sliced and re-allocated `Set`s of bigrams for the same static valid options on every call. This optimization reuses the `Set`s, preventing redundant allocations and CPU cycles.
📊 Impact: Reduces O(N*M) string slicing operations to O(N+M) when comparing against the same valid options, significantly lowering allocation overhead and execution time in high-frequency validation checks.
🔬 Measurement: Verified functionality by passing all unit tests (`bun run test src/tools/helpers/errors.test.ts`), ensuring fuzzy matching returns the correct closest matches. Performance is implicitly validated by avoiding redundant memory allocations.

---
*PR created automatically by Jules for task [7041673782369134091](https://jules.google.com/task/7041673782369134091) started by @n24q02m*