### PR TITLE
🎨 Palette: [UX improvement] cleanly lock form inputs during connection

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,8 @@
 **Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
 
 **Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.
+
+## 2025-02-17 - Cleanly locking forms during async operations
+
+**Learning:** When submitting a form with multiple dynamic inputs, disabling only the submit button leaves the form inputs editable during the async operation. This allows users to change data while a connection or submission is in progress, which can lead to confusing states or multiple submissions.
+**Action:** Wrap form inputs and related buttons in a `<fieldset>` and toggle `fieldset.disabled` to cleanly lock the entire form during submission processing, rather than individually targeting buttons.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -251,11 +251,13 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
-                <div id="accounts-container"></div>
+                <fieldset id="form-fieldset" style="border: none; padding: 0; margin: 0; min-width: 0;">
+                    <div id="accounts-container"></div>
 
-                <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
+                    <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
 
-                <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                    <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                </fieldset>
 
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
@@ -293,6 +295,7 @@ export function renderEmailCredentialForm(
             var container = document.getElementById("accounts-container");
             var addBtn = document.getElementById("add-account-btn");
             var form = document.getElementById("credential-form");
+            var formFieldset = document.getElementById("form-fieldset");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
 
@@ -667,6 +670,7 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
+                formFieldset.disabled = true;
                 submitBtn.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
@@ -680,6 +684,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
+                                formFieldset.disabled = false;
                                 submitBtn.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
@@ -717,6 +722,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
+                        formFieldset.disabled = false;
                         submitBtn.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";


### PR DESCRIPTION
💡 What: Wrapped the interactive elements of the email credentials form inside a `<fieldset>` and disabled the fieldset (along with the submit button) when the user submits the form.
🎯 Why: Prevents users from modifying form inputs or triggering additional actions while the server handles the asynchronous credential validation and connection process. This avoids confusing intermediate states and data loss.
📸 Before/After: Verified via Playwright screenshot; visually the "Connecting..." state looks the same but inputs and buttons are greyed out and unclickable.
♿ Accessibility: Fieldset locking uses native HTML constraints, fully supported by screen readers which correctly announce the group of fields as disabled.

---
*PR created automatically by Jules for task [15405766209927736319](https://jules.google.com/task/15405766209927736319) started by @n24q02m*