### PR TITLE
🎨 Palette: Disable entire form during submit

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 **Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
 
 **Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.
+## 2024-05-17 - [UX] Disable entire form on submit via Fieldset
+**Learning:** For dynamic HTML forms where modifying individual input states via JS is cumbersome, wrapping all inputs and buttons in a `<fieldset>` allows globally locking the form (`fieldset.disabled = true`). This prevents any user edits during asynchronous submissions and inherently updates the visual `disabled` states across all child elements gracefully. Playwright verification can assert this by checking `expect(fieldset).to_be_disabled()`.
+**Action:** Use `<fieldset>` wrapping as a standardized pattern to handle form locking states across the project to reduce manual DOM traversal and ensure robust user experience.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -251,13 +251,15 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
-                <div id="accounts-container"></div>
+                <fieldset id="form-fieldset" style="border: none; padding: 0; margin: 0;">
+                    <div id="accounts-container"></div>
 
-                <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
+                    <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
 
-                <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                    <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
 
-                <div class="status-box" id="status-box" role="alert"></div>
+                    <div class="status-box" id="status-box" role="alert"></div>
+                </fieldset>
             </form>
         </div>
     </main>
@@ -293,6 +295,7 @@ export function renderEmailCredentialForm(
             var container = document.getElementById("accounts-container");
             var addBtn = document.getElementById("add-account-btn");
             var form = document.getElementById("credential-form");
+            var formFieldset = document.getElementById("form-fieldset");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
 
@@ -667,7 +670,7 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
-                submitBtn.disabled = true;
+                if (formFieldset) formFieldset.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
 
@@ -680,7 +683,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
-                                submitBtn.disabled = false;
+                                if (formFieldset) formFieldset.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                                 return;
@@ -717,7 +720,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
-                        submitBtn.disabled = false;
+                        if (formFieldset) formFieldset.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     });


### PR DESCRIPTION
💡 What: Wraps the dynamic credential form inputs and buttons inside a `<fieldset>` and toggles its `disabled` state during connection submission, instead of just disabling the submit button.

🎯 Why: During asynchronous form submission, users were previously able to edit their credentials or click "Add Another Account", which could lead to confusion or inconsistent states. Disabling the entire fieldset provides clear feedback and prevents any modifications while the connection request is in flight.

📸 Before/After: Visual verification was performed with Playwright. The entire form visually updates to a grayed-out disabled state while the submit button shows the "Connecting..." spinner.

♿ Accessibility: The disabled attribute on a `<fieldset>` inherently propagates to all interactive child elements (inputs, buttons), ensuring screen readers correctly announce that the entire group of controls is currently unavailable, thus improving overall accessibility.

---
*PR created automatically by Jules for task [16760830555438763737](https://jules.google.com/task/16760830555438763737) started by @n24q02m*