### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in submitUrl and add CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Vulnerability:** The `openBrowser` function in `src/tools/helpers/oauth2.ts` called `tryOpenBrowser` directly with unvalidated URLs, which could lead to shell injection or malicious browser behavior via crafted URIs (e.g. `javascript:alert(1)`).
 **Learning:** Even internal helper wrappers that call external tools should enforce validation boundaries for untrusted inputs to prevent exploit chains.
 **Prevention:** Always validate URLs using the `isSafeUrl` utility (which enforces protocol allowlists and rejects shell metacharacters) before passing them to OS-level or external browser utilities.
+
+## 2026-05-17 - XSS via Inline Script Injection
+
+**Vulnerability:** The `submitUrl` string was injected into an inline `<script>` tag using `escapeHtml()`. This allowed for script breakout attacks because HTML entities are not unescaped inside script contexts.
+**Learning:** Using `escapeHtml()` inside a JS block is insufficient for preventing XSS. Safe serialization requires `JSON.stringify()` combined with replacing `<` with `<`.
+**Prevention:** Use `JSON.stringify()` for data injected into scripts and apply a strict `Content-Security-Policy` to disable inline scripts where possible or limit them strictly.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -50,13 +50,14 @@ export function renderEmailCredentialForm(
     _schema.description ??
       'Configure one or more email accounts (Gmail, Yahoo, iCloud, Outlook/Hotmail/Live, or custom IMAP). Outlook accounts use OAuth2 and are handled automatically by the server.'
   )
-  const submitUrl = escapeHtml(options.submitUrl)
+  const safeSubmitUrlJson = JSON.stringify(options.submitUrl).replace(/</g, '\\u003c')
 
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'" />
     <title>${displayName}</title>
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -264,7 +265,7 @@ export function renderEmailCredentialForm(
 
     <script>
         (function () {
-            var submitUrl = "${submitUrl}";
+            var submitUrl = ${safeSubmitUrlJson};
 
             var OAUTH_DOMAINS = ["outlook.com", "hotmail.com", "live.com"];
             var APP_PASSWORD_DOMAINS = {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `submitUrl` variable in `renderEmailCredentialForm` was unsafely injected into an inline `<script>` using `escapeHtml()`, allowing script breakout XSS attacks because HTML entities aren't unescaped in JS. Furthermore, no CSP was present on the statically generated page.
🎯 Impact: Attackers could inject arbitrary JavaScript if they controlled `submitUrl`, leading to cross-site scripting (XSS) and potential credential theft or data exfiltration.
🔧 Fix: Used `JSON.stringify(options.submitUrl).replace(/</g, '\\u003c')` to securely serialize the URL for injection into the `<script>` tag. Also added a strict `Content-Security-Policy` meta tag (`default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'`) as defense in depth against XSS attacks.
✅ Verification: Ran `bun run check` and `pnpm test` successfully. Verified the form visually with Playwright. Recorded learnings in the Sentinel journal.

---
*PR created automatically by Jules for task [8511436276377604](https://jules.google.com/task/8511436276377604) started by @n24q02m*