### PR TITLE
🎨 Palette: [UX improvement] Lock form during submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 **Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
 
 **Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.
+## 2025-05-20 - [Lock form during submission]
+**Learning:** Using a `<fieldset>` with the `disabled` attribute is an elegant and accessible way to holistically disable complex dynamic forms (including inputs, add/remove buttons, and submit buttons) during submission, rather than manually toggling individual elements. This prevents user interference while async actions resolve.
+**Action:** Always wrap form contents in a `<fieldset>` and disable the fieldset during background requests to ensure form integrity.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -251,11 +251,13 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
-                <div id="accounts-container"></div>
+                <fieldset id="form-fieldset" style="border: none; padding: 0; margin: 0; min-width: 0;">
+                    <div id="accounts-container"></div>
 
-                <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
+                    <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
 
-                <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                    <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                </fieldset>
 
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
@@ -293,6 +295,7 @@ export function renderEmailCredentialForm(
             var container = document.getElementById("accounts-container");
             var addBtn = document.getElementById("add-account-btn");
             var form = document.getElementById("credential-form");
+            var formFieldset = document.getElementById("form-fieldset");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
 
@@ -667,7 +670,7 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
-                submitBtn.disabled = true;
+                if (formFieldset) formFieldset.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
 
@@ -680,7 +683,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
-                                submitBtn.disabled = false;
+                                if (formFieldset) formFieldset.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                                 return;
@@ -717,7 +720,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
-                        submitBtn.disabled = false;
+                        if (formFieldset) formFieldset.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     });


### PR DESCRIPTION
💡 **What:** 
Replaced individually disabling the "Connect" button with wrapping the entire dynamic form structure inside a `<fieldset>` and disabling the fieldset during the network submission.

🎯 **Why:** 
Previously, only the submit button was disabled during the connection process. In a dynamic form with multiple inputs and add/remove buttons, this left users able to mutate form data, add new account rows, or attempt to remove accounts while the asynchronous action was still in-flight, potentially leading to race conditions or unexpected state.

📸 **Before/After:** 
Before: Only the "Connect" button went into a disabled/loading state. Inputs remained active.
After: The entire `fieldset` becomes disabled, semantically turning off all descendant inputs, the "Add Another Account" button, and the submit button without needing complicated JavaScript state tracking. Visual indicators apply to the disabled inputs.

♿ **Accessibility:**
The `<fieldset>` element inherently understands `disabled`. Screen readers will now announce the entire block of controls as unavailable while the form is submitting, providing better context than just a single disabled button.

---
*PR created automatically by Jules for task [6285304875818765437](https://jules.google.com/task/6285304875818765437) started by @n24q02m*