### PR TITLE
🎨 Palette: Disable entire form during submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,9 @@
 **Learning:** Unconditionally setting `autocomplete="off"` on dynamic form elements severely degrades user experience by preventing password managers from working and violates accessibility guidelines (WCAG 1.3.5 Identify Input Purpose).
 
 **Action:** Always dynamically assign semantic `autocomplete` attributes (like `email` or `current-password`) based on the input type to ensure password managers function correctly and assistive technologies understand the input's purpose.
+
+## 2024-05-21 - Form Lock down via Fieldset
+
+**Learning:** When submitting a dynamic form containing multiple sub-components (like "Add Account" buttons and numerous inputs), simply disabling the submit button (`<button type="submit" disabled>`) is insufficient to prevent user interaction during async loading states. Users can still modify inputs or click secondary action buttons, potentially causing corrupted state or accidental concurrent operations.
+
+**Action:** Wrap the entire interactive section of the form (inputs, secondary buttons, submit button) in a semantic `<fieldset>` element. During async operations (like API submission), set `fieldset.disabled = true` to instantly and cleanly lock down all child form controls simultaneously, ensuring a robust and predictable loading state.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -251,11 +251,13 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
-                <div id="accounts-container"></div>
+                <fieldset id="form-fieldset" style="border: none; padding: 0; margin: 0;">
+                    <div id="accounts-container"></div>
 
-                <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
+                    <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
 
-                <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                    <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                </fieldset>
 
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
@@ -295,6 +297,7 @@ export function renderEmailCredentialForm(
             var form = document.getElementById("credential-form");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
+            var formFieldset = document.getElementById("form-fieldset");
 
             var accountIndex = 0;
 
@@ -667,7 +670,7 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
-                submitBtn.disabled = true;
+                formFieldset.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
 
@@ -680,7 +683,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
-                                submitBtn.disabled = false;
+                                formFieldset.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                                 return;
@@ -717,7 +720,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
-                        submitBtn.disabled = false;
+                        formFieldset.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     });


### PR DESCRIPTION
💡 What: Wrapped the interactive elements of the credential form inside a `<fieldset>` and updated the submission logic to disable the entire fieldset during the async connection request, rather than just disabling the submit button.

🎯 Why: During the connection process (which can take several seconds, especially if polling for OAuth), users could previously still interact with text fields, click "Remove", or click "+ Add Another Account". This could lead to a confusing state or accidental concurrent modifications. Disabling the entire fieldset instantly locks down all child form controls safely and consistently.

📸 Before/After: 
*Before:* Only the "Connect" button was disabled and showed a spinner.
*After:* The entire form (inputs, remove buttons, add buttons, and submit button) is visually and functionally disabled during submission.

♿ Accessibility: Ensures that screen reader users and keyboard navigators cannot accidentally tab into or interact with form elements that are in an invalid intermediate state during an async submission.

---
*PR created automatically by Jules for task [4159544787716879413](https://jules.google.com/task/4159544787716879413) started by @n24q02m*