### PR TITLE
⚡ Bolt: Skip expensive mailparser HTML to text conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,6 @@
 ## 2024-05-07 - Avoid Unbounded Promise.all() on CPU-Heavy Operations
 **Learning:** Using `Promise.all(items.map(...))` to execute CPU-intensive tasks (like `mailparser.simpleParser` for parsing emails) blocks the event loop and can cause memory spikes in high-concurrency situations, despite JavaScript's asynchronous nature.
 **Action:** Use a concurrency-limited mapper like `mapLimit` to balance throughput and event loop responsiveness for intensive parallel workloads.
+## 2025-05-21 - [Skip Expensive mailparser HTML Conversions]
+**Learning:** `simpleParser` from `mailparser` performs slow HTML-to-text conversion by default, which can be bypassed if the parsed text is not needed (e.g. for downloading attachments, or if we use our own snippet extraction logic) by passing `{ skipHtmlToText: true, skipTextToHtml: true, skipTextLinks: true }` as `SimpleParserOptions`.
+**Action:** When using `simpleParser` for extracting short snippets or fetching attachments, specify options to skip text/HTML conversion to save CPU cycles and reduce blocking time on the main thread, releasing IMAP locks sooner.

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -4,7 +4,7 @@
  */
 
 import { ImapFlow, type SearchObject } from 'imapflow'
-import { simpleParser } from 'mailparser'
+import { type SimpleParserOptions, simpleParser } from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -217,7 +217,11 @@ async function mapLimit<T, R>(items: T[], limit: number, mapper: (item: T) => Pr
  */
 async function extractSnippet(source: string | Buffer, maxLength = 200): Promise<string> {
   try {
-    const parsed = await simpleParser(source)
+    const parsed = await simpleParser(source, {
+      skipHtmlToText: true,
+      skipTextToHtml: true,
+      skipTextLinks: true
+    } as SimpleParserOptions)
     const text = parsed.text || (parsed.html ? fastExtractSnippet(parsed.html as string, maxLength) : '')
     if (!text) return ''
     // If we used fastExtractSnippet, it's already cleaned and truncated
@@ -556,7 +560,11 @@ export async function getAttachment(
   // ⚡ Bolt: Execute CPU-intensive MIME parsing outside of the `withConnection` block.
   // This ensures the IMAP connection and mailbox lock are released as quickly as possible,
   // preventing other concurrent operations from being blocked while we parse attachments.
-  const parsed = await simpleParser(fetchResult.source)
+  const parsed = await simpleParser(fetchResult.source, {
+    skipHtmlToText: true,
+    skipTextToHtml: true,
+    skipTextLinks: true
+  } as SimpleParserOptions)
   const lowerFilename = filename.toLowerCase()
   const attachment = parsed.attachments?.find((att) => att.filename?.toLowerCase() === lowerFilename)
 


### PR DESCRIPTION
💡 What: Update `simpleParser` calls in `src/tools/helpers/imap-client.ts` (`extractSnippet` and `getAttachment`) to pass `{ skipHtmlToText: true, skipTextToHtml: true, skipTextLinks: true }` as `SimpleParserOptions`.

🎯 Why: The `mailparser` library performs CPU-intensive conversion from HTML to text by default. In `extractSnippet`, if text is not available we already fallback to `fastExtractSnippet` on the HTML string which is much faster. In `getAttachment`, we only need to parse the attachments and have no use for the text body. By skipping these conversions, we save CPU cycles and release IMAP locks sooner.

📊 Impact: Significantly faster execution times for `extractSnippet` and `getAttachment` when processing emails with large HTML bodies, reducing main-thread blocking.

🔬 Measurement: Verify by running `bun run test src/tools/helpers/imap-client.test.ts` and monitoring CPU usage/execution time for emails with heavy HTML content when downloading attachments or fetching snippets.

---
*PR created automatically by Jules for task [11071166146361709072](https://jules.google.com/task/11071166146361709072) started by @n24q02m*