### PR TITLE
Support custom IMAP host with port + security hardening

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-email-mcp",
-  "description": "Email management via IMAP/SMTP — multi-account",
-  "version": "1.29.0",
+  "description": "Email management via IMAP/SMTP \u2014 multi-account",
+  "version": "1.30.0-beta.1",
   "userConfig": {
     "EMAIL_CREDENTIALS": {
       "type": "string",
@@ -19,7 +19,10 @@
   "mcpServers": {
     "better-email-mcp": {
       "command": "npx",
-      "args": ["--yes", "@n24q02m/better-email-mcp@latest"],
+      "args": [
+        "--yes",
+        "@n24q02m/better-email-mcp@latest"
+      ],
       "env": {
         "MCP_TRANSPORT": "stdio",
         "EMAIL_CREDENTIALS": "${user_config.EMAIL_CREDENTIALS}"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-email-mcp",
-  "description": "Email management via IMAP/SMTP \u2014 multi-account",
+  "description": "Email management via IMAP/SMTP — multi-account",
   "version": "1.30.0-beta.1",
   "userConfig": {
     "EMAIL_CREDENTIALS": {
@@ -19,10 +19,7 @@
   "mcpServers": {
     "better-email-mcp": {
       "command": "npx",
-      "args": [
-        "--yes",
-        "@n24q02m/better-email-mcp@latest"
-      ],
+      "args": ["--yes", "@n24q02m/better-email-mcp@latest"],
       "env": {
         "MCP_TRANSPORT": "stdio",
         "EMAIL_CREDENTIALS": "${user_config.EMAIL_CREDENTIALS}"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "codex",
     "opencode"
   ],
-  "version": "1.29.0",
+  "version": "1.30.0-beta.1",
   "license": "MIT",
   "type": "module",
   "publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-email-mcp.git",
     "source": "github"
   },
-  "version": "1.29.0",
+  "version": "1.30.0-beta.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-email-mcp",
-      "version": "1.29.0",
+      "version": "1.30.0-beta.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/credential-form.test.ts
+++ b/src/credential-form.test.ts
@@ -80,4 +80,78 @@ describe('renderEmailCredentialForm', () => {
     expect(html).not.toMatch(/Outlook[^"]*not supported yet/i)
     expect(html).not.toMatch(/Remove any Outlook accounts/i)
   })
+
+  describe('security hardening', () => {
+    it('includes a Content-Security-Policy meta tag', () => {
+      const html = renderEmailCredentialForm(schema, { submitUrl: '/auth' })
+      expect(html).toMatch(/<meta\s+http-equiv="Content-Security-Policy"/i)
+      expect(html).toContain("default-src 'none'")
+      expect(html).toContain("frame-ancestors 'none'")
+      expect(html).toContain("base-uri 'none'")
+    })
+
+    it('serializes submitUrl as a JS literal (not HTML-escaped string)', () => {
+      const html = renderEmailCredentialForm(schema, { submitUrl: '/authorize?nonce=abc' })
+      // After the fix, submitUrl is interpolated via JSON.stringify, yielding
+      // `var submitUrl = "/authorize?nonce=abc";` -- never `var submitUrl = "${...}"`.
+      expect(html).toContain('var submitUrl = "/authorize?nonce=abc";')
+    })
+
+    it('escapes </script> in submitUrl so it cannot terminate the inline script', () => {
+      const html = renderEmailCredentialForm(schema, {
+        submitUrl: '/authorize?x=</script><script>alert(1)</script>'
+      })
+      // Look at the form's inline JS body (between its opening <script> tag
+      // and its closing </script>). The raw `<script>`/`</script>` payload
+      // must NOT appear inside the literal -- only the unicode-escaped form.
+      const openIdx = html.indexOf('<script>')
+      const scriptOpen = openIdx + '<script>'.length
+      const scriptEnd = html.indexOf('</script>', scriptOpen)
+      expect(scriptEnd).toBeGreaterThan(scriptOpen)
+      const scriptBody = html.slice(scriptOpen, scriptEnd)
+      expect(scriptBody).not.toContain('</script>')
+      expect(scriptBody).not.toContain('<script>')
+      expect(scriptBody).toContain('\\u003c/script\\u003e')
+      expect(scriptBody).toContain('\\u003cscript\\u003e')
+    })
+
+    it('escapes quote injection in submitUrl (no script-string breakout)', () => {
+      const html = renderEmailCredentialForm(schema, {
+        submitUrl: '/x";alert("xss");//'
+      })
+      // The JSON.stringify-encoded literal must appear verbatim. Every quote
+      // inside the value is escaped as \" so it cannot terminate the literal.
+      expect(html).toContain('var submitUrl = "/x\\";alert(\\"xss\\");//";')
+
+      // Defensive: every `alert(` (which only comes from the attacker payload)
+      // must be reachable only INSIDE the JS string literal -- meaning each
+      // `alert(` is preceded by `\";` (escaped-quote then semicolon, i.e.
+      // literal content), never by a bare `";` (which would terminate the
+      // literal and execute as JS).
+      const openIdx = html.indexOf('<script>')
+      const scriptOpen = openIdx + '<script>'.length
+      const scriptEnd = html.indexOf('</script>', scriptOpen)
+      const scriptBody = html.slice(scriptOpen, scriptEnd)
+      const alertIdxs = [...scriptBody.matchAll(/alert\(/g)].map((m) => m.index!)
+      expect(alertIdxs.length).toBeGreaterThan(0)
+      for (const idx of alertIdxs) {
+        // 3 characters preceding `alert(` should be `\";` -- the escaped
+        // quote (still inside the literal) followed by a literal semicolon.
+        expect(scriptBody.slice(idx - 3, idx)).toBe('\\";')
+      }
+    })
+
+    it('wraps form controls in a disable-able fieldset', () => {
+      const html = renderEmailCredentialForm(schema, { submitUrl: '/auth' })
+      expect(html).toMatch(/<fieldset[^>]*id="form-fieldset"/i)
+      expect(html).toContain('formFieldset.disabled')
+    })
+
+    it('clears submit button via DOM API rather than innerHTML when busy', () => {
+      const html = renderEmailCredentialForm(schema, { submitUrl: '/auth' })
+      // After the CSP-friendly fix, no innerHTML assignment of the spinner.
+      expect(html).not.toMatch(/submitBtn\.innerHTML\s*=\s*'<span class="spinner"/)
+      expect(html).toContain('createElement("span")')
+    })
+  })
 })

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -50,13 +50,23 @@ export function renderEmailCredentialForm(
     _schema.description ??
       'Configure one or more email accounts (Gmail, Yahoo, iCloud, Outlook/Hotmail/Live, or custom IMAP). Outlook accounts use OAuth2 and are handled automatically by the server.'
   )
-  const submitUrl = escapeHtml(options.submitUrl)
+  // submitUrl is interpolated into an inline <script>. HTML-escaping is not
+  // safe inside <script> blocks (HTML entities are NOT decoded there) — we
+  // need a JS-string-safe encoding. JSON.stringify gives us a quoted JS
+  // literal with `\u00xx`-escaped control chars and properly-escaped quotes
+  // and backslashes, so a malicious submitUrl cannot break out of the literal.
+  const submitUrlJsLiteral = JSON.stringify(String(options.submitUrl))
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
 
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; form-action 'self'; base-uri 'none'; frame-ancestors 'none';" />
+    <meta name="referrer" content="no-referrer" />
     <title>${displayName}</title>
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -202,6 +212,9 @@ export function renderEmailCredentialForm(
         .submit-btn:hover { background-color: #5a7fb5; }
         .submit-btn:focus-visible { outline: 2px solid #4a6fa5; outline-offset: 2px; }
         .submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .form-fieldset { border: 0; padding: 0; margin: 0; min-width: 0; }
+        .form-fieldset[disabled] { opacity: 0.6; pointer-events: none; }
+        .form-fieldset[disabled] .field-input { background-color: #0a0a0a; cursor: not-allowed; }
         .status-box {
             display: none;
             border-radius: 8px;
@@ -251,11 +264,13 @@ export function renderEmailCredentialForm(
             <h2 class="form-title">Email Accounts</h2>
 
             <form id="credential-form" novalidate>
-                <div id="accounts-container"></div>
+                <fieldset id="form-fieldset" class="form-fieldset">
+                    <div id="accounts-container"></div>
 
-                <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
+                    <button type="button" class="add-btn" id="add-account-btn">+ Add Another Account</button>
 
-                <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                    <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
+                </fieldset>
 
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
@@ -264,7 +279,7 @@ export function renderEmailCredentialForm(
 
     <script>
         (function () {
-            var submitUrl = "${submitUrl}";
+            var submitUrl = ${submitUrlJsLiteral};
 
             var OAUTH_DOMAINS = ["outlook.com", "hotmail.com", "live.com"];
             var APP_PASSWORD_DOMAINS = {
@@ -295,6 +310,11 @@ export function renderEmailCredentialForm(
             var form = document.getElementById("credential-form");
             var submitBtn = document.getElementById("submit-btn");
             var statusBox = document.getElementById("status-box");
+            var formFieldset = document.getElementById("form-fieldset");
+
+            function setFormBusy(busy) {
+                if (formFieldset) formFieldset.disabled = !!busy;
+            }
 
             var accountIndex = 0;
 
@@ -667,9 +687,17 @@ export function renderEmailCredentialForm(
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
+                setFormBusy(true);
                 submitBtn.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
-                submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
+                // Build spinner via DOM (no innerHTML on form-controlled content) so a
+                // strict CSP that blocks inline style would still allow it.
+                while (submitBtn.firstChild) submitBtn.removeChild(submitBtn.firstChild);
+                var spinner = document.createElement("span");
+                spinner.className = "spinner";
+                spinner.setAttribute("aria-hidden", "true");
+                submitBtn.appendChild(spinner);
+                submitBtn.appendChild(document.createTextNode(" Connecting..."));
 
                 fetch(submitUrl, {
                     method: "POST",
@@ -680,6 +708,7 @@ export function renderEmailCredentialForm(
                         return resp.json().then(function (data) {
                             if (!data.ok) {
                                 showStatus("error", data.error || data.error_description || "Request failed.");
+                                setFormBusy(false);
                                 submitBtn.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
@@ -694,8 +723,12 @@ export function renderEmailCredentialForm(
                             }
 
                             if (data.next_step && data.next_step.type === "oauth_device_code") {
-                                submitBtn.innerHTML =
-                                    '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
+                                while (submitBtn.firstChild) submitBtn.removeChild(submitBtn.firstChild);
+                                var sp = document.createElement("span");
+                                sp.className = "spinner";
+                                sp.setAttribute("aria-hidden", "true");
+                                submitBtn.appendChild(sp);
+                                submitBtn.appendChild(document.createTextNode(" Awaiting Microsoft..."));
                                 submitBtn.removeAttribute("aria-busy");
                                 renderOAuthDeviceCode(data.next_step);
                                 return;
@@ -717,6 +750,7 @@ export function renderEmailCredentialForm(
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);
+                        setFormBusy(false);
                         submitBtn.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";

--- a/src/tools/helpers/config.test.ts
+++ b/src/tools/helpers/config.test.ts
@@ -112,6 +112,69 @@ describe('parseCredentials', () => {
     expect(result[0]!.password).toBe('pass:with:colons:nohostname')
   })
 
+  it('handles localhost IMAP host with custom port (issue #610)', async () => {
+    const result = await parseCredentials('user@example.com:secret:localhost:1993')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.email).toBe('user@example.com')
+    expect(result[0]!.password).toBe('secret')
+    expect(result[0]!.imap.host).toBe('localhost')
+    expect(result[0]!.imap.port).toBe(1993)
+    // Non-standard port should fall back to STARTTLS (secure=false)
+    expect(result[0]!.imap.secure).toBe(false)
+  })
+
+  it('handles localhost without port (defaults to 993/TLS)', async () => {
+    const result = await parseCredentials('user@example.com:secret:localhost')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.imap.host).toBe('localhost')
+    expect(result[0]!.imap.port).toBe(993)
+    expect(result[0]!.imap.secure).toBe(true)
+  })
+
+  it('handles IPv4 IMAP host with custom port (issue #610)', async () => {
+    const result = await parseCredentials('user@example.com:pw:127.0.0.1:1430')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.password).toBe('pw')
+    expect(result[0]!.imap.host).toBe('127.0.0.1')
+    expect(result[0]!.imap.port).toBe(1430)
+    expect(result[0]!.imap.secure).toBe(false)
+  })
+
+  it('handles hostname with explicit standard TLS port', async () => {
+    const result = await parseCredentials('user@custom.com:pw:imap.proxy.local:993')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.imap.host).toBe('imap.proxy.local')
+    expect(result[0]!.imap.port).toBe(993)
+    expect(result[0]!.imap.secure).toBe(true)
+  })
+
+  it('handles password with colons + custom host:port', async () => {
+    const result = await parseCredentials('user@x.com:pass:with:colons:localhost:1993')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.password).toBe('pass:with:colons')
+    expect(result[0]!.imap.host).toBe('localhost')
+    expect(result[0]!.imap.port).toBe(1993)
+  })
+
+  it('handles user with localhost-domain email and localhost IMAP (issue #610)', async () => {
+    // Setup from issue: email-oauth2-proxy on localhost with email like me@x.com
+    const result = await parseCredentials('me@example.com:pw:localhost:2143')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.imap.host).toBe('localhost')
+    expect(result[0]!.imap.port).toBe(2143)
+    // SMTP for localhost proxy: keep the same host (don't rewrite imap. → smtp.)
+    expect(result[0]!.smtp.host).toBe('localhost')
+  })
+
+  it('rejects port numbers > 65535 (treats as password chunk)', async () => {
+    // 99999 isn't a valid port — `localhost:99999` is therefore not a host
+    const result = await parseCredentials('user@gmail.com:pw:localhost:99999')
+    // Falls through to password-with-colons path
+    expect(result).toHaveLength(1)
+    expect(result[0]!.password).toBe('pw:localhost:99999')
+    expect(result[0]!.imap.host).toBe('imap.gmail.com')
+  })
+
   it('parses Outlook email-only entry as OAuth2 account', async () => {
     const result = await parseCredentials('user@outlook.com')
     expect(result).toHaveLength(1)

--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -105,41 +105,112 @@ function emailToId(email: string): string {
 }
 
 /**
- * Parse password and custom IMAP host from credential parts
+ * Detect if a credential trailing token looks like an IMAP host endpoint.
+ * Accepts:
+ *   - hostnames with a dot (e.g. `imap.example.com`)
+ *   - `localhost`
+ *   - bare IPv4 (e.g. `127.0.0.1`)
+ *   - `host:port` variants of any of the above (e.g. `localhost:1993`,
+ *     `imap.local:993`).
+ *
+ * The previous "must contain a dot" heuristic was rejecting users who run
+ * an IMAP proxy on `localhost` with non-standard ports (issue #610).
+ */
+function looksLikeImapHost(token: string): boolean {
+  if (!token) return false
+
+  // host:port form — split off the port, validate the host portion, and
+  // ensure the port is a positive integer.
+  const lastColon = token.lastIndexOf(':')
+  if (lastColon > 0) {
+    const maybePort = token.slice(lastColon + 1)
+    if (/^\d{1,5}$/.test(maybePort)) {
+      const portNum = Number(maybePort)
+      if (portNum > 0 && portNum <= 65535) {
+        return looksLikeImapHost(token.slice(0, lastColon))
+      }
+    }
+    // Colon present but not followed by a valid port -- this isn't a host,
+    // it's a password chunk that happens to contain ':'.
+    return false
+  }
+
+  // Restrict to charset that fits hostnames / IPv4. Rejects passwords that
+  // look like words ("nohostname") but allows real hosts and `localhost`.
+  if (!/^[a-zA-Z0-9.-]+$/.test(token)) return false
+  if (token === 'localhost') return true
+  return token.includes('.')
+}
+
+/**
+ * Split a credential trailing token into host + optional port.
+ * Returns `null` if no port was specified.
+ */
+function splitHostPort(token: string): { host: string; port: number | null } {
+  const lastColon = token.lastIndexOf(':')
+  if (lastColon > 0) {
+    const maybePort = token.slice(lastColon + 1)
+    if (/^\d{1,5}$/.test(maybePort)) {
+      const portNum = Number(maybePort)
+      if (portNum > 0 && portNum <= 65535) {
+        return { host: token.slice(0, lastColon), port: portNum }
+      }
+    }
+  }
+  return { host: token, port: null }
+}
+
+/**
+ * Parse password and custom IMAP host (with optional port) from credential parts.
+ *
+ * Supported credential shapes after splitting on `:` (excluding the email
+ * prefix part 0):
+ *   - `email:password`
+ *   - `email:password:imap.host`         (host)
+ *   - `email:password:imap.host:993`     (host + port)
+ *   - `email:password:localhost:1993`    (localhost + port — issue #610)
+ *   - `email:password_with_colons[:...]` (password may contain colons)
  */
 function parsePasswordAndHost(parts: string[]): {
   password: string
   customImapHost?: string
+  customImapPort?: number
 } {
-  let password: string
-  let customImapHost: string | undefined
-
   if (parts.length === 2) {
-    // email:password
-    password = parts[1]!
-  } else if (parts.length === 3) {
-    // Could be email:password:imap_host OR email:password_with_colon
-    // Heuristic: if last part looks like a hostname (contains a dot), treat as imap host
-    const lastPart = parts[2]!
-    if (lastPart.includes('.')) {
-      password = parts[1]!
-      customImapHost = lastPart
-    } else {
-      // password contains a colon
-      password = `${parts[1]}:${parts[2]}`
-    }
-  } else {
-    // 4+ parts: everything between email and last part (if hostname) is password
-    const lastPart = parts[parts.length - 1]!
-    if (lastPart.includes('.')) {
-      password = parts.slice(1, -1).join(':')
-      customImapHost = lastPart
-    } else {
-      password = parts.slice(1).join(':')
+    return { password: parts[1]! }
+  }
+
+  // Greedy match: try to interpret a trailing `host[:port]` (1 or 2 trailing
+  // parts) as a custom endpoint. Prefer the longest match so passwords
+  // containing colons still parse cleanly.
+
+  // Try `host:port` (2 trailing parts that join into a host:port string).
+  if (parts.length >= 4) {
+    const candidate = `${parts[parts.length - 2]}:${parts[parts.length - 1]}`
+    if (looksLikeImapHost(candidate)) {
+      const { host, port } = splitHostPort(candidate)
+      return {
+        password: parts.slice(1, -2).join(':'),
+        customImapHost: host,
+        customImapPort: port ?? undefined
+      }
     }
   }
 
-  return { password, customImapHost }
+  // Try single trailing `host` (or `host:port` collapsed in one token like
+  // `imap.example.com:993` — uncommon because we split on `:` already).
+  const last = parts[parts.length - 1]!
+  if (looksLikeImapHost(last)) {
+    const { host, port } = splitHostPort(last)
+    return {
+      password: parts.slice(1, -1).join(':'),
+      customImapHost: host,
+      customImapPort: port ?? undefined
+    }
+  }
+
+  // No trailing host — password itself contains colons.
+  return { password: parts.slice(1).join(':') }
 }
 
 /**
@@ -179,22 +250,34 @@ async function applyOutlookOAuth2(account: AccountConfig): Promise<void> {
 }
 
 /**
- * Resolve IMAP/SMTP server configuration
+ * Resolve IMAP/SMTP server configuration.
+ *
+ * When a custom IMAP host is supplied with a non-default port, `secure` is
+ * inferred: ports 993 / 995 → TLS, all others (e.g. 143, 1993, 2525) → STARTTLS.
+ * This lets users point at local proxies on non-standard ports (issue #610).
  */
 function resolveServerConfig(
   email: string,
-  customImapHost?: string
+  customImapHost?: string,
+  customImapPort?: number
 ): { imap: ServerConfig; smtp: ServerConfig } | null {
   if (customImapHost) {
-    const imap = { host: customImapHost, port: 993, secure: true }
-    // Guess SMTP from IMAP host
-    const smtp = { host: customImapHost.replace('imap.', 'smtp.'), port: 587, secure: false }
+    const imapPort = customImapPort ?? 993
+    const imapSecure = imapPort === 993 || imapPort === 995
+    const imap = { host: customImapHost, port: imapPort, secure: imapSecure }
+    // Guess SMTP from IMAP host. Preserve the same host for localhost / proxy
+    // setups (rather than rewriting `imap.` → `smtp.`, which yields `smtp` /
+    // `smtp.localhost` and breaks lookups).
+    const smtpHost = customImapHost.includes('.') ? customImapHost.replace('imap.', 'smtp.') : customImapHost
+    const smtp = { host: smtpHost, port: 587, secure: false }
     return { imap, smtp }
   }
 
   const discovered = discoverSettings(email)
   if (!discovered) {
-    console.error('Cannot auto-discover settings for the provided email. Use format: email:password:imap.server.com')
+    console.error(
+      'Cannot auto-discover settings for the provided email. Use format: email:password:imap.server.com or email:password:host:port'
+    )
     return null
   }
   return discovered
@@ -219,10 +302,10 @@ async function parseSingleCredential(entry: string): Promise<AccountConfig | nul
     return null
   }
 
-  const { password, customImapHost } = parsePasswordAndHost(parts)
+  const { password, customImapHost, customImapPort } = parsePasswordAndHost(parts)
 
   // Auto-discover or use custom host
-  const servers = resolveServerConfig(email, customImapHost)
+  const servers = resolveServerConfig(email, customImapHost, customImapPort)
   if (!servers) return null
 
   const account: AccountConfig = {
@@ -246,9 +329,13 @@ async function parseSingleCredential(entry: string): Promise<AccountConfig | nul
  * Supported formats:
  * - Simple: email1:password1,email2:password2
  * - With custom IMAP host: email1:password1:imap.custom.com,email2:password2
+ * - With custom IMAP host + port: email:password:host:port (issue #610)
+ *     e.g. `user@example.com:secret:localhost:1993` for a local IMAP proxy
+ *          `user@example.com:secret:127.0.0.1:1430`
  * - Passwords with commas are NOT supported (use env var per account instead)
  *
- * For passwords containing colons, use the 3-field format to disambiguate:
+ * For passwords containing colons, use the explicit host (3+ field) format
+ * to disambiguate:
  *   email:password_with:colon:imap_host
  */
 export async function parseCredentials(envValue: string): Promise<AccountConfig[]> {

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -282,6 +282,18 @@ describe('findClosestMatch', () => {
     // "attach" should match "attachments" better than "send"
     expect(findClosestMatch('attach', ['send', 'attachments', 'folders'])).toBe('attachments')
   })
+
+  it('returns stable results across repeated calls with the same option list (memoized bigrams)', () => {
+    // The bigram cache uses the validOptions array as a WeakMap key, so the
+    // exact same array reference must produce identical results across calls.
+    const options = ['messages', 'folders', 'attachments']
+    const first = findClosestMatch('mesages', options)
+    const second = findClosestMatch('mesages', options)
+    const third = findClosestMatch('foldrs', options)
+    expect(first).toBe('messages')
+    expect(second).toBe('messages')
+    expect(third).toBe('folders')
+  })
 })
 
 describe('createUnknownActionError', () => {

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -160,6 +160,34 @@ function handleSmtpError(error: unknown): EmailMCPError {
 }
 
 /**
+ * Module-level cache for bigram Sets of static valid-option lists.
+ * Most callers pass the same enum array repeatedly (action names,
+ * supported folder paths, etc.). Caching avoids recomputing identical
+ * bigram Sets on every fuzzy-match call.
+ */
+const validOptionBigramCache = new WeakMap<readonly string[], Map<string, Set<string>>>()
+
+function getBigrams(value: string): Set<string> {
+  const bigrams = new Set<string>()
+  for (let i = 0; i < value.length - 1; i++) bigrams.add(value.slice(i, i + 2))
+  return bigrams
+}
+
+function getOptionBigrams(validOptions: readonly string[], optionLower: string): Set<string> {
+  let cache = validOptionBigramCache.get(validOptions)
+  if (!cache) {
+    cache = new Map()
+    validOptionBigramCache.set(validOptions, cache)
+  }
+  let bigrams = cache.get(optionLower)
+  if (!bigrams) {
+    bigrams = getBigrams(optionLower)
+    cache.set(optionLower, bigrams)
+  }
+  return bigrams
+}
+
+/**
  * Find the closest matching string from a list of valid options.
  * Uses bigram similarity for fuzzy matching.
  */
@@ -170,11 +198,7 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   let bestMatch: string | null = null
   let bestScore = 0
 
-  // ⚡ Bolt: Pre-compute the input bigrams outside the loop.
-  // This prevents redundant Set allocations and string slicing for the identical
-  // input string on every iteration of validOptions, reducing overhead from O(N*M) to O(N+M).
-  const inputBigrams = new Set<string>()
-  for (let i = 0; i < lower.length - 1; i++) inputBigrams.add(lower.slice(i, i + 2))
+  const inputBigrams = getBigrams(lower)
 
   for (const option of validOptions) {
     const optionLower = option.toLowerCase()
@@ -182,8 +206,7 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
       return option
     }
 
-    const optionBigrams = new Set<string>()
-    for (let i = 0; i < optionLower.length - 1; i++) optionBigrams.add(optionLower.slice(i, i + 2))
+    const optionBigrams = getOptionBigrams(validOptions, optionLower)
 
     let overlap = 0
     for (const b of inputBigrams) {

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -217,10 +217,16 @@ async function mapLimit<T, R>(items: T[], limit: number, mapper: (item: T) => Pr
  */
 async function extractSnippet(source: string | Buffer, maxLength = 200): Promise<string> {
   try {
-    const parsed = await simpleParser(source)
+    // Snippet only needs plain-text body; skip mailparser's expensive HTML
+    // conversions which dominate parse time when the body is large MIME multipart.
+    const parsed = await simpleParser(source, {
+      skipHtmlToText: true,
+      skipTextToHtml: true,
+      skipTextLinks: true,
+      skipImageLinks: true
+    })
     const text = parsed.text || (parsed.html ? fastExtractSnippet(parsed.html as string, maxLength) : '')
     if (!text) return ''
-    // If we used fastExtractSnippet, it's already cleaned and truncated
     if (parsed.html && !parsed.text) return text
     const cleaned = text.replace(/\s+/g, ' ').trim()
     if (cleaned.length <= maxLength) return cleaned


### PR DESCRIPTION
## Description

This PR adds support for custom IMAP hosts with explicit port numbers (addressing issue #610) and hardens the credential form against XSS attacks via Content-Security-Policy and DOM-based rendering.

### Issue #610: localhost IMAP proxy support

Users running local IMAP proxies (e.g., on `localhost:1993`) can now specify both host and port in the credential string. The parser now intelligently detects whether a trailing token is a hostname or part of the password, supporting:
- `email:password:localhost:1993` (localhost with custom port)
- `email:password:127.0.0.1:1430` (IPv4 with custom port)
- `email:password:imap.proxy.local:993` (hostname with explicit port)
- `email:password:pass:with:colons:localhost:1993` (password containing colons + host:port)

Port inference for TLS vs STARTTLS: ports 993/995 use TLS (`secure: true`), all others default to STARTTLS (`secure: false`), allowing users to point at non-standard proxy ports without manual configuration.

## Changes

### Core credential parsing (`src/tools/helpers/config.ts`)
- **`looksLikeImapHost(token)`**: New heuristic to detect if a token is a hostname. Accepts:
  - Hostnames with dots (e.g., `imap.example.com`)
  - `localhost` (fixes issue #610)
  - Bare IPv4 addresses (e.g., `127.0.0.1`)
  - `host:port` variants of any of the above
  - Rejects bare words like `nohostname` (treated as password chunks)

- **`splitHostPort(token)`**: Extracts host and optional port from a `host:port` string, validating port range (1–65535).

- **`parsePasswordAndHost(parts)`**: Refactored to use greedy matching:
  - Tries to match 2 trailing parts as `host:port` first (longest match)
  - Falls back to 1 trailing part as `host`
  - Treats remaining parts as password (supports colons in passwords)
  - Returns `customImapPort` in addition to `customImapHost`

- **`resolveServerConfig(email, customImapHost, customImapPort)`**: 
  - Uses provided port or defaults to 993
  - Infers `secure` based on port: 993/995 → TLS, others → STARTTLS
  - Preserves SMTP host for localhost/proxy setups (no `imap.` → `smtp.` rewrite)

### Security hardening (`src/credential-form.ts`)
- **Content-Security-Policy meta tag**: Blocks inline scripts except those in the page, disables frame embedding, restricts resource loading
- **JS string encoding**: Replaces `escapeHtml()` with `JSON.stringify()` + unicode escaping for `<`, `>`, `&` to prevent script injection in inline `<script>` blocks
- **DOM-based rendering**: Replaces `innerHTML` assignments with `createElement()` and `appendChild()` for spinner and status updates
- **Fieldset wrapper**: Wraps form controls in a `<fieldset>` that can be disabled during submission, improving UX and accessibility

### Tests
- Added 6 new test cases in `src/tools/helpers/config.test.ts`:
  - localhost with custom port (issue #610)
  - localhost without port (defaults to 993/TLS)
  - IPv4 with custom port
  - hostname with explicit standard port
  - password with colons + custom host:port
  - localhost SMTP host preservation
  - port validation (rejects > 65535)

- Added 5 new security tests in `src/credential-form.test.ts`:
  - CSP meta tag presence
  - JS literal serialization (no HTML escaping)
  - `</script>` tag escaping in submitUrl
  - Quote injection prevention
  - Fieldset disable mechanism
  - DOM-based spinner rendering (no innerHTML)

### Performance optimization (`src/tools/

https://claude.ai/code/session_01TVUJS4wA7jdHouYn1grzvd