### PR TITLE
🎨 Palette: Improve form validation with inline feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -49,3 +49,8 @@
 **Learning:** When submitting a dynamic form containing multiple sub-components (like "Add Account" buttons and numerous inputs), simply disabling the submit button (`<button type="submit" disabled>`) is insufficient to prevent user interaction during async loading states. Users can still modify inputs or click secondary action buttons, potentially causing corrupted state or accidental concurrent operations.
 
 **Action:** Wrap the entire interactive section of the form (inputs, secondary buttons, submit button) in a semantic `<fieldset>` element. During async operations (like API submission), set `fieldset.disabled = true` to instantly and cleanly lock down all child form controls simultaneously, ensuring a robust and predictable loading state.
+
+## 2025-05-24 - Form Validation with Inline Feedback
+
+**Learning:** Relying on default HTML5 form validation popups creates an inconsistent user experience across browsers and can be challenging for screen reader users to understand contextually. Additionally, users lack immediate visual feedback on errors before submission.
+**Action:** Implement custom inline form validation by overriding the default `invalid` event. Apply `aria-invalid="true"` for visual styling (e.g. red borders) and dynamically update a dedicated error message container connected to the input via `aria-describedby` (using `role="alert"` or `aria-live="polite"`) to provide accessible and immediate feedback.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -161,8 +161,21 @@ export function renderEmailCredentialForm(
             border-color: #4a6fa5;
             box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
         }
+        .field-input[aria-invalid="true"] {
+            border-color: #f87171;
+        }
+        .field-input[aria-invalid="true"]:focus {
+            box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.2);
+        }
         .field-input::placeholder { color: #9ca3af; }
         .help-text { font-size: 0.8125rem; color: #9ca3af; margin-top: 0.375rem; }
+        .field-error {
+            display: none;
+            font-size: 0.8125rem;
+            color: #f87171;
+            margin-top: 0.375rem;
+        }
+        .field-error.active { display: block; }
         .help-text a { color: #6c9bd2; text-decoration: none; }
         .help-text a:hover { text-decoration: underline; }
         .notice {
@@ -358,11 +371,19 @@ export function renderEmailCredentialForm(
                 if (required) input.setAttribute("required", "required");
                 group.appendChild(input);
 
+                var errorEl = document.createElement("div");
+                errorEl.id = "error-" + key + "_" + idx;
+                errorEl.className = "field-error";
+                errorEl.setAttribute("role", "alert");
+                errorEl.setAttribute("aria-live", "polite");
+
+                var describedBy = [errorEl.id];
+
                 if (helpText) {
                     var help = document.createElement("p");
                     help.id = "help-" + key + "_" + idx;
                     help.className = "help-text";
-                    input.setAttribute("aria-describedby", help.id);
+                    describedBy.push(help.id);
                     if (helpUrl) {
                         var a = document.createElement("a");
                         a.setAttribute("href", helpUrl);
@@ -375,6 +396,32 @@ export function renderEmailCredentialForm(
                     }
                     group.appendChild(help);
                 }
+
+                input.setAttribute("aria-describedby", describedBy.join(" "));
+                group.appendChild(errorEl);
+
+                input.addEventListener("invalid", function (event) {
+                    event.preventDefault();
+                    var inputEl = event.target;
+                    inputEl.setAttribute("aria-invalid", "true");
+                    if (inputEl.validity.valueMissing) {
+                        errorEl.textContent = "This field is required.";
+                    } else if (inputEl.validity.typeMismatch && inputEl.type === "email") {
+                        errorEl.textContent = "Please enter a valid email address.";
+                    } else {
+                        errorEl.textContent = "Invalid value.";
+                    }
+                    errorEl.classList.add("active");
+                });
+
+                input.addEventListener("input", function (event) {
+                    var inputEl = event.target;
+                    if (inputEl.hasAttribute("aria-invalid")) {
+                        inputEl.removeAttribute("aria-invalid");
+                        errorEl.textContent = "";
+                        errorEl.classList.remove("active");
+                    }
+                });
 
                 return { group: group, input: input };
             }


### PR DESCRIPTION
💡 What: 
Added custom inline form validation to `src/credential-form.ts` that intercepts the default HTML5 `invalid` event. It applies a red visual border to invalid fields and dynamically displays a contextual error message directly below the input.

🎯 Why: 
Relying on default browser validation popups leads to inconsistent styling and poor accessibility. Users often miss the popups or lose context when using screen readers. Inline validation provides immediate, clear, and styled feedback directly where the error occurs.

📸 Before/After: 
*   **Before:** Attempting to submit an invalid email showed a generic browser tooltip that disappeared.
*   **After:** The input gains a red border (`aria-invalid="true"`) and a clear, red text message ("Please enter a valid email address.") appears below the field, remaining until corrected.

♿ Accessibility:
*   Invalid inputs are correctly marked with `aria-invalid="true"`.
*   Error messages are injected into dedicated containers with `role="alert"` and `aria-live="polite"`.
*   The error container's ID is dynamically appended to the input's `aria-describedby` attribute, ensuring screen readers announce both the validation error and any existing helper text.
*   Added a journal entry to `.jules/palette.md` noting the importance of accessible inline validation over default browser behaviors.

---
*PR created automatically by Jules for task [16268865982295914780](https://jules.google.com/task/16268865982295914780) started by @n24q02m*