### PR TITLE
🎨 Palette: Focus management for dynamic forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -54,3 +54,8 @@
 
 **Learning:** Relying on default HTML5 form validation popups creates an inconsistent user experience across browsers and can be challenging for screen reader users to understand contextually. Additionally, users lack immediate visual feedback on errors before submission.
 **Action:** Implement custom inline form validation by overriding the default `invalid` event. Apply `aria-invalid="true"` for visual styling (e.g. red borders) and dynamically update a dedicated error message container connected to the input via `aria-describedby` (using `role="alert"` or `aria-live="polite"`) to provide accessible and immediate feedback.
+
+## 2025-05-25 - Focus Management for Dynamic Content
+
+**Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
+**Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -544,6 +544,10 @@ export function renderEmailCredentialForm(
                     }
                     card.remove();
                     updateAccountNumbers();
+
+                    // Return focus to the "Add Another Account" button after a card is removed
+                    // to prevent keyboard focus from being dropped back to the document body.
+                    if (addBtn) addBtn.focus();
                 });
                 header.appendChild(removeBtn);
                 card.appendChild(header);
@@ -704,8 +708,14 @@ export function renderEmailCredentialForm(
             updateAccountNumbers();
 
             addBtn.addEventListener("click", function () {
-                container.appendChild(createAccountCard(accountIndex++));
+                var newCard = createAccountCard(accountIndex++);
+                container.appendChild(newCard);
                 updateAccountNumbers();
+
+                // Immediately focus the first input field of the new card
+                // so keyboard users can seamlessly start typing.
+                var firstInput = newCard.querySelector("input");
+                if (firstInput) firstInput.focus();
             });
 
             form.addEventListener("submit", function (evt) {


### PR DESCRIPTION
💡 **What:** 
Added programmatic focus management to the dynamic account form in `src/credential-form.ts`. When a user clicks "+ Add Another Account", the first input of the newly created form card is automatically focused. When an account card is removed, focus is programmatically returned to the "+ Add Another Account" button.

🎯 **Why:** 
Without active focus management, appending new inputs forces keyboard users to manually tab through the interface to reach the newly created content. More critically, when an element that currently has focus is removed from the DOM, focus typically drops to the document `<body>`. This forces keyboard-only and screen reader users to completely restart their navigation flow from the top of the page.

📸 **Before/After:** 
_No visual changes to the UI layout. The changes only affect browser focus states._

♿ **Accessibility:** 
Drastically improves keyboard navigation and screen reader continuity by ensuring focus is never lost to the `<body>` during dynamic DOM manipulations. This directly satisfies WCAG 2.1 Success Criterion 2.4.3 (Focus Order).

---
*PR created automatically by Jules for task [1700972780735610634](https://jules.google.com/task/1700972780735610634) started by @n24q02m*