### PR TITLE
🎨 Palette: Active programmatic focus management for dynamic fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -54,3 +54,7 @@
 
 **Learning:** Relying on default HTML5 form validation popups creates an inconsistent user experience across browsers and can be challenging for screen reader users to understand contextually. Additionally, users lack immediate visual feedback on errors before submission.
 **Action:** Implement custom inline form validation by overriding the default `invalid` event. Apply `aria-invalid="true"` for visual styling (e.g. red borders) and dynamically update a dedicated error message container connected to the input via `aria-describedby` (using `role="alert"` or `aria-live="polite"`) to provide accessible and immediate feedback.
+
+## 2024-05-27 - Active Programmatic Focus Management
+**Learning:** When dynamically adding or removing elements from a statically generated form (e.g., `src/credential-form.ts`), focus often drops to the document body `<body>`, breaking keyboard navigation flow.
+**Action:** Implement active focus management by explicitly capturing the newly added element to invoke `.focus()` on its primary input, and explicitly returning focus to a logical preceding element (like the "Add" button) when a form section is removed.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -544,6 +544,7 @@ export function renderEmailCredentialForm(
                     }
                     card.remove();
                     updateAccountNumbers();
+                    addBtn.focus();
                 });
                 header.appendChild(removeBtn);
                 card.appendChild(header);
@@ -704,8 +705,13 @@ export function renderEmailCredentialForm(
             updateAccountNumbers();
 
             addBtn.addEventListener("click", function () {
-                container.appendChild(createAccountCard(accountIndex++));
+                var newCard = createAccountCard(accountIndex++);
+                container.appendChild(newCard);
                 updateAccountNumbers();
+                var firstInput = newCard.querySelector("input");
+                if (firstInput) {
+                    firstInput.focus();
+                }
             });
 
             form.addEventListener("submit", function (evt) {


### PR DESCRIPTION
💡 **What:** Added programmatic focus management when adding and removing account cards in the multi-account credential form.

🎯 **Why:** Previously, when removing a form fieldset, focus would drop to the generic document body, interrupting keyboard navigation. When adding a new fieldset, users had to manually tab into it. 

📸 **Before/After:** See attached Playwright verification recording. Focus now smoothly transitions to the newly created email input when "Add Another Account" is clicked, and gracefully returns to the "Add" button when a section is removed.

♿ **Accessibility:** This directly addresses WCAG 2.1 Success Criterion 2.4.3 (Focus Order), ensuring a logical and predictable reading and navigation order for keyboard and screen-reader users interacting with dynamic DOM content.

---
*PR created automatically by Jules for task [8389158401570619315](https://jules.google.com/task/8389158401570619315) started by @n24q02m*