### PR TITLE
[TEST] Untested public function setSetupUrl

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -89,6 +89,20 @@ describe('credential-state', () => {
     })
   })
 
+  describe('setSetupUrl', () => {
+    it('sets the setup URL', () => {
+      const url = 'http://localhost:3000/setup'
+      mod.setSetupUrl(url)
+      expect(mod.getSetupUrl()).toBe(url)
+    })
+
+    it('allows clearing the setup URL with null', () => {
+      mod.setSetupUrl('http://localhost:3000/setup')
+      mod.setSetupUrl(null)
+      expect(mod.getSetupUrl()).toBeNull()
+    })
+  })
+
   describe('resolveCredentialState', () => {
     it('returns configured when EMAIL_CREDENTIALS env is set', async () => {
       process.env.EMAIL_CREDENTIALS = 'user@gmail.com:pass'


### PR DESCRIPTION
This PR adds unit tests for the `setSetupUrl` function in `src/credential-state.ts`. It verifies that the setup URL can be correctly set and later cleared by passing `null`. Additionally, the Biome configuration was updated to match the CLI version to ensure linting checks pass.

---
*PR created automatically by Jules for task [2031844008130310815](https://jules.google.com/task/2031844008130310815) started by @n24q02m*