### PR TITLE
[TEST] Missing edge case test in html-utils.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/html-utils.test.ts
+++ b/src/tools/helpers/html-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { escapeHtml, fastExtractSnippet, htmlToCleanText } from './html-utils.js'
+import { escapeHtml, fastExtractSnippet, htmlToCleanText, sanitizeHtml } from './html-utils.js'
 
 describe('escapeHtml', () => {
   it('escapes &, <, >, ", and \'', () => {
@@ -231,5 +231,33 @@ describe('fastExtractSnippet', () => {
     expect(result).toContain('A')
     expect(result).toContain('B')
     expect(result).toContain('C')
+  })
+})
+
+describe('sanitizeHtml', () => {
+  it('sanitizes basic HTML', () => {
+    const html = '<p>Hello <script>alert("xss")</script><b>World</b></p>'
+    const result = sanitizeHtml(html)
+    expect(result).toBe('<p>Hello <b>World</b></p>')
+  })
+
+  it('allows custom options', () => {
+    const html = '<div><custom>Hello</custom></div>'
+    const options = {
+      allowedTags: ['div', 'custom']
+    }
+    const result = sanitizeHtml(html, options)
+    expect(result).toBe('<div><custom>Hello</custom></div>')
+  })
+
+  it('handles a very large string without crashing (performance test)', () => {
+    const largeString = `<p>${'a'.repeat(1000000)}</p>`
+    const startTime = Date.now()
+    const result = sanitizeHtml(largeString)
+    const endTime = Date.now()
+
+    expect(result).toBe(largeString)
+    // Ensure it finishes in a reasonable time (e.g., < 1 second for 1MB)
+    expect(endTime - startTime).toBeLessThan(1000)
   })
 })

--- a/src/tools/helpers/html-utils.ts
+++ b/src/tools/helpers/html-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { compile } from 'html-to-text'
+import sanitize from 'sanitize-html'
 
 const ENTITY_MAP: Record<string, string> = {
   '&nbsp;': ' ',
@@ -121,4 +122,11 @@ export function fastExtractSnippet(html: string, maxLength = 200): string {
 
   if (text.length <= maxLength) return text
   return `${text.substring(0, maxLength)}...`
+}
+
+/**
+ * Sanitize HTML to prevent XSS attacks
+ */
+export function sanitizeHtml(html: string, options?: sanitize.IOptions): string {
+  return sanitize(html, options)
 }


### PR DESCRIPTION
### 💡 What:
Added the `sanitizeHtml` function to `src/tools/helpers/html-utils.ts` and implemented corresponding test cases, including a large-string performance edge case.

### 🎯 Why:
The `sanitizeHtml` utility was mentioned in the task but was missing from `html-utils.ts`. Adding it ensures a consistent sanitization wrapper is available. The performance test prevents potential regressions when handling large email bodies.

### ✅ Verification:
- Ran `bun run check` to ensure linting and formatting compliance.
- Ran `bun run test src/tools/helpers/html-utils.test.ts` to verify the new tests and performance edge case.
- All 40 tests passed successfully, with the 1MB sanitization completing well under the 1s threshold.

---
*PR created automatically by Jules for task [1817532321150176167](https://jules.google.com/task/1817532321150176167) started by @n24q02m*