### PR TITLE
[FIX] Potential flaky test using setTimeout in http.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -102,8 +102,8 @@ describe('http transport', () => {
   async function runStartHttpAndTriggerShutdown(fn?: () => Promise<void>) {
     const startPromise = startHttp()
 
-    // Give it some time to run up to the signal wait
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    // Wait for the server to start
+    await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
 
     if (fn) await fn()
 
@@ -141,7 +141,7 @@ describe('http transport', () => {
     beforeEach(async () => {
       // Start server and capture the callback
       startHttp()
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
       onCredentialsSaved = vi.mocked(runHttpServer).mock.calls[0][1].onCredentialsSaved
     })
 
@@ -383,7 +383,7 @@ describe('http transport', () => {
       vi.mocked(loadConfig).mockResolvedValue(mockAccounts as any)
 
       const startPromise = startHttp()
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
 
       const factory = vi.mocked(runHttpServer).mock.calls[0][0]
 


### PR DESCRIPTION
Arbitrary timeouts in http.test.ts were replaced with deterministic vi.waitFor checks to improve test reliability and prevent flakiness during asynchronous server setup. Additionally, migrated Biome configuration to match CLI version.

---
*PR created automatically by Jules for task [193798501612045315](https://jules.google.com/task/193798501612045315) started by @n24q02m*