### PR TITLE
[TEST] Untested public function clearSentFolderCache

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/imap-client.test.ts
+++ b/src/tools/helpers/imap-client.test.ts
@@ -46,6 +46,7 @@ import { ImapFlow } from 'imapflow'
 import { simpleParser } from 'mailparser'
 import {
   appendToFolder,
+  clearSentFolderCache,
   getAttachment,
   listFolders,
   modifyFlags,
@@ -1012,5 +1013,36 @@ describe('OAuth2 IMAP authentication', () => {
     await listFolders(account)
 
     expect(ensureValidToken).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
+// clearSentFolderCache
+// ============================================================================
+
+describe('clearSentFolderCache', () => {
+  it('returns 0 when the cache is empty', () => {
+    // Ensure cache is empty
+    clearSentFolderCache()
+
+    const count = clearSentFolderCache()
+    expect(count).toBe(0)
+  })
+
+  it('returns the correct count and clears the cache after resolveSentFolder', async () => {
+    // Clear initial state
+    clearSentFolderCache()
+
+    mockClient.list.mockResolvedValue([{ name: 'Sent', path: 'Sent', flags: new Set(['\\Sent']), delimiter: '/' }])
+
+    // Populate cache
+    await resolveSentFolder(account)
+    await resolveSentFolder({ ...account, id: 'another-account' })
+
+    const count = clearSentFolderCache()
+    expect(count).toBe(2)
+
+    // Verify it is empty
+    expect(clearSentFolderCache()).toBe(0)
   })
 })


### PR DESCRIPTION
This PR adds unit test coverage for the `clearSentFolderCache` function in `src/tools/helpers/imap-client.ts`. 

The tests verify that:
1. Invoking the function when the cache is empty returns `0`.
2. Invoking the function after the cache has been populated (via `resolveSentFolder`) returns the correct count of cleared entries and leaves the cache empty for subsequent calls.

Additionally, `biome.json` was updated to the latest schema version (2.4.16) to resolve linter warnings.

---
*PR created automatically by Jules for task [8631530692575371127](https://jules.google.com/task/8631530692575371127) started by @n24q02m*