### PR TITLE
[FIX] Long Function: parseSingleCredential

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -128,6 +128,93 @@ export type SmtpSecurity = 'tls' | 'ssl' | 'starttls' | 'none'
 function isSmtpSecurity(segment: string): segment is SmtpSecurity {
   return /^(tls|ssl|starttls|none)$/i.test(segment)
 }
+/**
+ * Helper: an "all-digit" segment looks like a port attempt (even if value
+ * is out-of-range, in which case parsePort returns undefined and the
+ * caller falls back to the protocol-default port).
+ */
+const isPortSegment = (s: string) => /^\d+$/.test(s)
+
+interface SmtpSegments {
+  host?: string
+  port?: number
+  security?: SmtpSecurity
+}
+
+/**
+ * Extract SMTP segments from the end of the credential tail.
+ * Returns the detected SMTP segments and modifies the tail array by popping them.
+ */
+function extractSmtpSegments(tail: string[]): SmtpSegments {
+  let security: SmtpSecurity | undefined
+  let host: string | undefined
+  let port: number | undefined
+
+  // 1. Optional SMTP security keyword at end (only valid when an SMTP host
+  //    can also be detected; otherwise the keyword belongs to the password).
+  //    We tentatively pop + restore if SMTP host parsing fails.
+  let popped_security = false
+  if (tail.length >= 4 && isSmtpSecurity(tail.at(-1)!)) {
+    security = tail.at(-1)!.toLowerCase() as SmtpSecurity
+    tail.pop()
+    popped_security = true
+  }
+
+  // 2. SMTP host + port (host:port pair). Detected only when tail has BOTH:
+  //    - tail.at(-1) is all-digit (a port attempt)
+  //    - tail.at(-2) is a host
+  //    AND there's another preceding host (the IMAP host) — otherwise the
+  //    "host:port" we see IS the IMAP host:port and there's no SMTP suffix.
+  const canHaveSmtpHostPort =
+    tail.length >= 5 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!) && looksLikeHost(tail.at(-4) ?? '')
+  if (canHaveSmtpHostPort) {
+    port = parsePort(tail.at(-1)!)
+    tail.pop()
+    host = tail.pop()
+  }
+
+  // 3. SMTP host without explicit port (only valid when security was popped
+  //    OR when there's an explicit IMAP host:port already detected).
+  if (!host && popped_security && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
+    host = tail.pop()
+  }
+
+  // If security keyword was tentatively popped but no SMTP host was found,
+  // restore it — the keyword is part of the password.
+  if (popped_security && !host) {
+    tail.push(security!)
+    security = undefined
+  }
+
+  return { host, port, security }
+}
+
+interface ImapSegments {
+  host?: string
+  port?: number
+}
+
+/**
+ * Extract IMAP segments from the end of the credential tail.
+ * Returns the detected IMAP segments and modifies the tail array by popping them.
+ */
+function extractImapSegments(tail: string[]): ImapSegments {
+  let host: string | undefined
+  let port: number | undefined
+
+  // IMAP host + port (port may be out-of-range; resolveServerConfig
+  // falls back to default 993 when port is undefined).
+  if (tail.length >= 3 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!)) {
+    port = parsePort(tail.at(-1)!)
+    tail.pop()
+    host = tail.pop()
+  } else if (looksLikeHost(tail.at(-1)!)) {
+    // Trailing host segment, default IMAP port
+    host = tail.pop()
+  }
+
+  return { host, port }
+}
 
 /**
  * Parse password, custom IMAP/SMTP host+port from the colon-separated
@@ -162,74 +249,20 @@ function parsePasswordAndHost(parts: string[]): {
 
   // Mutable tail; pop SMTP, then IMAP, then rest is password.
   const tail = parts.slice(1)
-  let smtpSecurity: SmtpSecurity | undefined
-  let smtpHost: string | undefined
-  let smtpPort: number | undefined
-  let imapHost: string | undefined
-  let imapPort: number | undefined
 
-  // 1. Optional SMTP security keyword at end (only valid when an SMTP host
-  //    can also be detected; otherwise the keyword belongs to the password).
-  //    We tentatively pop + restore if SMTP host parsing fails.
-  let popped_security = false
-  if (tail.length >= 4 && isSmtpSecurity(tail.at(-1)!)) {
-    smtpSecurity = tail.at(-1)!.toLowerCase() as SmtpSecurity
-    tail.pop()
-    popped_security = true
-  }
+  const smtp = extractSmtpSegments(tail)
+  const imap = extractImapSegments(tail)
 
-  // Helper: an "all-digit" segment looks like a port attempt (even if value
-  // is out-of-range, in which case parsePort returns undefined and the
-  // caller falls back to the protocol-default port).
-  const isPortSegment = (s: string) => /^\d+$/.test(s)
-
-  // 2. SMTP host + port (host:port pair). Detected only when tail has BOTH:
-  //    - tail.at(-1) is all-digit (a port attempt)
-  //    - tail.at(-2) is a host
-  //    AND there's another preceding host (the IMAP host) — otherwise the
-  //    "host:port" we see IS the IMAP host:port and there's no SMTP suffix.
-  const canHaveSmtpHostPort =
-    tail.length >= 5 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!) && looksLikeHost(tail.at(-4) ?? '') // ensure there's an IMAP host before
-  if (canHaveSmtpHostPort) {
-    smtpPort = parsePort(tail.at(-1)!) // may be undefined if out-of-range → buildSmtpConfig defaults
-    tail.pop()
-    smtpHost = tail.pop()
-  }
-
-  // 3. SMTP host without explicit port (only valid when security was popped
-  //    OR when there's an explicit IMAP host:port already detected).
-  if (!smtpHost && popped_security && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
-    smtpHost = tail.pop()
-  }
-
-  // If security keyword was tentatively popped but no SMTP host was found,
-  // restore it — the keyword is part of the password.
-  if (popped_security && !smtpHost) {
-    tail.push(smtpSecurity!)
-    smtpSecurity = undefined
-  }
-
-  // 4. IMAP host + port (port may be out-of-range; resolveServerConfig
-  //    falls back to default 993 when port is undefined).
-  if (tail.length >= 3 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!)) {
-    imapPort = parsePort(tail.at(-1)!)
-    tail.pop()
-    imapHost = tail.pop()
-  } else if (looksLikeHost(tail.at(-1)!)) {
-    // Trailing host segment, default IMAP port
-    imapHost = tail.pop()
-  }
-
-  // 5. Whatever remains (after the email shift) is the password.
+  // Whatever remains (after the email shift) is the password.
   const password = tail.join(':')
 
   return {
     password,
-    customImapHost: imapHost,
-    customImapPort: imapPort,
-    customSmtpHost: smtpHost,
-    customSmtpPort: smtpPort,
-    customSmtpSecurity: smtpSecurity
+    customImapHost: imap.host,
+    customImapPort: imap.port,
+    customSmtpHost: smtp.host,
+    customSmtpPort: smtp.port,
+    customSmtpSecurity: smtp.security
   }
 }
 
@@ -335,6 +368,17 @@ function resolveServerConfig(
 /**
  * Parse a single credential entry
  */
+/**
+ * Handle Outlook/Hotmail/Live email-only entry (OAuth2, no password needed).
+ */
+async function handleOAuth2OnlyEntry(email: string): Promise<AccountConfig | null> {
+  const account = await createOAuth2Account(email)
+  if (account) return account
+
+  console.error('Skipping invalid credential entry (expected email:password)')
+  return null
+}
+
 async function parseSingleCredential(entry: string): Promise<AccountConfig | null> {
   const trimmed = entry.trim()
   if (!trimmed) return null
@@ -344,11 +388,7 @@ async function parseSingleCredential(entry: string): Promise<AccountConfig | nul
 
   // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
   if (parts.length < 2) {
-    const account = await createOAuth2Account(email)
-    if (account) return account
-
-    console.error('Skipping invalid credential entry (expected email:password)')
-    return null
+    return handleOAuth2OnlyEntry(email)
   }
 
   const { password, customImapHost, customImapPort, customSmtpHost, customSmtpPort, customSmtpSecurity } =


### PR DESCRIPTION
The `parseSingleCredential` function and its associated `parsePasswordAndHost` function were refactored to address a "Long Function" issue. 

Key changes:
- Extracted OAuth2-only entry handling into `handleOAuth2OnlyEntry`.
- Extracted SMTP segment parsing into `extractSmtpSegments`.
- Extracted IMAP segment parsing into `extractImapSegments`.
- Maintained the 'greedy-from-the-end' parsing strategy to ensure backward compatibility and support for passwords containing colons.
- Updated `biome.json` to the correct schema version and ensured all formatting checks pass.

This refactoring improves the maintainability and readability of the configuration parsing logic without changing its behavior, as verified by the existing test suite.

---
*PR created automatically by Jules for task [11863392428372624108](https://jules.google.com/task/11863392428372624108) started by @n24q02m*