### PR TITLE
[FIX] Long Function: buildOptions

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -136,6 +136,107 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[]): Promise<N
   }
 }
 
+/** Categorize accounts into Outlook/OAuth2 and IMAP groups. */
+function partitionAccounts(accounts: AccountConfig[]): {
+  outlookAccounts: AccountConfig[]
+  imapAccounts: AccountConfig[]
+} {
+  const outlookAccounts: AccountConfig[] = []
+  const imapAccounts: AccountConfig[] = []
+  for (const account of accounts) {
+    if (isOutlookDomain(account.email) || account.authType === 'oauth2') {
+      // Force fresh device-code flow for every form submit by clearing any
+      // cached tokens that ``parseCredentials`` may have populated via
+      // ``loadStoredTokens``. Without this, ``initiateOutlookOAuth`` filters
+      // out accounts with ``.oauth2`` set and silently returns ``null`` →
+      // the form shows "Setup complete" without ever displaying the Microsoft
+      // device-code step (UX bug reported 2026-04-24).
+      account.oauth2 = undefined
+      outlookAccounts.push(account)
+    } else {
+      imapAccounts.push(account)
+    }
+  }
+  return { outlookAccounts, imapAccounts }
+}
+
+/** Handle both per-user and shared credential persistence. */
+async function saveAndPersistCredentials(
+  raw: string,
+  accounts: AccountConfig[],
+  context: SubjectContext
+): Promise<NextStep | null> {
+  // Persistence: per-user (multi-user JWT-sub) + shared config.enc fallback.
+  // Per-user store guarantees isolation in multi-user deployments. Shared
+  // config.enc lets single-user self-host installs survive process restarts
+  // and lets tool calls outside an HTTP request scope (e.g. internal calls)
+  // still see the saved credentials.
+  const sub = context?.sub
+  if (sub) {
+    try {
+      await credStore.save(sub, { accounts })
+    } catch (err) {
+      console.error(`[${SERVER_NAME}] Failed to save per-user credentials for sub=${sub}: ${(err as Error).message}`)
+      return { type: 'error', text: 'Failed to save credentials. Please retry.' }
+    }
+    console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured for sub=${sub} (per-user scope)`)
+  }
+
+  try {
+    await writeConfig(SERVER_NAME, { EMAIL_CREDENTIALS: raw })
+  } catch (err) {
+    console.error(`[${SERVER_NAME}] Failed to persist credentials: ${(err as Error).message}`)
+  }
+  process.env.EMAIL_CREDENTIALS = raw
+  return null
+}
+
+/** Orchestrate the full credential saving flow. */
+async function handleOnCredentialsSaved(
+  creds: Record<string, string>,
+  context: SubjectContext,
+  onAccountsLoaded: (accounts: AccountConfig[]) => void
+): Promise<NextStep | null> {
+  const raw = creds?.EMAIL_CREDENTIALS?.trim()
+  if (!raw) {
+    return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }
+  }
+
+  let accounts: AccountConfig[]
+  try {
+    accounts = await parseCredentials(raw)
+  } catch (err) {
+    return {
+      type: 'error',
+      text: `Failed to parse credentials: ${(err as Error)?.message ?? 'invalid format'}`
+    }
+  }
+
+  if (accounts.length === 0) {
+    return {
+      type: 'error',
+      text: 'No valid accounts parsed. Expected email:app-password (multi-account: email1:pass1,email2:pass2)'
+    }
+  }
+
+  const { outlookAccounts, imapAccounts } = partitionAccounts(accounts)
+
+  const imapResult = await validateImapAccounts(imapAccounts)
+  if (imapResult) return imapResult
+
+  const saveResult = await saveAndPersistCredentials(raw, accounts, context)
+  if (saveResult) return saveResult
+
+  onAccountsLoaded(accounts)
+  console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
+
+  const outlookResult = await initiateOutlookOAuth(outlookAccounts)
+  if (outlookResult) return outlookResult
+
+  setState('configured')
+  return null
+}
+
 /**
  * Build `RunHttpServerOptions` for the email HTTP mode. Per-user credentials
  * are keyed by the JWT `sub` from `SubjectContext`; the shared `config.enc`
@@ -149,90 +250,12 @@ function buildOptions(args: {
 }): RunHttpServerOptions {
   const { port, host, onAccountsLoaded } = args
 
-  const onCredentialsSaved = async (
-    creds: Record<string, string>,
-    context: SubjectContext
-  ): Promise<NextStep | null> => {
-    const raw = creds?.EMAIL_CREDENTIALS?.trim()
-    if (!raw) {
-      return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }
-    }
-
-    let accounts: AccountConfig[]
-    try {
-      accounts = await parseCredentials(raw)
-    } catch (err) {
-      return {
-        type: 'error',
-        text: `Failed to parse credentials: ${(err as Error)?.message ?? 'invalid format'}`
-      }
-    }
-
-    if (accounts.length === 0) {
-      return {
-        type: 'error',
-        text: 'No valid accounts parsed. Expected email:app-password (multi-account: email1:pass1,email2:pass2)'
-      }
-    }
-
-    const outlookAccounts: AccountConfig[] = []
-    const imapAccounts: AccountConfig[] = []
-    for (const account of accounts) {
-      if (isOutlookDomain(account.email) || account.authType === 'oauth2') {
-        // Force fresh device-code flow for every form submit by clearing any
-        // cached tokens that ``parseCredentials`` may have populated via
-        // ``loadStoredTokens``. Without this, ``initiateOutlookOAuth`` filters
-        // out accounts with ``.oauth2`` set and silently returns ``null`` →
-        // the form shows "Setup complete" without ever displaying the Microsoft
-        // device-code step (UX bug reported 2026-04-24).
-        account.oauth2 = undefined
-        outlookAccounts.push(account)
-      } else {
-        imapAccounts.push(account)
-      }
-    }
-
-    const imapResult = await validateImapAccounts(imapAccounts)
-    if (imapResult) return imapResult
-
-    // Persistence: per-user (multi-user JWT-sub) + shared config.enc fallback.
-    // Per-user store guarantees isolation in multi-user deployments. Shared
-    // config.enc lets single-user self-host installs survive process restarts
-    // and lets tool calls outside an HTTP request scope (e.g. internal calls)
-    // still see the saved credentials.
-    const sub = context?.sub
-    if (sub) {
-      try {
-        await credStore.save(sub, { accounts })
-      } catch (err) {
-        console.error(`[${SERVER_NAME}] Failed to save per-user credentials for sub=${sub}: ${(err as Error).message}`)
-        return { type: 'error', text: 'Failed to save credentials. Please retry.' }
-      }
-      console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured for sub=${sub} (per-user scope)`)
-    }
-
-    try {
-      await writeConfig(SERVER_NAME, { EMAIL_CREDENTIALS: raw })
-    } catch (err) {
-      console.error(`[${SERVER_NAME}] Failed to persist credentials: ${(err as Error).message}`)
-    }
-    process.env.EMAIL_CREDENTIALS = raw
-    onAccountsLoaded(accounts)
-    console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
-
-    const outlookResult = await initiateOutlookOAuth(outlookAccounts)
-    if (outlookResult) return outlookResult
-
-    setState('configured')
-    return null
-  }
-
   return {
     serverName: SERVER_NAME,
     relaySchema: RELAY_SCHEMA as unknown as RelayConfigSchema,
     port,
     host,
-    onCredentialsSaved,
+    onCredentialsSaved: (creds, context) => handleOnCredentialsSaved(creds, context, onAccountsLoaded),
     customCredentialFormHtml: renderEmailCredentialForm,
     setupCompleteHook: (markComplete: (key?: string) => void) => {
       setMarkSetupComplete(markComplete)


### PR DESCRIPTION
Refactored the `buildOptions` function in `src/transports/http.ts` by extracting complex credential handling logic into smaller, focused helper functions (`partitionAccounts`, `saveAndPersistCredentials`, and `handleOnCredentialsSaved`). This improves code readability and maintainability.

---
*PR created automatically by Jules for task [6209729851987667034](https://jules.google.com/task/6209729851987667034) started by @n24q02m*