### PR TITLE
[FIX] Clear cached tokens on form submit to force device-code flow

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -4,7 +4,7 @@ import { ImapFlow } from 'imapflow'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { getMarkSetupComplete, resolveCredentialState, setState } from '../credential-state.js'
 import { loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
+import { _resetTokenCache, initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 // Mock dependencies
@@ -35,6 +35,7 @@ vi.mock('../tools/helpers/config.js', () => ({
 }))
 
 vi.mock('../tools/helpers/oauth2.js', () => ({
+  _resetTokenCache: vi.fn(),
   initiateOutlookDeviceCode: vi.fn(),
   isOutlookDomain: vi.fn(),
   saveOutlookTokens: vi.fn()
@@ -228,6 +229,7 @@ describe('http transport', () => {
 
       const result = await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
+      expect(_resetTokenCache).toHaveBeenCalled()
       expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function))
       expect(setState).toHaveBeenCalledWith('setup_in_progress')
       expect(result).toEqual({
@@ -346,6 +348,7 @@ describe('http transport', () => {
 
       const result = await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
+      expect(_resetTokenCache).toHaveBeenCalled()
       expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function))
       expect(result).toEqual({
         type: 'oauth_device_code',

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -34,7 +34,7 @@ import {
 } from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
+import { _resetTokenCache, initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 const SERVER_NAME = 'better-email-mcp'
@@ -153,6 +153,12 @@ function buildOptions(args: {
     creds: Record<string, string>,
     context: SubjectContext
   ): Promise<NextStep | null> => {
+    // Force a fresh device-code flow by clearing the global in-memory token cache.
+    // parseCredentials() may load stored tokens from disk; clearing here ensures
+    // that initiateOutlookOAuth() won't find them and will instead trigger
+    // the interactive UI.
+    _resetTokenCache()
+
     const raw = creds?.EMAIL_CREDENTIALS?.trim()
     if (!raw) {
       return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }


### PR DESCRIPTION
This PR addresses a UX bug where stale cached tokens would bypass the Microsoft device-code flow during credential setup.

Key changes:
- In `src/transports/http.ts`, `_resetTokenCache()` is now called at the beginning of the `onCredentialsSaved` callback.
- This ensures that any tokens loaded from disk during credential parsing are cleared from the in-memory cache before initiating OAuth.
- Updated `src/transports/http.test.ts` to mock `_resetTokenCache` and verify it is called during form submission.

Verification:
- Ran `bun run check` (linting and type-checking).
- Ran `bun run test` (all tests passed, including the updated regression tests).

---
*PR created automatically by Jules for task [9739435463549634875](https://jules.google.com/task/9739435463549634875) started by @n24q02m*