### PR TITLE
[CLEANUP] Use of 'any' Type: buildSearchCriteria

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,8 +3,8 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import { type FetchMessageObject, ImapFlow, type ListResponse, type SearchObject } from 'imapflow'
+import { type AddressObject, type Attachment, type SimpleParserOptions, simpleParser } from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -110,7 +110,7 @@ async function withConnection<T>(account: AccountConfig, fn: (client: ImapFlow) 
  */
 // Pre-compile static RegExp patterns as module-level constants so
 // buildSearchCriteria does not recompile them per call.
-const FLAG_MATCHERS: ReadonlyArray<{ pattern: RegExp; key: keyof SearchObject; value: boolean }> = [
+const FLAG_MATCHERS: ReadonlyArray<{ pattern: RegExp; key: 'flagged' | 'seen'; value: boolean }> = [
   { pattern: /\bUNFLAGGED\b/i, key: 'flagged', value: false },
   { pattern: /\bUNSTARRED\b/i, key: 'flagged', value: false },
   { pattern: /\bUNREAD\b/i, key: 'seen', value: false },
@@ -145,7 +145,7 @@ function buildSearchCriteria(query: string): SearchObject {
   //    Check longer prefixes first to avoid partial matches (UNFLAGGED before FLAGGED, etc.)
   for (const { pattern, key, value } of FLAG_MATCHERS) {
     if (pattern.test(remaining)) {
-      ;(criteria as any)[key] = value
+      criteria[key] = value
       remaining = remaining.replace(pattern, ' ').trim()
     }
   }
@@ -155,8 +155,8 @@ function buildSearchCriteria(query: string): SearchObject {
     const { valid, invalid } = DATE_MATCHERS[keyword]
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
-      const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = new Date(dateMatch[1]!)
+      const criteriaKey = keyword.toLowerCase() as 'since' | 'before'
+      criteria[criteriaKey] = new Date(dateMatch[1]!)
       remaining = remaining.replace(dateMatch[0], ' ').trim()
     } else if (invalid.test(remaining)) {
       throw new EmailMCPError(
@@ -171,8 +171,8 @@ function buildSearchCriteria(query: string): SearchObject {
   for (const keyword of ['FROM', 'TO'] as const) {
     const kvMatch = remaining.match(KV_MATCHERS[keyword])
     if (kvMatch) {
-      const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = kvMatch[1]!.replace(/^["']|["']$/g, '')
+      const criteriaKey = keyword.toLowerCase() as 'from' | 'to'
+      criteria[criteriaKey] = kvMatch[1]!.replace(/^["']|["']$/g, '')
       remaining = remaining.replace(kvMatch[0], ' ').trim()
     }
   }
@@ -236,12 +236,15 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
+  if (Array.isArray(addr)) {
+    return addr.map((a) => formatAddress(a)).join(', ')
+  }
   if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+  if (addr.value) {
+    return addr.value.map((a) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
   }
   return ''
 }
@@ -365,7 +368,7 @@ export async function searchEmails(
       // This ensures the IMAP connection and mailbox lock are released as quickly as possible.
       // We use `mapLimit` with a concurrency of 5 instead of a sequential for...of loop or unbounded Promise.all
       // to improve performance without blocking the event loop or causing memory spikes from CPU-heavy MIME parsing.
-      const summaries = await mapLimit(emails, 5, async (msg: any) => {
+      const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {
         const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
         return {
@@ -377,7 +380,7 @@ export async function searchEmails(
           from: msg.envelope?.from?.[0]
             ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
             : '',
-          to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
+          to: msg.envelope?.to?.map((a) => a.address).join(', ') || '',
           date: msg.envelope?.date?.toISOString() || '',
           flags: Array.from((msg.flags as Set<string> | string[]) || []),
           snippet
@@ -447,7 +450,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,
@@ -529,7 +532,7 @@ export async function trashEmails(
 export async function listFolders(account: AccountConfig): Promise<FolderInfo[]> {
   return withConnection(account, async (client) => {
     const mailboxes = await client.list()
-    return mailboxes.map((mb: any) => ({
+    return mailboxes.map((mb: ListResponse) => ({
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),


### PR DESCRIPTION
Replaced multiple usages of the 'any' type in src/tools/helpers/imap-client.ts with specific interfaces from imapflow (FetchMessageObject, ListResponse) and mailparser (AddressObject, Attachment). This improves type safety and helps prevent runtime errors. Specifically:
- Refactored buildSearchCriteria to use type-safe key assignments.
- Updated formatAddress to recursively handle AddressObject arrays with strict typing.
- Added explicit types to map callbacks in searchEmails, readEmail, and listFolders.
- Migrated biome.json schema version to match the current CLI.

---
*PR created automatically by Jules for task [4483738783878726790](https://jules.google.com/task/4483738783878726790) started by @n24q02m*