### PR TITLE
[FIX] Invoke markSetupCompleteFn after saving tokens

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -246,10 +246,6 @@ describe('http transport', () => {
       // → form spinner stuck on "Waiting for Microsoft authorization..."
       // forever even though tokens were persisted to disk.
       //
-      // Fix: device-code ``onComplete`` callback in ``initiateOutlookOAuth``
-      // must invoke ``getMarkSetupComplete()?.("outlook")`` AFTER ``saveTokens``
-      // returns (mcp-core's default ``mark_setup_complete()`` uses key
-      // "gdrive" -- email plugin must explicitly pass "outlook").
       const mockAccounts = [{ email: 'test@outlook.com', imap: {}, authType: 'oauth2' }]
       vi.mocked(parseCredentials).mockResolvedValue(mockAccounts as any)
       vi.mocked(isOutlookDomain).mockReturnValue(true)


### PR DESCRIPTION
The issue was that the credential form spinner would remain stuck after Microsoft token save because the setup completion wasn't being explicitly signaled for the "outlook" key.

Upon investigation, the fix was already present in \`src/transports/http.ts\`:
\`\`\`typescript
getMarkSetupComplete()?.('outlook')
\`\`\`
However, a "Fix:" instructional comment remained in \`src/transports/http.test.ts\`.

**Changes:**
- Verified that \`src/transports/http.ts\` correctly invokes \`getMarkSetupComplete()?.('outlook')\` after token save.
- Removed the redundant instructional "Fix:" comment from \`src/transports/http.test.ts\`.
- Migrated \`biome.json\` to match the CLI version (2.4.16) to ensure CI passes.
- Confirmed that all 14 tests in \`src/transports/http.test.ts\` pass.

---
*PR created automatically by Jules for task [12845419526651044867](https://jules.google.com/task/12845419526651044867) started by @n24q02m*