### PR TITLE
[CLEANUP] Use of 'any' Type: enhanceError

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -26,6 +26,19 @@ export class EmailMCPError extends Error {
 }
 
 /**
+ * Interface for raw error objects from various libraries (IMAP, SMTP, etc.)
+ */
+export interface RawError {
+  message?: unknown
+  name?: unknown
+  code?: unknown
+  status?: unknown
+  responseCode?: unknown
+  authenticationFailed?: unknown
+  [key: string]: unknown
+}
+
+/**
  * Sanitize error object to remove sensitive information (passwords, tokens)
  */
 function sanitizeErrorDetails(error: unknown): unknown {
@@ -33,14 +46,14 @@ function sanitizeErrorDetails(error: unknown): unknown {
     return error
   }
 
-  const errObj = error as Record<string, unknown>
+  const errObj = error as RawError
   const safe: Record<string, unknown> = {}
 
-  if ('message' in errObj) safe.message = errObj.message
-  if ('name' in errObj) safe.name = errObj.name
-  if ('code' in errObj) safe.code = errObj.code
-  if ('status' in errObj) safe.status = errObj.status
-  if ('responseCode' in errObj) safe.responseCode = errObj.responseCode
+  if (typeof errObj.message === 'string') safe.message = errObj.message
+  if (typeof errObj.name === 'string') safe.name = errObj.name
+  if (errObj.code !== undefined) safe.code = errObj.code
+  if (errObj.status !== undefined) safe.status = errObj.status
+  if (errObj.responseCode !== undefined) safe.responseCode = errObj.responseCode
 
   return safe
 }
@@ -53,7 +66,11 @@ export function enhanceError(error: unknown): EmailMCPError {
     return error
   }
 
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
+  if (!error) {
+    return new EmailMCPError('Unknown error occurred', 'UNKNOWN_ERROR')
+  }
+
+  const errObj = typeof error === 'object' ? (error as RawError) : { message: String(error) }
   const message = typeof errObj.message === 'string' ? errObj.message : 'Unknown error occurred'
 
   // IMAP authentication errors
@@ -123,7 +140,7 @@ export function enhanceError(error: unknown): EmailMCPError {
  * Handle SMTP-specific errors
  */
 function handleSmtpError(error: unknown): EmailMCPError {
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
+  const errObj = error !== null && typeof error === 'object' ? (error as RawError) : {}
   const code = errObj.responseCode as number
 
   switch (code) {
@@ -269,10 +286,10 @@ export function suggestFixes(error: EmailMCPError): string[] {
 /**
  * Wrap async function with error handling
  */
-export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(
-  fn: T
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+export function withErrorHandling<Args extends unknown[], R>(
+  fn: (...args: Args) => Promise<R>
+): (...args: Args) => Promise<R> {
+  return async (...args: Args): Promise<R> => {
     try {
       return await fn(...args)
     } catch (error) {


### PR DESCRIPTION
This PR refactors \`src/tools/helpers/errors.ts\` to improve type safety and remove uses of the \`any\` type.

Key changes:
- Defined a \`RawError\` interface to describe common properties of error objects from external libraries (IMAP, SMTP).
- Updated \`enhanceError\` to use \`RawError\` and added handling for null/undefined or string inputs, ensuring robust error conversion.
- Refactored \`withErrorHandling\` to use generic \`Args extends unknown[]\` and return type \`R\`, eliminating \`any\` while preserving full type support for wrapped functions.
- Migrated Biome configuration to version 2.4.16.

These changes reduce the risk of runtime errors and improve developer experience through better TypeScript definitions.

---
*PR created automatically by Jules for task [12136622773437150312](https://jules.google.com/task/12136622773437150312) started by @n24q02m*