### PR TITLE
[FIX] Deep Nesting in Credential Form

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/credential-form.test.ts
+++ b/src/credential-form.test.ts
@@ -71,7 +71,7 @@ describe('renderEmailCredentialForm', () => {
   it('polls /setup-status for outlook === "complete"', () => {
     const html = renderEmailCredentialForm(schema, { submitUrl: '/authorize?nonce=abc' })
     expect(html).toContain('/setup-status')
-    expect(html).toMatch(/s\.outlook\s*===\s*["']complete["']/)
+    expect(html).toMatch(/s\.outlook\s*!==\s*["']complete["']/)
   })
 
   it('no longer blocks submit when only Outlook accounts are present', () => {

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -678,26 +678,29 @@ export function renderEmailCredentialForm(
                     fetch(statusUrl)
                         .then(function (r) { return r.json(); })
                         .then(function (s) {
-                            if (s && s.outlook === "complete") {
-                                clearInterval(pollId);
-                                statusBox.className = "status-box success";
-                                while (statusBox.firstChild) statusBox.removeChild(statusBox.firstChild);
-                                var done = document.createElement("strong");
-                                done.textContent = "Setup complete!";
-                                statusBox.appendChild(done);
-                                statusBox.appendChild(document.createElement("br"));
-                                statusBox.appendChild(document.createElement("br"));
-                                submitBtn.textContent = "Connected";
-                                if (typeof pendingRedirectUrl === "string" && pendingRedirectUrl.length > 0) {
-                                    // Follow the OAuth redirect so external clients receive the
-                                    // auth code. Without this the form stalls on "close tab" and
-                                    // the client callback server hangs forever.
-                                    statusBox.appendChild(document.createTextNode("Outlook authorized. Redirecting..."));
-                                    window.location.replace(pendingRedirectUrl);
-                                } else {
-                                    statusBox.appendChild(document.createTextNode("Outlook authorized. You can close this tab."));
-                                }
+                            if (!s || s.outlook !== "complete") return;
+
+                            clearInterval(pollId);
+                            statusBox.className = "status-box success";
+                            while (statusBox.firstChild) statusBox.removeChild(statusBox.firstChild);
+
+                            var done = document.createElement("strong");
+                            done.textContent = "Setup complete!";
+                            statusBox.appendChild(done);
+                            statusBox.appendChild(document.createElement("br"));
+                            statusBox.appendChild(document.createElement("br"));
+                            submitBtn.textContent = "Connected";
+
+                            if (typeof pendingRedirectUrl === "string" && pendingRedirectUrl.length > 0) {
+                                // Follow the OAuth redirect so external clients receive the
+                                // auth code. Without this the form stalls on "close tab" and
+                                // the client callback server hangs forever.
+                                statusBox.appendChild(document.createTextNode("Outlook authorized. Redirecting..."));
+                                window.location.replace(pendingRedirectUrl);
+                                return;
                             }
+
+                            statusBox.appendChild(document.createTextNode("Outlook authorized. You can close this tab."));
                         })
                         .catch(function () {});
                 }, 3000);
@@ -735,20 +738,25 @@ export function renderEmailCredentialForm(
                 var parts = [];
                 for (var i = 0; i < collected.accounts.length; i++) {
                     var a = collected.accounts[i];
+
                     if (a.oauth) {
                         // Outlook/Hotmail/Live: just the email, server triggers
                         // Microsoft Device Code OAuth2 on receipt.
                         parts.push(a.email);
-                    } else if (a.imapHost) {
+                        continue;
+                    }
+
+                    if (a.imapHost) {
                         var imapSpec = a.imapHost;
                         // Append the port unless the host field already carries one.
                         if (a.imapPort && imapSpec.indexOf(":") === -1) {
                             imapSpec = imapSpec + ":" + a.imapPort;
                         }
                         parts.push(a.email + ":" + a.password + ":" + imapSpec);
-                    } else {
-                        parts.push(a.email + ":" + a.password);
+                        continue;
                     }
+
+                    parts.push(a.email + ":" + a.password);
                 }
                 var payload = { EMAIL_CREDENTIALS: parts.join(",") };
 
@@ -761,44 +769,43 @@ export function renderEmailCredentialForm(
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(payload)
                 })
-                    .then(function (resp) {
-                        return resp.json().then(function (data) {
-                            if (!data.ok) {
-                                showStatus("error", data.error || data.error_description || "Request failed.");
-                                formFieldset.disabled = false;
-                                submitBtn.removeAttribute("aria-busy");
-                                submitBtn.textContent = "Connect";
-                                return;
-                            }
+                    .then(function (resp) { return resp.json(); })
+                    .then(function (data) {
+                        if (!data.ok) {
+                            showStatus("error", data.error || data.error_description || "Request failed.");
+                            formFieldset.disabled = false;
+                            submitBtn.removeAttribute("aria-busy");
+                            submitBtn.textContent = "Connect";
+                            return;
+                        }
 
-                            // Stash the OAuth redirect target so follow-up async steps
-                            // (device code poll, future OTP) can navigate to it when
-                            // they complete instead of orphaning the client callback.
-                            if (typeof data.redirect_url === "string" && data.redirect_url.length > 0) {
-                                pendingRedirectUrl = data.redirect_url;
-                            }
+                        // Stash the OAuth redirect target so follow-up async steps
+                        // (device code poll, future OTP) can navigate to it when
+                        // they complete instead of orphaning the client callback.
+                        if (typeof data.redirect_url === "string" && data.redirect_url.length > 0) {
+                            pendingRedirectUrl = data.redirect_url;
+                        }
 
-                            if (data.next_step && data.next_step.type === "oauth_device_code") {
-                                submitBtn.innerHTML =
-                                    '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
-                                submitBtn.removeAttribute("aria-busy");
-                                renderOAuthDeviceCode(data.next_step);
-                                return;
-                            }
+                        if (data.next_step && data.next_step.type === "oauth_device_code") {
+                            submitBtn.innerHTML =
+                                '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
+                            submitBtn.removeAttribute("aria-busy");
+                            renderOAuthDeviceCode(data.next_step);
+                            return;
+                        }
 
-                            if (pendingRedirectUrl) {
-                                // No interactive next step — follow the OAuth redirect now.
-                                showStatus("success", "Credentials saved. Redirecting...");
-                                submitBtn.textContent = "Connected";
-                                submitBtn.removeAttribute("aria-busy");
-                                window.location.replace(pendingRedirectUrl);
-                                return;
-                            }
-
-                            showStatus("success", data.message || "Setup complete! You can close this tab.");
+                        if (pendingRedirectUrl) {
+                            // No interactive next step — follow the OAuth redirect now.
+                            showStatus("success", "Credentials saved. Redirecting...");
                             submitBtn.textContent = "Connected";
                             submitBtn.removeAttribute("aria-busy");
-                        });
+                            window.location.replace(pendingRedirectUrl);
+                            return;
+                        }
+
+                        showStatus("success", data.message || "Setup complete! You can close this tab.");
+                        submitBtn.textContent = "Connected";
+                        submitBtn.removeAttribute("aria-busy");
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);


### PR DESCRIPTION
This PR refactors the embedded JavaScript within `src/credential-form.ts` to improve readability and maintainability by reducing deep nesting.

### Changes:
- **Flattened Promise Chain:** Refactored the `fetch` call in the form's `submit` listener to use a flattened `.then()` chain instead of nested handlers.
- **Early Returns in Polling:** Simplified the Outlook OAuth device code polling logic by using an early return if the status is not "complete".
- **Simplified Account Loop:** Refactored the credential serialization loop to use `continue` statements instead of complex `if/else if/else` blocks.
- **Updated Tests:** Adjusted `src/credential-form.test.ts` to align with the refactored logic in the frontend script.
- **Biome Migration:** Updated `biome.json` schema version to match the installed CLI.

Verified with `bun run check`, `bun run test`, and visual confirmation via Playwright.

---
*PR created automatically by Jules for task [8018489474646661363](https://jules.google.com/task/8018489474646661363) started by @n24q02m*