### PR TITLE
⚡ Bolt: [PERF] Use asynchronous file reading in saveTokens

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+
+## 2026-05-28 - [Use asynchronous file reading in saveTokens]
+**Learning:** Synchronous file operations like `readFileSync`, `writeFileSync`, and `mkdirSync` block the event loop, which can lead to significant performance bottlenecks in high-concurrency Node.js applications. This is especially critical in I/O-heavy operations like token management.
+**Action:** Always prefer asynchronous file operations (`readFile`, `writeFile`, `mkdir`) from `node:fs/promises` in production code. Update all callers in the call chain to be `async` and use `await` to ensure the application remains responsive during disk I/O.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -7,14 +7,13 @@ vi.mock('@n24q02m/mcp-core', () => ({
 }))
 
 vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn()
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn()
 }))
 
 vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-  mkdirSync: vi.fn(),
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn()
+  existsSync: vi.fn()
 }))
 
 vi.mock('node:os', () => ({
@@ -23,13 +22,12 @@ vi.mock('node:os', () => ({
 
 const mockTryOpenBrowser = vi.mocked(tryOpenBrowser)
 
-import { readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 
+const mockMkdir = vi.mocked(mkdir)
 const mockReadFile = vi.mocked(readFile)
+const mockWriteFile = vi.mocked(writeFile)
 const mockExistsSync = vi.mocked(existsSync)
-const mockReadFileSync = vi.mocked(readFileSync)
-const mockWriteFileSync = vi.mocked(writeFileSync)
-const mockMkdirSync = vi.mocked(mkdirSync)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -189,54 +187,54 @@ describe('saveTokens', () => {
     clientId: 'cid'
   }
 
-  it('creates config directory if not exists', () => {
+  it('creates config directory if not exists', async () => {
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return false
       return false // config dir doesn't exist
     })
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining('.better-email-mcp'), {
+    expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('.better-email-mcp'), {
       recursive: true,
       mode: 0o700
     })
   })
 
-  it('writes tokens with 0600 permissions', () => {
+  it('writes tokens with 0600 permissions', async () => {
     mockExistsSync.mockReturnValue(false)
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
+    expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining('tokens.json'),
       expect.stringContaining('"user@outlook.com"'),
       { mode: 0o600 }
     )
   })
 
-  it('merges with existing tokens', () => {
+  it('merges with existing tokens', async () => {
     const existing = { 'other@hotmail.com': { accessToken: 'old', refreshToken: 'old', expiresAt: 0, clientId: 'c' } }
 
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return true
       return true
     })
-    mockReadFileSync.mockReturnValue(JSON.stringify(existing))
+    mockReadFile.mockResolvedValue(JSON.stringify(existing))
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['other@hotmail.com']).toBeDefined()
     expect(written['user@outlook.com']).toEqual(tokens)
   })
 
-  it('normalizes email to lowercase', () => {
+  it('normalizes email to lowercase', async () => {
     mockExistsSync.mockReturnValue(false)
 
-    saveTokens('User@OUTLOOK.com', tokens)
+    await saveTokens('User@OUTLOOK.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual(tokens)
   })
 })
@@ -398,7 +396,7 @@ describe('ensureValidToken', () => {
 
     await ensureValidToken(account)
 
-    expect(mockWriteFileSync).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalled()
   })
 
   it('loads tokens from disk when not in memory', async () => {
@@ -419,7 +417,7 @@ describe('ensureValidToken', () => {
 
   it('initiates Device Code flow when no tokens exist', async () => {
     // No tokens on disk
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     // Mock device code request
     mockFetch.mockResolvedValueOnce({
@@ -442,7 +440,7 @@ describe('ensureValidToken', () => {
   })
 
   it('opens browser when initiating Device Code flow', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -466,7 +464,7 @@ describe('ensureValidToken', () => {
   })
 
   it('does not open browser on retry (reuses pending auth)', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -494,7 +492,7 @@ describe('ensureValidToken', () => {
   })
 
   it('reuses pending auth code on retry', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     // First call: device code request
     mockFetch.mockResolvedValueOnce({
@@ -599,7 +597,7 @@ describe('deviceCodeAuth', () => {
     expect(tokens.accessToken).toBe('at-success')
     expect(tokens.refreshToken).toBe('rt-success')
     expect(tokens.clientId).toBe('test-client-id')
-    expect(mockWriteFileSync).toHaveBeenCalled() // Tokens saved
+    expect(mockWriteFile).toHaveBeenCalled() // Tokens saved
   })
 
   it('polls until authorization is granted', async () => {
@@ -784,12 +782,12 @@ describe('saveTokens edge cases', () => {
     vi.clearAllMocks()
   })
 
-  it('starts fresh store if existing token file is corrupted JSON', () => {
+  it('starts fresh store if existing token file is corrupted JSON', async () => {
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return true
       return true // config dir exists
     })
-    mockReadFileSync.mockImplementation(() => {
+    mockReadFile.mockImplementation(() => {
       throw new SyntaxError('Unexpected token')
     })
 
@@ -800,15 +798,15 @@ describe('saveTokens edge cases', () => {
       clientId: 'cid'
     }
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual(tokens)
     // Should only have the new token, not corrupted data
     expect(Object.keys(written)).toEqual(['user@outlook.com'])
   })
 
-  it('uses cached token store on subsequent saves', () => {
+  it('uses cached token store on subsequent saves', async () => {
     mockExistsSync.mockReturnValue(false)
 
     const tokens1: OAuth2Tokens = {
@@ -825,12 +823,12 @@ describe('saveTokens edge cases', () => {
     }
 
     // First save populates cache
-    saveTokens('first@outlook.com', tokens1)
+    await saveTokens('first@outlook.com', tokens1)
     // Second save should use cache, not read from disk
-    saveTokens('second@outlook.com', tokens2)
+    await saveTokens('second@outlook.com', tokens2)
 
     // readFileSync should NOT be called for second save (cache is used)
-    const written = JSON.parse(mockWriteFileSync.mock.calls[1]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[1]![1] as string)
     expect(written['first@outlook.com']).toEqual(tokens1)
     expect(written['second@outlook.com']).toEqual(tokens2)
   })
@@ -908,7 +906,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('forwards malicious URLs with shell metacharacters to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     const maliciousUri = 'https://microsoft.com/devicelogin?code=ABCD;echo"vulnerable"'
     mockFetch.mockResolvedValueOnce({
@@ -934,7 +932,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('intercepts non-http/https protocols before delegating to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -958,7 +956,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('forwards URLs with leading hyphens to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     const hyphenUri = 'https://-example.com'
     mockFetch.mockResolvedValueOnce({
@@ -1070,7 +1068,7 @@ describe('initiateOutlookDeviceCode', () => {
 
     expect(onComplete).toHaveBeenCalled()
     // Tokens persisted to disk.
-    expect(mockWriteFileSync).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalled()
   })
 
   it('throws descriptive error when Microsoft rejects the device code request', async () => {

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -6,8 +6,8 @@
  * persistent token storage, and automatic token refresh.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
@@ -130,15 +130,15 @@ export async function loadStoredTokens(email: string): Promise<OAuth2Tokens | nu
  * Persist OAuth2 tokens to disk.
  * Creates config directory if needed. File permissions: 0600.
  */
-export function saveTokens(email: string, tokens: OAuth2Tokens): void {
+export async function saveTokens(email: string, tokens: OAuth2Tokens): Promise<void> {
   if (!existsSync(CONFIG_DIR)) {
-    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
+    await mkdir(CONFIG_DIR, { recursive: true, mode: 0o700 })
   }
 
   let store: TokenStore = cachedTokenStore || {}
   try {
     if (!cachedTokenStore && existsSync(TOKEN_FILE)) {
-      store = JSON.parse(readFileSync(TOKEN_FILE, 'utf-8'))
+      store = JSON.parse(await readFile(TOKEN_FILE, 'utf-8'))
     }
   } catch {
     // Start fresh if file is corrupted
@@ -147,7 +147,7 @@ export function saveTokens(email: string, tokens: OAuth2Tokens): void {
 
   store[email.toLowerCase()] = tokens
   cachedTokenStore = store
-  writeFileSync(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 })
+  await writeFile(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 })
 }
 
 /**
@@ -278,7 +278,7 @@ function startBackgroundPoll(
 
       if (data.access_token) {
         const now = Math.floor(Date.now() / MS_PER_SECOND)
-        saveTokens(email, {
+        await saveTokens(email, {
           accessToken: data.access_token,
           refreshToken: data.refresh_token,
           expiresAt: now + data.expires_in,
@@ -433,7 +433,7 @@ export async function ensureValidToken(account: { email: string; oauth2?: OAuth2
   }
 
   // Persist updated tokens
-  saveTokens(account.email, account.oauth2)
+  await saveTokens(account.email, account.oauth2)
 
   return newTokens.access_token
 }
@@ -454,7 +454,7 @@ export async function saveOutlookTokens(tokens: Record<string, unknown>): Promis
   const email = typeof tokens.email === 'string' ? tokens.email : (process.env.OUTLOOK_EMAIL ?? 'outlook-device-code')
   const now = Math.floor(Date.now() / MS_PER_SECOND)
   const expiresIn = typeof tokens.expires_in === 'number' ? tokens.expires_in : 3600
-  saveTokens(email, {
+  await saveTokens(email, {
     accessToken: typeof tokens.access_token === 'string' ? tokens.access_token : '',
     refreshToken: typeof tokens.refresh_token === 'string' ? tokens.refresh_token : '',
     expiresAt: now + expiresIn,
@@ -503,7 +503,7 @@ export async function deviceCodeAuth(email: string, clientId?: string): Promise<
         clientId: resolvedClientId
       }
 
-      saveTokens(email, tokens)
+      await saveTokens(email, tokens)
       console.error(`\nSuccess! Token saved for ${email}`)
       return tokens
     }


### PR DESCRIPTION
💡 What: Converted \`saveTokens\` in \`src/tools/helpers/oauth2.ts\` from synchronous to asynchronous using \`node:fs/promises\`. Updated all call sites in the module and associated tests to correctly \`await\` the operation.

🎯 Why: Synchronous file I/O blocks the event loop, which can cause latency spikes and reduced throughput in high-concurrency environments. Moving to \`fs/promises\` allows the event loop to continue processing other tasks while waiting for disk I/O.

📊 Impact: Prevents event loop blocking during token persistence, which happens during every OAuth2 token acquisition or refresh.

🔬 Measurement: Verified with \`bun run test\` (566/566 passing) and \`bun run check\`.

---
*PR created automatically by Jules for task [5282304293343978305](https://jules.google.com/task/5282304293343978305) started by @n24q02m*