### PR TITLE
fix: sync docs with current code (env vars, modes, file structure)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,13 +44,14 @@ src/
   init-server.ts                 # Entry point, env validation
   relay-setup.ts                 # Zero-config relay: create session, poll for config
   relay-schema.ts                # Relay form schema (email credential fields)
-  auth/                          # OAuth 2.1 + DCR, per-user credential store
-    stateless-client-store.ts    # HMAC-based stateless DCR (shared with Notion MCP)
-    email-auth-provider.ts       # OAuthServerProvider for multi-user HTTP mode
+  credential-state.ts            # Single-user / stdio credential resolution from env
+  auth/                          # Per-user credential store + Outlook OAuth (HTTP mode)
     per-user-credential-store.ts # AES-256-GCM encrypted per-user credential storage
+    in-memory-cred-store.ts      # Ephemeral in-memory credential store
+    outlook-device-code.ts       # Microsoft device-code OAuth flow
+    subject-context.ts           # Per-request JWT-sub scope (AsyncLocalStorage)
   transports/
     http.ts                      # Multi-user HTTP transport with OAuth 2.1
-    credential-store.ts          # Single-user encrypted credential store (stdio mode)
   docs/                          # Markdown docs phuc vu qua MCP resources
   tools/
     registry.ts                  # Tool registration + routing
@@ -65,8 +66,8 @@ src/
   - Custom IMAP host: `user@custom.com:password:imap.custom.com`
   - Custom IMAP host + port: `user@custom.com:password:imap.custom.com:1993`
   - Local IMAP proxy: `user@custom.com:password:localhost:1993` (`localhost` accepted as host; per-account port)
-- **http mode**: `TRANSPORT_MODE=http`, `PUBLIC_URL`, `DCR_SERVER_SECRET`
-- `PORT` (default 8080)
+- **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `PUBLIC_URL` (for relay/OAuth redirect URLs). `CREDENTIAL_SECRET` optional (per-user store encryption; auto-generated to a 0600 secret file if unset). `MCP_AUTH_DISABLE=1` skips Bearer JWT verification (for deploys behind an external auth gateway).
+- `PORT` (default `0` = OS-assigned random port), `HOST` (optional bind address)
 - `OUTLOOK_CLIENT_ID` -- tu chon, cho self-hosted OAuth2 client
 
 ## Code conventions
@@ -93,15 +94,12 @@ PSR v10 (workflow_dispatch) -> npm + Docker (amd64+arm64) + GHCR + MCP Registry.
 - Pre-commit: biome check --write, tsc --noEmit, bun run test.
 - Secrets: skret SSM namespace `/better-email-mcp/prod` (region `ap-southeast-1`)
 
-## Modes (Phase L2 restored 2026-04-18)
+## Modes
 
-Selected via `MCP_MODE` env var:
+Two transports, selected in `init-server.ts:52-53`. There is no `MCP_MODE` env var; the old `remote-relay` / `local-relay` distinction was removed (see `transports/http.ts:5`).
 
-- **`remote-relay` (default)**: HTTP + delegated device-code OAuth flow tới Microsoft (`login.microsoftonline.com/common/oauth2/v2.0/devicecode`). Bắt buộc env `OUTLOOK_CLIENT_ID` (Azure app client ID). Token lưu tại `~/.better-email-mcp/tokens.json`. Deploy tại `https://better-email-mcp.n24q02m.com`.
-- **`local-relay`**: HTTP + `runLocalServer` với relaySchema — user paste `email:app-password` vào `/authorize` form. Outlook accounts bị reject với hướng dẫn chuyển `MCP_MODE=remote-relay`. Gmail/Yahoo/iCloud/custom IMAP vẫn work qua paste form này.
-- **`stdio proxy`**: `--stdio` hoặc `MCP_TRANSPORT=stdio`. Backward compat.
-
-Chuyển giữa remote-relay ↔ local-relay qua `MCP_MODE` env var. Default = remote-relay nếu không set.
+- **stdio (default)**: MCP SDK `StdioServerTransport` directly. Reads credentials from `EMAIL_CREDENTIALS` OR `EMAIL_USER` + `EMAIL_APP_PASSWORD`. Outlook accounts use an App Password in this mode.
+- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Single multi-user relay: `/authorize` form for App-Password providers (paste `email:app-password`) plus bundled Outlook device-code OAuth. Per-user credentials keyed by JWT `sub`. Outlook token file: `~/.better-email-mcp/tokens.json`. Deploy at `https://better-email-mcp.n24q02m.com`.
 
 ## Known bugs (phat hien 2026-04-18 E2E)
 
@@ -137,6 +135,6 @@ Tier policy:
 - **T2 non-interaction** (`make e2e-config CONFIG=<id>` locally) - driver pre-fills relay form from skret AWS SSM `/better-email-mcp/prod` (`ap-southeast-1`). No user gate.
 - **T2 interaction** - driver fills relay form, then prints upstream user-gate URL; user signs in / types OTP at provider. Driver enforces per-flow timeouts (device-code 900s, oauth-redirect 300s, browser-form 600s) and emits `[poll] elapsed=Xs remaining=Ys status=<body>` every 30s. On timeout, container logs + last `setup-status` are saved to `<tmp>/e2e-diag/` BEFORE teardown for post-mortem.
 
-Multi-user remote mode (deployment property; not a separate config) requires `MCP_DCR_SERVER_SECRET` in the same skret namespace - driver refuses to start the container without it when `PUBLIC_URL` is set.
+Multi-user remote mode (deployment property; not a separate config) uses `CREDENTIAL_SECRET` to encrypt the per-user credential store (`auth/per-user-credential-store.ts:78`). It is optional — if unset, a 32-byte secret is generated and persisted to a 0600 secret file. Provide it via the skret namespace to keep per-user stores decryptable across container restarts.
 
 References: `mcp-core/scripts/e2e/matrix.yaml`, `~/.claude/skills/mcp-dev/references/e2e-full-matrix.md` (harness-readiness gate), `~/.claude/skills/mcp-dev/references/secrets-skret.md` (per-server credential layout), `~/.claude/skills/mcp-dev/references/multi-user-pattern.md` (per-JWT-sub isolation).

--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ Single multi-user mode (relay form for App-Password providers + bundled Outlook 
 
 ```bash
 docker run -p 8080:8080 \
+  -e PORT=8080 \
   -e PUBLIC_URL=https://your-domain.com \
-  -e DCR_SERVER_SECRET=$(openssl rand -hex 32) \
+  -e CREDENTIAL_SECRET=$(openssl rand -hex 32) \
   n24q02m/better-email-mcp:latest
 ```
 
@@ -175,9 +176,11 @@ In **stdio mode**, Outlook accounts use an **App Password** instead (Outlook Acc
 | `EMAIL_APP_PASSWORD` | Yes (stdio, single-account) | - | App password (Gmail/Yahoo/iCloud) or Outlook App Password |
 | `EMAIL_IMAP_HOST` | No (custom only) | - | Custom IMAP hostname when `EMAIL_PROVIDER=custom` |
 | `EMAIL_CREDENTIALS` | Alternative (multi-account) | - | Legacy `user@gmail.com:app-password` (comma-separated for multi-account) |
-| `PUBLIC_URL` | Yes (http) | - | Server's public URL for OAuth redirects |
-| `DCR_SERVER_SECRET` | Yes (http) | - | HMAC secret for stateless client registration |
-| `PORT` | No | `8080` | Server port (http mode) |
+| `PUBLIC_URL` | No (http) | - | Server's public URL for relay / OAuth redirect links |
+| `CREDENTIAL_SECRET` | No (http) | auto-generated | Secret used to encrypt the per-user credential store; if unset, a random 32-byte secret is generated and persisted to a 0600 file |
+| `PORT` | No | `0` (OS-assigned) | Server port (http mode); set explicitly (e.g. `8080`) to bind a fixed port |
+| `HOST` | No | - | Bind address (http mode) |
+| `MCP_AUTH_DISABLE` | No (http) | - | Set to `1` to skip Bearer JWT verification when behind an external auth gateway |
 | `OUTLOOK_CLIENT_ID` | No | `d56f8c71-9f7c-43f4-9934-be29cb6e77b0` (bundled public client) | Override the bundled Azure AD public client for self-hosted Outlook OAuth2 |
 | `OUTLOOK_EMAIL` | No | - | Workaround when Microsoft device-code response omits the email field |
 


### PR DESCRIPTION
Audit + fix of documentation drift in `CLAUDE.md` and `README.md`, each change verified against source `file:line` (docs-only, no code changes).

| doc file:line | claimed | actual (code) | fixed |
|---|---|---|---|
| CLAUDE.md / README.md | `PORT` default `8080` | `0` = OS-assigned (`transports/http.ts:264`) | yes |
| CLAUDE.md, README.md, docker snippet | http requires `DCR_SERVER_SECRET` | not read anywhere; encryption secret is `CREDENTIAL_SECRET` (optional, auto-generated) (`auth/per-user-credential-store.ts:78`) | yes |
| CLAUDE.md E2E | requires `MCP_DCR_SERVER_SECRET` | not read; `CREDENTIAL_SECRET` optional | yes |
| CLAUDE.md Modes | `MCP_MODE` remote-relay/local-relay/stdio-proxy | no `MCP_MODE`; distinction removed (`transports/http.ts:5`); modes = stdio + http | yes |
| CLAUDE.md structure | `auth/stateless-client-store.ts`, `auth/email-auth-provider.ts`, `transports/credential-store.ts` | none exist; real files listed | yes |
| CLAUDE.md / README.md | (missing) `HOST`, `MCP_AUTH_DISABLE` | read in `transports/http.ts:265,285` | added |

Flagged (not changed): `README.md` Status section links `docs/setup-manual.md` which does not exist in the repo; left as-is pending human decision on intended target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)