### PR TITLE
🎨 Palette: [UX improvement] Enhance form validation accessibility with programmatic focus

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,6 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+## 2026-06-03 - Manual Form Validation Focus
+**Learning:** When handling form validation manually (e.g., overriding submit on forms with novalidate), explicitly calling form.checkValidity() triggers native invalid events. However, programmatic focus must be manually managed to improve accessibility. The first invalid element can be found using form.querySelector('input:invalid, select:invalid, textarea:invalid') and focused if the method is available.
+**Action:** Use this pattern to improve form validation UX, ensuring screen readers and keyboard users are directed appropriately to validation errors.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -720,6 +720,15 @@ export function renderEmailCredentialForm(
 
             form.addEventListener("submit", function (evt) {
                 evt.preventDefault();
+
+                if (!form.checkValidity()) {
+                    var firstInvalid = form.querySelector("input:invalid, select:invalid, textarea:invalid");
+                    if (firstInvalid && "focus" in firstInvalid) {
+                        firstInvalid.focus();
+                    }
+                    return;
+                }
+
                 statusBox.style.display = "none";
 
                 var collected = collectAccounts();


### PR DESCRIPTION
💡 **What:** Added programmatic focus management when the custom email credential form fails HTML5 validation on submit.

🎯 **Why:** Since the form uses `novalidate` to manage validation states inline (preventing native popups), pressing "Connect" with an empty form displayed inline errors but dropped focus. Keyboard and screen reader users had to manually navigate back to the top of the form to correct errors. Programmatically focusing the first invalid element immediately directs them to the issue.

📸 **Before/After:** See the attached visual verification artifact.

♿ **Accessibility:**
- Directs focus to `input:invalid`, `select:invalid`, or `textarea:invalid` upon failed submission.
- Prevents screen reader users from losing context.
- Eliminates manual tabbing required by keyboard users to find the validation error.

---
*PR created automatically by Jules for task [3456905274587847063](https://jules.google.com/task/3456905274587847063) started by @n24q02m*