### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1130,6 +1130,10 @@ describe('initiateOutlookDeviceCode', () => {
 
     await expect(initiateOutlookDeviceCode('bad@outlook.com')).rejects.toThrow('Unknown client ID')
   })
+
+  it('throws error if email is empty', async () => {
+    await expect(initiateOutlookDeviceCode('')).rejects.toThrow('Email is required')
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -357,6 +357,9 @@ export async function initiateOutlookDeviceCode(
   email: string,
   onComplete?: () => void
 ): Promise<{ verificationUri: string; userCode: string; expiresIn: number; interval: number }> {
+  if (!email) {
+    throw new Error('Email is required')
+  }
   const emailKey = email.toLowerCase()
   const existing = pendingAuths.get(emailKey)
   if (existing && existing.expiresAt > Date.now()) {


### PR DESCRIPTION
This PR addresses a missing edge case in the `initiateOutlookDeviceCode` function within `src/tools/helpers/oauth2.ts`.

### 🚨 Severity:
Low (Testing/Robustness improvement)

### 💡 Vulnerability:
The function `initiateOutlookDeviceCode` did not validate if the `email` argument was empty. Calling it with an empty string led to a `TypeError` when subsequent fetch calls or object property accesses occurred (e.g., trying to call `.json()` on an undefined mock response in tests, or potentially failing silently in production).

### 🎯 Impact:
Improved robustness and clearer error reporting when the function is called with invalid input.

### 🛠️ Fix:
- Added a check at the beginning of `initiateOutlookDeviceCode` to throw `Error('Email is required')` if the `email` parameter is falsy.
- Added a new test case in `src/tools/helpers/oauth2.test.ts` to verify this behavior.

### ✅ Verification:
- Ran `bun run test src/tools/helpers/oauth2.test.ts` and verified all 60 tests (including the new one) pass.
- Ran `bun run test` for the full suite (591 tests passed).
- Ran `bun run check` to ensure linting and type safety.

---
*PR created automatically by Jules for task [13858749363452717412](https://jules.google.com/task/13858749363452717412) started by @n24q02m*