### PR TITLE
[FIX] Clear cached tokens on form submit to force device-code flow

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -4,7 +4,7 @@ import { ImapFlow } from 'imapflow'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { getMarkSetupComplete, resolveCredentialState, setState } from '../credential-state.js'
 import { loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
+import { _resetTokenCache, initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 // Mock dependencies
@@ -35,6 +35,7 @@ vi.mock('../tools/helpers/config.js', () => ({
 }))
 
 vi.mock('../tools/helpers/oauth2.js', () => ({
+  _resetTokenCache: vi.fn(),
   initiateOutlookDeviceCode: vi.fn(),
   isOutlookDomain: vi.fn(),
   saveOutlookTokens: vi.fn()
@@ -228,6 +229,7 @@ describe('http transport', () => {
 
       const result = await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
+      expect(_resetTokenCache).toHaveBeenCalled()
       expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function))
       expect(setState).toHaveBeenCalledWith('setup_in_progress')
       expect(result).toEqual({
@@ -346,6 +348,7 @@ describe('http transport', () => {
 
       const result = await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
+      expect(_resetTokenCache).toHaveBeenCalled()
       expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function))
       expect(result).toEqual({
         type: 'oauth_device_code',

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -34,7 +34,7 @@ import {
 } from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
+import { _resetTokenCache, initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 const SERVER_NAME = 'better-email-mcp'
@@ -153,6 +153,7 @@ function buildOptions(args: {
     creds: Record<string, string>,
     context: SubjectContext
   ): Promise<NextStep | null> => {
+    _resetTokenCache()
     const raw = creds?.EMAIL_CREDENTIALS?.trim()
     if (!raw) {
       return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }


### PR DESCRIPTION
This PR fixes a UX bug where stale cached tokens would bypass the Microsoft device-code flow when submitting the credential form. 

### Changes:
- Modified `src/transports/http.ts` to import `_resetTokenCache` and call it at the beginning of the `onCredentialsSaved` handler.
- Updated `src/transports/http.test.ts` to mock `_resetTokenCache` and added assertions to verify it is called during the credential saving flow.

This ensures that every form submit clears the token cache, forcing `initiateOutlookOAuth` to trigger a fresh device-code flow for Outlook/OAuth2 accounts.

---
*PR created automatically by Jules for task [16320789616772853536](https://jules.google.com/task/16320789616772853536) started by @n24q02m*