### PR TITLE
[FIX] Potential flaky test using setTimeout in http.test.ts

### DIFF
--- a/http_test_fix.diff
+++ b/http_test_fix.diff
@@ -1,0 +1,17 @@
+<<<<<<< SEARCH
+    // Wait for the server to start
+    await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+
+    if (fn) await fn()
+
+    // Trigger shutdown
+    if (sigintHandler) await sigintHandler()
+=======
+    // Wait for the server to start and register shutdown signal handlers
+    await vi.waitFor(() => expect(sigintHandler).toBeInstanceOf(Function))
+
+    if (fn) await fn()
+
+    // Trigger shutdown
+    await sigintHandler()
+>>>>>>> REPLACE

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -102,13 +102,13 @@ describe('http transport', () => {
   async function runStartHttpAndTriggerShutdown(fn?: () => Promise<void>) {
     const startPromise = startHttp()
 
-    // Wait for the server to start
-    await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+    // Wait for the server to start and register shutdown signal handlers
+    await vi.waitFor(() => expect(sigintHandler).toBeInstanceOf(Function))
 
     if (fn) await fn()
 
     // Trigger shutdown
-    if (sigintHandler) await sigintHandler()
+    await sigintHandler()
     await startPromise
   }
 


### PR DESCRIPTION
Refactored `runStartHttpAndTriggerShutdown` in `src/transports/http.test.ts` to improve reliability.
- Replaced the dependency on `runHttpServer` being called with a more robust check for `sigintHandler` being initialized.
- This ensures the server is actually waiting for a signal before the test proceeds to trigger shutdown.
- Verified that all arbitrary `setTimeout` calls are removed from the file.
- Confirmed all tests in `src/transports/http.test.ts` pass and linting is clean.

---
*PR created automatically by Jules for task [7055083667216570937](https://jules.google.com/task/7055083667216570937) started by @n24q02m*