### PR TITLE
[CLEANUP] Use of 'any' Type: buildSearchCriteria

### DIFF
--- a/imap_imports.diff
+++ b/imap_imports.diff
@@ -1,0 +1,13 @@
+<<<<<<< SEARCH
+import { ImapFlow, type SearchObject } from 'imapflow'
+import { type SimpleParserOptions, simpleParser } from 'mailparser'
+=======
+import { type FetchMessageObject, ImapFlow, type ListResponse, type SearchObject } from 'imapflow'
+import {
+  type AddressObject,
+  type Attachment,
+  type EmailAddress,
+  type SimpleParserOptions,
+  simpleParser
+} from 'mailparser'
+>>>>>>> REPLACE

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,8 +3,14 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import { type FetchMessageObject, ImapFlow, type ListResponse, type SearchObject } from 'imapflow'
+import {
+  type AddressObject,
+  type Attachment,
+  type EmailAddress,
+  type SimpleParserOptions,
+  simpleParser
+} from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -145,7 +151,11 @@ function buildSearchCriteria(query: string): SearchObject {
   //    Check longer prefixes first to avoid partial matches (UNFLAGGED before FLAGGED, etc.)
   for (const { pattern, key, value } of FLAG_MATCHERS) {
     if (pattern.test(remaining)) {
-      ;(criteria as any)[key] = value
+      if (key === 'flagged') {
+        criteria.flagged = value
+      } else if (key === 'seen') {
+        criteria.seen = value
+      }
       remaining = remaining.replace(pattern, ' ').trim()
     }
   }
@@ -155,8 +165,12 @@ function buildSearchCriteria(query: string): SearchObject {
     const { valid, invalid } = DATE_MATCHERS[keyword]
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
-      const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = new Date(dateMatch[1]!)
+      const dateValue = new Date(dateMatch[1]!)
+      if (keyword === 'SINCE') {
+        criteria.since = dateValue
+      } else {
+        criteria.before = dateValue
+      }
       remaining = remaining.replace(dateMatch[0], ' ').trim()
     } else if (invalid.test(remaining)) {
       throw new EmailMCPError(
@@ -171,8 +185,12 @@ function buildSearchCriteria(query: string): SearchObject {
   for (const keyword of ['FROM', 'TO'] as const) {
     const kvMatch = remaining.match(KV_MATCHERS[keyword])
     if (kvMatch) {
-      const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = kvMatch[1]!.replace(/^["']|["']$/g, '')
+      const value = kvMatch[1]!.replace(/^["']|["']$/g, '')
+      if (keyword === 'FROM') {
+        criteria.from = value
+      } else {
+        criteria.to = value
+      }
       remaining = remaining.replace(kvMatch[0], ' ').trim()
     }
   }
@@ -236,12 +254,15 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+function formatAddress(addr: AddressObject | AddressObject[] | string | undefined): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
+  if (Array.isArray(addr)) {
+    return addr.map((a) => formatAddress(a)).join(', ')
+  }
   if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+  if (addr.value && Array.isArray(addr.value)) {
+    return addr.value.map((a: EmailAddress) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
   }
   return ''
 }
@@ -365,7 +386,7 @@ export async function searchEmails(
       // This ensures the IMAP connection and mailbox lock are released as quickly as possible.
       // We use `mapLimit` with a concurrency of 5 instead of a sequential for...of loop or unbounded Promise.all
       // to improve performance without blocking the event loop or causing memory spikes from CPU-heavy MIME parsing.
-      const summaries = await mapLimit(emails, 5, async (msg: any) => {
+      const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {
         const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
         return {
@@ -377,7 +398,7 @@ export async function searchEmails(
           from: msg.envelope?.from?.[0]
             ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
             : '',
-          to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
+          to: msg.envelope?.to?.map((a) => a.address).join(', ') || '',
           date: msg.envelope?.date?.toISOString() || '',
           flags: Array.from((msg.flags as Set<string> | string[]) || []),
           snippet
@@ -447,7 +468,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,
@@ -529,7 +550,7 @@ export async function trashEmails(
 export async function listFolders(account: AccountConfig): Promise<FolderInfo[]> {
   return withConnection(account, async (client) => {
     const mailboxes = await client.list()
-    return mailboxes.map((mb: any) => ({
+    return mailboxes.map((mb: ListResponse) => ({
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),


### PR DESCRIPTION
Refactored `src/tools/helpers/imap-client.ts` to remove `any` type usages and replace them with specific types from `imapflow` and `mailparser`. 

Key changes:
- Imported `FetchMessageObject`, `ListResponse`, and `SearchObject` from `imapflow`.
- Imported `AddressObject`, `Attachment`, and `EmailAddress` from `mailparser`.
- Refactored `buildSearchCriteria` to use explicit property assignments on the `SearchObject` instead of dynamic key assignments with `any` casts.
- Refactored `formatAddress` to use a type-safe signature `AddressObject | AddressObject[] | string | undefined` and implemented recursive handling.
- Updated `searchEmails`, `readEmail`, and `listFolders` to use specific types in their mapping and callback functions.
- Verified all changes with `bun run check` (linting + type-checking) and unit tests.

---
*PR created automatically by Jules for task [12129313353001721112](https://jules.google.com/task/12129313353001721112) started by @n24q02m*