### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1130,6 +1130,10 @@ describe('initiateOutlookDeviceCode', () => {
 
     await expect(initiateOutlookDeviceCode('bad@outlook.com')).rejects.toThrow('Unknown client ID')
   })
+
+  it('throws error if email is empty', async () => {
+    await expect(initiateOutlookDeviceCode('')).rejects.toThrow('Email is required')
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -357,6 +357,9 @@ export async function initiateOutlookDeviceCode(
   email: string,
   onComplete?: () => void
 ): Promise<{ verificationUri: string; userCode: string; expiresIn: number; interval: number }> {
+  if (!email) {
+    throw new Error('Email is required')
+  }
   const emailKey = email.toLowerCase()
   const existing = pendingAuths.get(emailKey)
   if (existing && existing.expiresAt > Date.now()) {


### PR DESCRIPTION
This PR addresses a missing edge case in `src/tools/helpers/oauth2.ts`.
- Added validation to `initiateOutlookDeviceCode` to throw an error if the `email` parameter is empty.
- Added a corresponding test case in `src/tools/helpers/oauth2.test.ts` to ensure the error is thrown as expected.
- Verified all tests pass and the codebase is compliant with linting/type-checking.

---
*PR created automatically by Jules for task [5581661842794447727](https://jules.google.com/task/5581661842794447727) started by @n24q02m*