### PR TITLE
[FIX] Clear cached tokens on form submit to force device-code flow

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -4,7 +4,7 @@ import { ImapFlow } from 'imapflow'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { getMarkSetupComplete, resolveCredentialState, setState } from '../credential-state.js'
 import { loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
+import { _resetTokenCache, initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 // Mock dependencies
@@ -35,6 +35,7 @@ vi.mock('../tools/helpers/config.js', () => ({
 }))
 
 vi.mock('../tools/helpers/oauth2.js', () => ({
+  _resetTokenCache: vi.fn(),
   initiateOutlookDeviceCode: vi.fn(),
   isOutlookDomain: vi.fn(),
   saveOutlookTokens: vi.fn()
@@ -228,6 +229,7 @@ describe('http transport', () => {
 
       const result = await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
+      expect(_resetTokenCache).toHaveBeenCalled()
       expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function))
       expect(setState).toHaveBeenCalledWith('setup_in_progress')
       expect(result).toEqual({
@@ -346,6 +348,7 @@ describe('http transport', () => {
 
       const result = await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
+      expect(_resetTokenCache).toHaveBeenCalled()
       expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function))
       expect(result).toEqual({
         type: 'oauth_device_code',

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -34,7 +34,7 @@ import {
 } from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
+import { _resetTokenCache, initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 const SERVER_NAME = 'better-email-mcp'
@@ -153,6 +153,9 @@ function buildOptions(args: {
     creds: Record<string, string>,
     context: SubjectContext
   ): Promise<NextStep | null> => {
+    // Force fresh device-code flow by clearing memory cache on every submit.
+    _resetTokenCache()
+
     const raw = creds?.EMAIL_CREDENTIALS?.trim()
     if (!raw) {
       return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }


### PR DESCRIPTION
This PR fixes a UX bug where stale tokens from a previous session could bypass the Microsoft device-code flow during form submission. By calling `_resetTokenCache()` at the start of `onCredentialsSaved`, we ensure that a fresh authentication flow is always initiated when the user submits their credentials. This has been verified with updated tests in `src/transports/http.test.ts`.

---
*PR created automatically by Jules for task [6622523209011169170](https://jules.google.com/task/6622523209011169170) started by @n24q02m*