### PR TITLE
[CLEANUP] Use of 'any' Type: enhanceError

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -25,22 +25,32 @@ export class EmailMCPError extends Error {
   }
 }
 
+export interface RawError {
+  message?: string
+  name?: string
+  code?: string | number
+  status?: number
+  responseCode?: number
+  authenticationFailed?: boolean
+}
+
 /**
  * Sanitize error object to remove sensitive information (passwords, tokens)
  */
-function sanitizeErrorDetails(error: unknown): unknown {
+export function sanitizeErrorDetails(error: unknown): unknown {
   if (error === null || typeof error !== 'object') {
     return error
   }
 
   const errObj = error as Record<string, unknown>
   const safe: Record<string, unknown> = {}
+  const whitelist = ['message', 'name', 'code', 'status', 'responseCode']
 
-  if ('message' in errObj) safe.message = errObj.message
-  if ('name' in errObj) safe.name = errObj.name
-  if ('code' in errObj) safe.code = errObj.code
-  if ('status' in errObj) safe.status = errObj.status
-  if ('responseCode' in errObj) safe.responseCode = errObj.responseCode
+  for (const key of whitelist) {
+    if (key in errObj) {
+      safe[key] = errObj[key]
+    }
+  }
 
   return safe
 }
@@ -53,8 +63,10 @@ export function enhanceError(error: unknown): EmailMCPError {
     return error
   }
 
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
-  const message = typeof errObj.message === 'string' ? errObj.message : 'Unknown error occurred'
+  const errObj =
+    error !== null && typeof error === 'object' ? (error as RawError) : { message: String(error || 'Unknown error') }
+
+  const message = errObj.message || 'Unknown error occurred'
 
   // IMAP authentication errors
   if (
@@ -123,7 +135,7 @@ export function enhanceError(error: unknown): EmailMCPError {
  * Handle SMTP-specific errors
  */
 function handleSmtpError(error: unknown): EmailMCPError {
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
+  const errObj = error !== null && typeof error === 'object' ? (error as RawError) : {}
   const code = errObj.responseCode as number
 
   switch (code) {
@@ -269,10 +281,10 @@ export function suggestFixes(error: EmailMCPError): string[] {
 /**
  * Wrap async function with error handling
  */
-export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(
-  fn: T
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+export function withErrorHandling<Args extends unknown[], R>(
+  fn: (...args: Args) => Promise<R>
+): (...args: Args) => Promise<R> {
+  return async (...args: Args): Promise<R> => {
     try {
       return await fn(...args)
     } catch (error) {


### PR DESCRIPTION
This PR refactors the error handling utilities in \`src/tools/helpers/errors.ts\` to eliminate the use of the \`any\` type. Key changes include:
- Defining a \`RawError\` interface for consistent and type-safe access to properties of errors from external libraries.
- Refactoring \`enhanceError\` and \`handleSmtpError\` to use \`RawError\` and properly handle non-object error inputs.
- Refactoring \`withErrorHandling\` using generics to provide full type safety for wrapped async functions.
- Exporting and improving \`sanitizeErrorDetails\` with a whitelist-based sanitization approach.
These changes improve type safety, maintainability, and error reporting consistency across the email MCP tools.

---
*PR created automatically by Jules for task [7393848435061561140](https://jules.google.com/task/7393848435061561140) started by @n24q02m*