### PR TITLE
[FIX] Long Function: parseSingleCredential

### DIFF
--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -130,6 +130,87 @@ function isSmtpSecurity(segment: string): segment is SmtpSecurity {
 }
 
 /**
+ * Helper: an "all-digit" segment looks like a port attempt
+ */
+const isPortSegment = (s: string) => /^\d+$/.test(s)
+
+/**
+ * Extract SMTP segments from the end of the tail array if present.
+ * Uses .pop() to mutate the array.
+ */
+function extractSmtpSegments(tail: string[]): {
+  host?: string
+  port?: number
+  security?: SmtpSecurity
+} {
+  let security: SmtpSecurity | undefined
+  let host: string | undefined
+  let port: number | undefined
+
+  // 1. Optional SMTP security keyword at end (only valid when an SMTP host
+  //    can also be detected; otherwise the keyword belongs to the password).
+  let popped_security = false
+  if (tail.length >= 4 && isSmtpSecurity(tail.at(-1)!)) {
+    security = tail.at(-1)!.toLowerCase() as SmtpSecurity
+    tail.pop()
+    popped_security = true
+  }
+
+  // 2. SMTP host + port (host:port pair). Detected only when tail has BOTH:
+  //    - tail.at(-1) is all-digit (a port attempt)
+  //    - tail.at(-2) is a host
+  //    AND there's another preceding host (the IMAP host) — otherwise the
+  //    "host:port" we see IS the IMAP host:port and there's no SMTP suffix.
+  const canHaveSmtpHostPort =
+    tail.length >= 5 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!) && looksLikeHost(tail.at(-4) ?? '')
+  if (canHaveSmtpHostPort) {
+    port = parsePort(tail.at(-1)!)
+    tail.pop()
+    host = tail.pop()
+  }
+
+  // 3. SMTP host without explicit port (only valid when security was popped
+  //    OR when there's an explicit IMAP host:port already detected).
+  if (!host && popped_security && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
+    host = tail.pop()
+  }
+
+  // If security keyword was tentatively popped but no SMTP host was found,
+  // restore it — the keyword is part of the password.
+  if (popped_security && !host) {
+    tail.push(security!)
+    security = undefined
+  }
+
+  return { host, port, security }
+}
+
+/**
+ * Extract IMAP segments from the end of the tail array if present.
+ * Uses .pop() to mutate the array.
+ */
+function extractImapSegments(tail: string[]): {
+  host?: string
+  port?: number
+} {
+  let host: string | undefined
+  let port: number | undefined
+
+  // 4. IMAP host + port (port may be out-of-range; resolveServerConfig
+  //    falls back to default 993 when port is undefined).
+  if (tail.length >= 3 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!)) {
+    port = parsePort(tail.at(-1)!)
+    tail.pop()
+    host = tail.pop()
+  } else if (looksLikeHost(tail.at(-1)!)) {
+    // Trailing host segment, default IMAP port
+    host = tail.pop()
+  }
+
+  return { host, port }
+}
+
+/**
  * Parse password, custom IMAP/SMTP host+port from the colon-separated
  * segments of a credential entry (`parts[0]` is the email).
  *
@@ -162,74 +243,23 @@ function parsePasswordAndHost(parts: string[]): {
 
   // Mutable tail; pop SMTP, then IMAP, then rest is password.
   const tail = parts.slice(1)
-  let smtpSecurity: SmtpSecurity | undefined
-  let smtpHost: string | undefined
-  let smtpPort: number | undefined
-  let imapHost: string | undefined
-  let imapPort: number | undefined
 
-  // 1. Optional SMTP security keyword at end (only valid when an SMTP host
-  //    can also be detected; otherwise the keyword belongs to the password).
-  //    We tentatively pop + restore if SMTP host parsing fails.
-  let popped_security = false
-  if (tail.length >= 4 && isSmtpSecurity(tail.at(-1)!)) {
-    smtpSecurity = tail.at(-1)!.toLowerCase() as SmtpSecurity
-    tail.pop()
-    popped_security = true
-  }
+  // 1-3. SMTP segments
+  const smtp = extractSmtpSegments(tail)
 
-  // Helper: an "all-digit" segment looks like a port attempt (even if value
-  // is out-of-range, in which case parsePort returns undefined and the
-  // caller falls back to the protocol-default port).
-  const isPortSegment = (s: string) => /^\d+$/.test(s)
-
-  // 2. SMTP host + port (host:port pair). Detected only when tail has BOTH:
-  //    - tail.at(-1) is all-digit (a port attempt)
-  //    - tail.at(-2) is a host
-  //    AND there's another preceding host (the IMAP host) — otherwise the
-  //    "host:port" we see IS the IMAP host:port and there's no SMTP suffix.
-  const canHaveSmtpHostPort =
-    tail.length >= 5 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!) && looksLikeHost(tail.at(-4) ?? '') // ensure there's an IMAP host before
-  if (canHaveSmtpHostPort) {
-    smtpPort = parsePort(tail.at(-1)!) // may be undefined if out-of-range → buildSmtpConfig defaults
-    tail.pop()
-    smtpHost = tail.pop()
-  }
-
-  // 3. SMTP host without explicit port (only valid when security was popped
-  //    OR when there's an explicit IMAP host:port already detected).
-  if (!smtpHost && popped_security && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
-    smtpHost = tail.pop()
-  }
-
-  // If security keyword was tentatively popped but no SMTP host was found,
-  // restore it — the keyword is part of the password.
-  if (popped_security && !smtpHost) {
-    tail.push(smtpSecurity!)
-    smtpSecurity = undefined
-  }
-
-  // 4. IMAP host + port (port may be out-of-range; resolveServerConfig
-  //    falls back to default 993 when port is undefined).
-  if (tail.length >= 3 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!)) {
-    imapPort = parsePort(tail.at(-1)!)
-    tail.pop()
-    imapHost = tail.pop()
-  } else if (looksLikeHost(tail.at(-1)!)) {
-    // Trailing host segment, default IMAP port
-    imapHost = tail.pop()
-  }
+  // 4. IMAP segments
+  const imap = extractImapSegments(tail)
 
   // 5. Whatever remains (after the email shift) is the password.
   const password = tail.join(':')
 
   return {
     password,
-    customImapHost: imapHost,
-    customImapPort: imapPort,
-    customSmtpHost: smtpHost,
-    customSmtpPort: smtpPort,
-    customSmtpSecurity: smtpSecurity
+    customImapHost: imap.host,
+    customImapPort: imap.port,
+    customSmtpHost: smtp.host,
+    customSmtpPort: smtp.port,
+    customSmtpSecurity: smtp.security
   }
 }
 
@@ -342,7 +372,7 @@ async function parseSingleCredential(entry: string): Promise<AccountConfig | nul
   const parts = trimmed.split(':')
   const email = parts[0]!.trim()
 
-  // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
+  // 1. Handle email-only entries (OAuth2)
   if (parts.length < 2) {
     const account = await createOAuth2Account(email)
     if (account) return account
@@ -351,32 +381,32 @@ async function parseSingleCredential(entry: string): Promise<AccountConfig | nul
     return null
   }
 
-  const { password, customImapHost, customImapPort, customSmtpHost, customSmtpPort, customSmtpSecurity } =
-    parsePasswordAndHost(parts)
+  // 2. Parse password and server overrides
+  const creds = parsePasswordAndHost(parts)
 
-  // Auto-discover or use custom host (SMTP override applied if provided)
+  // 3. Resolve server settings (auto-discover or custom)
   const servers = resolveServerConfig(
     email,
-    customImapHost,
-    customImapPort,
-    customSmtpHost,
-    customSmtpPort,
-    customSmtpSecurity
+    creds.customImapHost,
+    creds.customImapPort,
+    creds.customSmtpHost,
+    creds.customSmtpPort,
+    creds.customSmtpSecurity
   )
   if (!servers) return null
 
+  // 4. Build account config
   const account: AccountConfig = {
     id: emailToId(email),
     email,
-    password,
+    password: creds.password,
     authType: 'password',
     imap: servers.imap,
     smtp: servers.smtp
   }
 
-  // Outlook domains use OAuth2 by default. An explicit custom IMAP host means
-  // the account is routed through a proxy with password auth — honour that.
-  if (!customImapHost) {
+  // 5. Post-process for Outlook (OAuth2 default)
+  if (!creds.customImapHost) {
     await applyOutlookOAuth2(account)
   }
 


### PR DESCRIPTION
Refactored \`parsePasswordAndHost\` and \`parseSingleCredential\` in \`src/tools/helpers/config.ts\` to improve maintainability and readability.

Key changes:
- Extracted \`extractSmtpSegments\` and \`extractImapSegments\` helper functions from \`parsePasswordAndHost\`.
- Improved the structure of \`parseSingleCredential\` by breaking it down into clear, commented steps.
- Maintained the "greedy from the end" parsing strategy to preserve backward compatibility for passwords with colons.
- Verified that all 59 tests in \`src/tools/helpers/config.test.ts\` pass and that \`bun run check\` succeeds.

---
*PR created automatically by Jules for task [13360967407195011268](https://jules.google.com/task/13360967407195011268) started by @n24q02m*