### PR TITLE
[CLEANUP] Use of 'any' Type: formatAddress

### DIFF
--- a/src/tools/helpers/format-address.test.ts
+++ b/src/tools/helpers/format-address.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { formatAddress } from './imap-client.js'
+
+describe('formatAddress', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(formatAddress(null)).toBe('')
+    expect(formatAddress(undefined)).toBe('')
+  })
+
+  it('returns string as is', () => {
+    expect(formatAddress('test@example.com')).toBe('test@example.com')
+  })
+
+  it('returns addr.text if available', () => {
+    expect(formatAddress({ text: 'User <test@example.com>' })).toBe('User <test@example.com>')
+  })
+
+  it('formats addr.value array correctly', () => {
+    const addr = {
+      value: [
+        { name: 'User', address: 'test@example.com' },
+        { name: '', address: 'no-name@example.com' }
+      ]
+    }
+    expect(formatAddress(addr)).toBe('User <test@example.com>, no-name@example.com')
+  })
+
+  it('handles empty value array', () => {
+    expect(formatAddress({ value: [] })).toBe('')
+  })
+
+  it('handles array of AddressObjects', () => {
+    const validAddrs = [{ text: 'User 1 <user1@test.com>' }, { value: [{ name: 'User 2', address: 'user2@test.com' }] }]
+    expect(formatAddress(validAddrs)).toBe('User 1 <user1@test.com>, User 2 <user2@test.com>')
+  })
+
+  it('returns empty string for unknown objects', () => {
+    expect(formatAddress({} as any)).toBe('')
+  })
+})

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,7 +3,7 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow'
+import { type FetchMessageObject, ImapFlow, type MessageAddressObject, type SearchObject } from 'imapflow'
 import { type SimpleParserOptions, simpleParser } from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
@@ -145,7 +145,7 @@ function buildSearchCriteria(query: string): SearchObject {
   //    Check longer prefixes first to avoid partial matches (UNFLAGGED before FLAGGED, etc.)
   for (const { pattern, key, value } of FLAG_MATCHERS) {
     if (pattern.test(remaining)) {
-      ;(criteria as any)[key] = value
+      ;(criteria as unknown as Record<string, boolean>)[key] = value
       remaining = remaining.replace(pattern, ' ').trim()
     }
   }
@@ -156,7 +156,7 @@ function buildSearchCriteria(query: string): SearchObject {
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = new Date(dateMatch[1]!)
+      ;(criteria as unknown as Record<string, Date>)[criteriaKey] = new Date(dateMatch[1]!)
       remaining = remaining.replace(dateMatch[0], ' ').trim()
     } else if (invalid.test(remaining)) {
       throw new EmailMCPError(
@@ -234,14 +234,37 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 }
 
 /**
+ * Represents an address component (name and email)
+ */
+export interface AddressComponent {
+  name?: string
+  address?: string
+}
+
+/**
+ * Represents an address object from mailparser
+ */
+export interface AddressObject {
+  value?: AddressComponent[]
+  text?: string
+  html?: string
+}
+
+/**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+export function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
+  if (Array.isArray(addr)) {
+    return addr.map((a) => formatAddress(a)).join(', ')
+  }
   if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+  if (addr.value && Array.isArray(addr.value)) {
+    return addr.value
+      .map((a: AddressComponent) => (a.name ? `${a.name} <${a.address}>` : a.address))
+      .filter(Boolean)
+      .join(', ')
   }
   return ''
 }
@@ -365,7 +388,7 @@ export async function searchEmails(
       // This ensures the IMAP connection and mailbox lock are released as quickly as possible.
       // We use `mapLimit` with a concurrency of 5 instead of a sequential for...of loop or unbounded Promise.all
       // to improve performance without blocking the event loop or causing memory spikes from CPU-heavy MIME parsing.
-      const summaries = await mapLimit(emails, 5, async (msg: any) => {
+      const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {
         const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
         return {
@@ -377,7 +400,11 @@ export async function searchEmails(
           from: msg.envelope?.from?.[0]
             ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
             : '',
-          to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
+          to:
+            msg.envelope?.to
+              ?.map((a: MessageAddressObject) => a.address)
+              .filter(Boolean)
+              .join(', ') || '',
           date: msg.envelope?.date?.toISOString() || '',
           flags: Array.from((msg.flags as Set<string> | string[]) || []),
           snippet
@@ -447,7 +474,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,
@@ -529,7 +556,7 @@ export async function trashEmails(
 export async function listFolders(account: AccountConfig): Promise<FolderInfo[]> {
   return withConnection(account, async (client) => {
     const mailboxes = await client.list()
-    return mailboxes.map((mb: any) => ({
+    return mailboxes.map((mb) => ({
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),


### PR DESCRIPTION
This PR addresses the use of the `any` type in the `formatAddress` function and surrounding code in `src/tools/helpers/imap-client.ts`.

### Changes:
- Defined `AddressObject` and `AddressComponent` interfaces to replace `any` in `formatAddress`.
- Exported `formatAddress` for better utility usage and testing.
- Refactored `formatAddress` to support recursive formatting for arrays of address objects.
- Replaced multiple other instances of `any` in `src/tools/helpers/imap-client.ts` using types from `imapflow` (`FetchMessageObject`, `MessageAddressObject`) and `mailparser`.
- Improved type safety in `buildSearchCriteria` by using `unknown` and `Record<string, ...>` instead of `any`.
- Added a new test file `src/tools/helpers/format-address.test.ts` to verify the refactored function.

All linting (`biome check`) and type checks (`tsc --noEmit`) pass. Existing IMAP client tests also pass.

---
*PR created automatically by Jules for task [9499212528087244384](https://jules.google.com/task/9499212528087244384) started by @n24q02m*