### PR TITLE
[FIX] Potential flaky test using setTimeout in http.test.ts

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -102,8 +102,8 @@ describe('http transport', () => {
   async function runStartHttpAndTriggerShutdown(fn?: () => Promise<void>) {
     const startPromise = startHttp()
 
-    // Wait for the server to start
-    await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+    // Wait for the server to start and signal handlers to be registered
+    await vi.waitFor(() => expect(sigintHandler).toBeTruthy())
 
     if (fn) await fn()
 
@@ -137,16 +137,18 @@ describe('http transport', () => {
 
   describe('onCredentialsSaved', () => {
     let onCredentialsSaved: any
+    let startPromise: Promise<void>
 
     beforeEach(async () => {
       // Start server and capture the callback
-      startHttp()
-      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+      startPromise = startHttp()
+      await vi.waitFor(() => expect(sigintHandler).toBeTruthy())
       onCredentialsSaved = vi.mocked(runHttpServer).mock.calls[0][1].onCredentialsSaved
     })
 
     afterEach(async () => {
       if (sigintHandler) await sigintHandler()
+      await startPromise
     })
 
     it('returns error if EMAIL_CREDENTIALS is missing', async () => {
@@ -383,7 +385,7 @@ describe('http transport', () => {
       vi.mocked(loadConfig).mockResolvedValue(mockAccounts as any)
 
       const startPromise = startHttp()
-      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+      await vi.waitFor(() => expect(sigintHandler).toBeTruthy())
 
       const factory = vi.mocked(runHttpServer).mock.calls[0][0]
 


### PR DESCRIPTION
The HTTP transport tests were using an imprecise synchronization mechanism, waiting only for the `runHttpServer` mock to be called. This created a race condition where tests could attempt to trigger a shutdown signal before the server had actually registered its signal handlers, leading to flakiness.

Changes:
1.  **Deterministic Synchronization:** Replaced `await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())` with `await vi.waitFor(() => expect(sigintHandler).toBeTruthy())`. Since `sigintHandler` is assigned inside the `process.once` mock within `startHttp` (after server setup), this ensures the server is fully ready.
2.  **Promise Leak Fix:** In the `onCredentialsSaved` test suite, the `startHttp` promise was being ignored. It is now stored and explicitly awaited in `afterEach` to ensure clean test isolation and prevent unhandled promise rejections.
3.  **Code Cleanup:** Improved comments explaining the synchronization strategy.

Verified with `bun run test src/transports/http.test.ts` (all 14 tests passing) and `bun run check`.

---
*PR created automatically by Jules for task [4101854864630014](https://jules.google.com/task/4101854864630014) started by @n24q02m*