### PR TITLE
[SECURITY] Unvalidated JSON Parsing in Credential Store

### DIFF
--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -194,7 +194,7 @@ export async function loadUserCredentials(userId: string): Promise<AccountConfig
       new Uint8Array(ciphertext)
     )
     const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-    if (!isValidAccountConfigs(parsed.accounts)) {
+    if (!parsed || typeof parsed !== 'object' || !isValidAccountConfigs(parsed.accounts)) {
       throw new Error('Invalid account configuration in stored credentials')
     }
     return parsed.accounts
@@ -242,7 +242,12 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
         new Uint8Array(ciphertext)
       )
       const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-      if (typeof parsed.userId === 'string' && isValidAccountConfigs(parsed.accounts)) {
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof parsed.userId === 'string' &&
+        isValidAccountConfigs(parsed.accounts)
+      ) {
         result.set(parsed.userId, parsed.accounts)
       }
     } catch (err: unknown) {


### PR DESCRIPTION
Added non-null object validation checks after parsing JSON in `loadUserCredentials` and `loadAllUserCredentials` within `src/auth/per-user-credential-store.ts`. This addresses a security vulnerability where unvalidated JSON parsing could lead to crashes or type confusion from unexpected data payloads.

---
*PR created automatically by Jules for task [15257868486694033572](https://jules.google.com/task/15257868486694033572) started by @n24q02m*