### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1130,6 +1130,10 @@ describe('initiateOutlookDeviceCode', () => {
 
     await expect(initiateOutlookDeviceCode('bad@outlook.com')).rejects.toThrow('Unknown client ID')
   })
+
+  it('throws "Email is required" when email is an empty string', async () => {
+    await expect(initiateOutlookDeviceCode('')).rejects.toThrow('Email is required')
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -357,6 +357,9 @@ export async function initiateOutlookDeviceCode(
   email: string,
   onComplete?: () => void
 ): Promise<{ verificationUri: string; userCode: string; expiresIn: number; interval: number }> {
+  if (!email) {
+    throw new Error('Email is required')
+  }
   const emailKey = email.toLowerCase()
   const existing = pendingAuths.get(emailKey)
   if (existing && existing.expiresAt > Date.now()) {


### PR DESCRIPTION
Added input validation for the `email` parameter in `initiateOutlookDeviceCode` to ensure it is not empty, and added a corresponding unit test to verify the fix. This addresses a missing edge case in the OAuth2 helper.

---
*PR created automatically by Jules for task [10036788541889130746](https://jules.google.com/task/10036788541889130746) started by @n24q02m*