### PR TITLE
[CLEANUP] Use of 'any' Type: buildSearchCriteria

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,8 +3,14 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import {
+  type FetchMessageObject,
+  ImapFlow,
+  type ListResponse,
+  type MessageAddressObject,
+  type SearchObject
+} from 'imapflow'
+import { type AddressObject, type Attachment, type SimpleParserOptions, simpleParser } from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -110,7 +116,11 @@ async function withConnection<T>(account: AccountConfig, fn: (client: ImapFlow) 
  */
 // Pre-compile static RegExp patterns as module-level constants so
 // buildSearchCriteria does not recompile them per call.
-const FLAG_MATCHERS: ReadonlyArray<{ pattern: RegExp; key: keyof SearchObject; value: boolean }> = [
+const FLAG_MATCHERS: ReadonlyArray<{
+  pattern: RegExp
+  key: 'flagged' | 'seen'
+  value: boolean
+}> = [
   { pattern: /\bUNFLAGGED\b/i, key: 'flagged', value: false },
   { pattern: /\bUNSTARRED\b/i, key: 'flagged', value: false },
   { pattern: /\bUNREAD\b/i, key: 'seen', value: false },
@@ -122,13 +132,13 @@ const FLAG_MATCHERS: ReadonlyArray<{ pattern: RegExp; key: keyof SearchObject; v
 ]
 
 const DATE_MATCHERS = {
-  SINCE: { valid: /\bSINCE\s+(\d{4}-\d{2}-\d{2})\b/i, invalid: /\bSINCE\s+\S/i },
-  BEFORE: { valid: /\bBEFORE\s+(\d{4}-\d{2}-\d{2})\b/i, invalid: /\bBEFORE\s+\S/i }
+  SINCE: { valid: /\bSINCE\s+(\d{4}-\d{2}-\d{2})\b/i, invalid: /\bSINCE\s+\S/i, key: 'since' },
+  BEFORE: { valid: /\bBEFORE\s+(\d{4}-\d{2}-\d{2})\b/i, invalid: /\bBEFORE\s+\S/i, key: 'before' }
 } as const
 
 const KV_MATCHERS = {
-  FROM: /\bFROM\s+("[^"]+"|'[^']+'|\S+)/i,
-  TO: /\bTO\s+("[^"]+"|'[^']+'|\S+)/i
+  FROM: { pattern: /\bFROM\s+("[^"]+"|'[^']+'|\S+)/i, key: 'from' },
+  TO: { pattern: /\bTO\s+("[^"]+"|'[^']+'|\S+)/i, key: 'to' }
 } as const
 
 function buildSearchCriteria(query: string): SearchObject {
@@ -145,18 +155,17 @@ function buildSearchCriteria(query: string): SearchObject {
   //    Check longer prefixes first to avoid partial matches (UNFLAGGED before FLAGGED, etc.)
   for (const { pattern, key, value } of FLAG_MATCHERS) {
     if (pattern.test(remaining)) {
-      ;(criteria as any)[key] = value
+      criteria[key] = value
       remaining = remaining.replace(pattern, ' ').trim()
     }
   }
 
   // 2. Extract date clauses: SINCE YYYY-MM-DD, BEFORE YYYY-MM-DD
   for (const keyword of ['SINCE', 'BEFORE'] as const) {
-    const { valid, invalid } = DATE_MATCHERS[keyword]
+    const { valid, invalid, key } = DATE_MATCHERS[keyword]
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
-      const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = new Date(dateMatch[1]!)
+      criteria[key] = new Date(dateMatch[1]!)
       remaining = remaining.replace(dateMatch[0], ' ').trim()
     } else if (invalid.test(remaining)) {
       throw new EmailMCPError(
@@ -169,10 +178,10 @@ function buildSearchCriteria(query: string): SearchObject {
 
   // 3. Extract FROM / TO (single token or quoted string)
   for (const keyword of ['FROM', 'TO'] as const) {
-    const kvMatch = remaining.match(KV_MATCHERS[keyword])
+    const { pattern, key } = KV_MATCHERS[keyword]
+    const kvMatch = remaining.match(pattern)
     if (kvMatch) {
-      const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = kvMatch[1]!.replace(/^["']|["']$/g, '')
+      criteria[key] = kvMatch[1]!.replace(/^["']|["']$/g, '')
       remaining = remaining.replace(kvMatch[0], ' ').trim()
     }
   }
@@ -236,13 +245,23 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+export function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
-  if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+
+  if (Array.isArray(addr)) {
+    return addr.map((a) => formatAddress(a)).join(', ')
   }
+
+  if (addr.text) return addr.text
+
+  if (Array.isArray(addr.value)) {
+    return addr.value
+      .map((a: { name?: string; address?: string }) => (a.name ? `${a.name} <${a.address}>` : a.address))
+      .filter(Boolean)
+      .join(', ')
+  }
+
   return ''
 }
 
@@ -365,7 +384,7 @@ export async function searchEmails(
       // This ensures the IMAP connection and mailbox lock are released as quickly as possible.
       // We use `mapLimit` with a concurrency of 5 instead of a sequential for...of loop or unbounded Promise.all
       // to improve performance without blocking the event loop or causing memory spikes from CPU-heavy MIME parsing.
-      const summaries = await mapLimit(emails, 5, async (msg: any) => {
+      const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {
         const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
         return {
@@ -377,8 +396,8 @@ export async function searchEmails(
           from: msg.envelope?.from?.[0]
             ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
             : '',
-          to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
-          date: msg.envelope?.date?.toISOString() || '',
+          to: msg.envelope?.to?.map((a: MessageAddressObject) => a.address).join(', ') || '',
+          date: msg.envelope?.date instanceof Date ? msg.envelope.date.toISOString() : '',
           flags: Array.from((msg.flags as Set<string> | string[]) || []),
           snippet
         }
@@ -447,7 +466,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,
@@ -529,7 +548,7 @@ export async function trashEmails(
 export async function listFolders(account: AccountConfig): Promise<FolderInfo[]> {
   return withConnection(account, async (client) => {
     const mailboxes = await client.list()
-    return mailboxes.map((mb: any) => ({
+    return mailboxes.map((mb: ListResponse) => ({
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),


### PR DESCRIPTION
This PR refactors \`src/tools/helpers/imap-client.ts\` to improve type safety by replacing the \`any\` type with specific interfaces and types from the \`imapflow\` and \`mailparser\` libraries.

### Key Changes:
- **buildSearchCriteria**: Refactored to remove \`as any\` casts by using explicit property assignments and updating matcher constants (\`FLAG_MATCHERS\`, \`DATE_MATCHERS\`, \`KV_MATCHERS\`) to include \`SearchObject\` keys.
- **formatAddress**: Updated signature to accept \`AddressObject | AddressObject[] | string | undefined | null\` and implemented safe, recursive formatting without \`any\`.
- **Other Functions**: Replaced \`any\` with \`FetchMessageObject\`, \`ListResponse\`, \`MessageAddressObject\`, and \`Attachment\` in \`searchEmails\`, \`readEmail\`, and \`listFolders\`.
- **Imports**: Added necessary type imports from \`imapflow\` and \`mailparser\`.

### Verification:
- Ran \`bun run check\` (Biome lint + TSC type-check) - Passed.
- Ran \`bun run test\` (Vitest) - All 590 tests passed.
- Verified that no \`any\` types remain in the file (checked via grep).

---
*PR created automatically by Jules for task [11667366446818553937](https://jules.google.com/task/11667366446818553937) started by @n24q02m*