### PR TITLE
[PERF] Use asynchronous file reading in saveTokens

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -7,7 +7,9 @@ vi.mock('@n24q02m/mcp-core', () => ({
 }))
 
 vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn()
+  readFile: vi.fn(),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined)
 }))
 
 vi.mock('node:fs', () => ({
@@ -23,13 +25,12 @@ vi.mock('node:os', () => ({
 
 const mockTryOpenBrowser = vi.mocked(tryOpenBrowser)
 
-import { readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 
 const mockReadFile = vi.mocked(readFile)
+const mockWriteFile = vi.mocked(writeFile)
+const mockMkdir = vi.mocked(mkdir)
 const mockExistsSync = vi.mocked(existsSync)
-const mockReadFileSync = vi.mocked(readFileSync)
-const mockWriteFileSync = vi.mocked(writeFileSync)
-const mockMkdirSync = vi.mocked(mkdirSync)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -63,35 +64,35 @@ afterEach(() => {
 })
 
 describe('isOutlookDomain', () => {
-  it('detects outlook.com', () => {
+  it('detects outlook.com', async () => {
     expect(isOutlookDomain('user@outlook.com')).toBe(true)
   })
 
-  it('detects hotmail.com', () => {
+  it('detects hotmail.com', async () => {
     expect(isOutlookDomain('user@hotmail.com')).toBe(true)
   })
 
-  it('detects live.com', () => {
+  it('detects live.com', async () => {
     expect(isOutlookDomain('user@live.com')).toBe(true)
   })
 
-  it('rejects gmail.com', () => {
+  it('rejects gmail.com', async () => {
     expect(isOutlookDomain('user@gmail.com')).toBe(false)
   })
 
-  it('rejects yahoo.com', () => {
+  it('rejects yahoo.com', async () => {
     expect(isOutlookDomain('user@yahoo.com')).toBe(false)
   })
 
-  it('handles empty string', () => {
+  it('handles empty string', async () => {
     expect(isOutlookDomain('')).toBe(false)
   })
 
-  it('handles email without domain', () => {
+  it('handles email without domain', async () => {
     expect(isOutlookDomain('nodomain')).toBe(false)
   })
 
-  it('is case-insensitive via domain extraction', () => {
+  it('is case-insensitive via domain extraction', async () => {
     expect(isOutlookDomain('user@OUTLOOK.COM')).toBe(true)
   })
 })
@@ -111,12 +112,12 @@ describe('getClientId', () => {
     }
   })
 
-  it('returns OUTLOOK_CLIENT_ID from env', () => {
+  it('returns OUTLOOK_CLIENT_ID from env', async () => {
     process.env.OUTLOOK_CLIENT_ID = 'test-client-id-123'
     expect(getClientId()).toBe('test-client-id-123')
   })
 
-  it('returns bundled default when OUTLOOK_CLIENT_ID is not set', () => {
+  it('returns bundled default when OUTLOOK_CLIENT_ID is not set', async () => {
     delete process.env.OUTLOOK_CLIENT_ID
     expect(getClientId()).toBe('d56f8c71-9f7c-43f4-9934-be29cb6e77b0')
   })
@@ -192,54 +193,54 @@ describe('saveTokens', () => {
     clientId: 'cid'
   }
 
-  it('creates config directory if not exists', () => {
+  it('creates config directory if not exists', async () => {
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return false
       return false // config dir doesn't exist
     })
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining('.better-email-mcp'), {
+    expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('.better-email-mcp'), {
       recursive: true,
       mode: 0o700
     })
   })
 
-  it('writes tokens with 0600 permissions', () => {
+  it('writes tokens with 0600 permissions', async () => {
     mockExistsSync.mockReturnValue(false)
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
+    expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining('tokens.json'),
       expect.stringContaining('"user@outlook.com"'),
       { mode: 0o600 }
     )
   })
 
-  it('merges with existing tokens', () => {
+  it('merges with existing tokens', async () => {
     const existing = { 'other@hotmail.com': { accessToken: 'old', refreshToken: 'old', expiresAt: 0, clientId: 'c' } }
 
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return true
       return true
     })
-    mockReadFileSync.mockReturnValue(JSON.stringify(existing))
+    mockReadFile.mockResolvedValue(JSON.stringify(existing))
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['other@hotmail.com']).toBeDefined()
     expect(written['user@outlook.com']).toEqual(tokens)
   })
 
-  it('normalizes email to lowercase', () => {
+  it('normalizes email to lowercase', async () => {
     mockExistsSync.mockReturnValue(false)
 
-    saveTokens('User@OUTLOOK.com', tokens)
+    await saveTokens('User@OUTLOOK.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual(tokens)
   })
 })
@@ -401,7 +402,7 @@ describe('ensureValidToken', () => {
 
     await ensureValidToken(account)
 
-    expect(mockWriteFileSync).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalled()
   })
 
   it('loads tokens from disk when not in memory', async () => {
@@ -422,7 +423,7 @@ describe('ensureValidToken', () => {
 
   it('initiates Device Code flow when no tokens exist', async () => {
     // No tokens on disk
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     // Mock device code request
     mockFetch.mockResolvedValueOnce({
@@ -445,7 +446,7 @@ describe('ensureValidToken', () => {
   })
 
   it('opens browser when initiating Device Code flow', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -469,7 +470,7 @@ describe('ensureValidToken', () => {
   })
 
   it('does not open browser on retry (reuses pending auth)', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -497,7 +498,7 @@ describe('ensureValidToken', () => {
   })
 
   it('reuses pending auth code on retry', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     // First call: device code request
     mockFetch.mockResolvedValueOnce({
@@ -602,7 +603,7 @@ describe('deviceCodeAuth', () => {
     expect(tokens.accessToken).toBe('at-success')
     expect(tokens.refreshToken).toBe('rt-success')
     expect(tokens.clientId).toBe('test-client-id')
-    expect(mockWriteFileSync).toHaveBeenCalled() // Tokens saved
+    expect(mockWriteFile).toHaveBeenCalled() // Tokens saved
   })
 
   it('polls until authorization is granted', async () => {
@@ -787,12 +788,12 @@ describe('saveTokens edge cases', () => {
     vi.clearAllMocks()
   })
 
-  it('starts fresh store if existing token file is corrupted JSON', () => {
+  it('starts fresh store if existing token file is corrupted JSON', async () => {
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return true
       return true // config dir exists
     })
-    mockReadFileSync.mockImplementation(() => {
+    mockReadFile.mockImplementation(() => {
       throw new SyntaxError('Unexpected token')
     })
 
@@ -803,15 +804,15 @@ describe('saveTokens edge cases', () => {
       clientId: 'cid'
     }
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual(tokens)
     // Should only have the new token, not corrupted data
     expect(Object.keys(written)).toEqual(['user@outlook.com'])
   })
 
-  it('uses cached token store on subsequent saves', () => {
+  it('uses cached token store on subsequent saves', async () => {
     mockExistsSync.mockReturnValue(false)
 
     const tokens1: OAuth2Tokens = {
@@ -828,12 +829,12 @@ describe('saveTokens edge cases', () => {
     }
 
     // First save populates cache
-    saveTokens('first@outlook.com', tokens1)
+    await saveTokens('first@outlook.com', tokens1)
     // Second save should use cache, not read from disk
-    saveTokens('second@outlook.com', tokens2)
+    await saveTokens('second@outlook.com', tokens2)
 
     // readFileSync should NOT be called for second save (cache is used)
-    const written = JSON.parse(mockWriteFileSync.mock.calls[1]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[1]![1] as string)
     expect(written['first@outlook.com']).toEqual(tokens1)
     expect(written['second@outlook.com']).toEqual(tokens2)
   })
@@ -870,7 +871,7 @@ describe('loadStoredTokens validation', () => {
     expect(retry).not.toBeNull()
   })
 
-  it('isValidTokens validates structure correctly', () => {
+  it('isValidTokens validates structure correctly', async () => {
     expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c' })).toBe(true)
     expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: '1', clientId: 'c' })).toBe(false)
     expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', clientId: 'c' })).toBe(false)
@@ -878,7 +879,7 @@ describe('loadStoredTokens validation', () => {
     expect(isValidTokens('not-an-object')).toBe(false)
   })
 
-  it('isValidTokenStore validates store correctly', () => {
+  it('isValidTokenStore validates store correctly', async () => {
     const valid = { 'a@b.com': { accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c' } }
     expect(isValidTokenStore(valid)).toBe(true)
     expect(isValidTokenStore({ ...valid, 'x@y.com': { bad: true } })).toBe(false)
@@ -955,7 +956,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('forwards malicious URLs with shell metacharacters to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     const maliciousUri = 'https://microsoft.com/devicelogin?code=ABCD;echo"vulnerable"'
     mockFetch.mockResolvedValueOnce({
@@ -981,7 +982,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('intercepts non-http/https protocols before delegating to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -1005,7 +1006,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('forwards URLs with leading hyphens to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     const hyphenUri = 'https://-example.com'
     mockFetch.mockResolvedValueOnce({
@@ -1117,7 +1118,7 @@ describe('initiateOutlookDeviceCode', () => {
 
     expect(onComplete).toHaveBeenCalled()
     // Tokens persisted to disk.
-    expect(mockWriteFileSync).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalled()
   })
 
   it('throws descriptive error when Microsoft rejects the device code request', async () => {
@@ -1165,8 +1166,8 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    expect(mockWriteFileSync).toHaveBeenCalled()
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    expect(mockWriteFile).toHaveBeenCalled()
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual({
       accessToken: 'at-123',
       refreshToken: 'rt-123',
@@ -1184,7 +1185,7 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['env@outlook.com']).toBeDefined()
     expect(written['env@outlook.com'].accessToken).toBe('at-env')
   })
@@ -1197,7 +1198,7 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['outlook-device-code']).toBeDefined()
   })
 
@@ -1209,7 +1210,7 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['defaults@outlook.com']).toEqual({
       accessToken: '',
       refreshToken: '',

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -6,8 +6,8 @@
  * persistent token storage, and automatic token refresh.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
@@ -156,15 +156,15 @@ export async function loadStoredTokens(email: string): Promise<OAuth2Tokens | nu
  * Persist OAuth2 tokens to disk.
  * Creates config directory if needed. File permissions: 0600.
  */
-export function saveTokens(email: string, tokens: OAuth2Tokens): void {
+export async function saveTokens(email: string, tokens: OAuth2Tokens): Promise<void> {
   if (!existsSync(CONFIG_DIR)) {
-    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
+    await mkdir(CONFIG_DIR, { recursive: true, mode: 0o700 })
   }
 
   let store: TokenStore = cachedTokenStore || {}
   try {
     if (!cachedTokenStore && existsSync(TOKEN_FILE)) {
-      const data: unknown = JSON.parse(readFileSync(TOKEN_FILE, 'utf-8'))
+      const data: unknown = JSON.parse(await readFile(TOKEN_FILE, 'utf-8'))
       if (isValidTokenStore(data)) {
         store = data
       } else {
@@ -178,7 +178,7 @@ export function saveTokens(email: string, tokens: OAuth2Tokens): void {
 
   store[email.toLowerCase()] = tokens
   cachedTokenStore = store
-  writeFileSync(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 })
+  await writeFile(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 })
 }
 
 /**
@@ -309,7 +309,7 @@ function startBackgroundPoll(
 
       if (data.access_token) {
         const now = Math.floor(Date.now() / MS_PER_SECOND)
-        saveTokens(email, {
+        await saveTokens(email, {
           accessToken: data.access_token,
           refreshToken: data.refresh_token,
           expiresAt: now + data.expires_in,
@@ -464,7 +464,7 @@ export async function ensureValidToken(account: { email: string; oauth2?: OAuth2
   }
 
   // Persist updated tokens
-  saveTokens(account.email, account.oauth2)
+  await saveTokens(account.email, account.oauth2)
 
   return newTokens.access_token
 }
@@ -485,7 +485,7 @@ export async function saveOutlookTokens(tokens: Record<string, unknown>): Promis
   const email = typeof tokens.email === 'string' ? tokens.email : (process.env.OUTLOOK_EMAIL ?? 'outlook-device-code')
   const now = Math.floor(Date.now() / MS_PER_SECOND)
   const expiresIn = typeof tokens.expires_in === 'number' ? tokens.expires_in : 3600
-  saveTokens(email, {
+  await saveTokens(email, {
     accessToken: typeof tokens.access_token === 'string' ? tokens.access_token : '',
     refreshToken: typeof tokens.refresh_token === 'string' ? tokens.refresh_token : '',
     expiresAt: now + expiresIn,
@@ -534,7 +534,7 @@ export async function deviceCodeAuth(email: string, clientId?: string): Promise<
         clientId: resolvedClientId
       }
 
-      saveTokens(email, tokens)
+      await saveTokens(email, tokens)
       console.error(`\nSuccess! Token saved for ${email}`)
       return tokens
     }


### PR DESCRIPTION
This PR replaces synchronous file I/O operations in the `saveTokens` function with their asynchronous counterparts from `node:fs/promises`.

### 💡 What:
- Converted `saveTokens` to an `async` function.
- Replaced `mkdirSync`, `readFileSync`, and `writeFileSync` with `mkdir`, `readFile`, and `writeFile`.
- Updated all internal call sites in `src/tools/helpers/oauth2.ts` to use `await`.
- Updated `src/tools/helpers/oauth2.test.ts` to mock the new async functions and handle the `async` nature of `saveTokens`.

### 🎯 Why:
- Prevents blocking the event loop, which is critical for maintaining high performance in an asynchronous application.
- Follows Node.js best practices for file system operations.

### 📊 Impact:
- Improved responsiveness of the application during OAuth token persistence.

### 🧪 Measurement:
- Verified that all 59 tests in `src/tools/helpers/oauth2.test.ts` pass.
- Verified that the full test suite (590 tests) passes.
- Verified that linting and type-checking (`bun run check`) pass.

---
*PR created automatically by Jules for task [18406866537013396536](https://jules.google.com/task/18406866537013396536) started by @n24q02m*