### PR TITLE
[FIX] Potential flaky test using setTimeout in http.test.ts

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -103,7 +103,7 @@ describe('http transport', () => {
     const startPromise = startHttp()
 
     // Wait for the server to start
-    await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+    await vi.waitFor(() => expect(sigintHandler).toBeTruthy())
 
     if (fn) await fn()
 
@@ -137,16 +137,21 @@ describe('http transport', () => {
 
   describe('onCredentialsSaved', () => {
     let onCredentialsSaved: any
+    let startPromise: Promise<void>
 
     beforeEach(async () => {
       // Start server and capture the callback
-      startHttp()
-      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+      startPromise = startHttp()
+      await vi.waitFor(() => {
+        expect(sigintHandler).toBeTruthy()
+        expect(runHttpServer).toHaveBeenCalled()
+      })
       onCredentialsSaved = vi.mocked(runHttpServer).mock.calls[0][1].onCredentialsSaved
     })
 
     afterEach(async () => {
       if (sigintHandler) await sigintHandler()
+      await startPromise
     })
 
     it('returns error if EMAIL_CREDENTIALS is missing', async () => {
@@ -383,7 +388,10 @@ describe('http transport', () => {
       vi.mocked(loadConfig).mockResolvedValue(mockAccounts as any)
 
       const startPromise = startHttp()
-      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+      await vi.waitFor(() => {
+        expect(sigintHandler).toBeTruthy()
+        expect(runHttpServer).toHaveBeenCalled()
+      })
 
       const factory = vi.mocked(runHttpServer).mock.calls[0][0]
 


### PR DESCRIPTION
Replaced non-deterministic timeouts and generic wait conditions in http.test.ts with robust vi.waitFor checks on signal handlers and server initialization. Improved test cleanup by ensuring startHttp promises are properly captured and awaited.

---
*PR created automatically by Jules for task [11663338544763724773](https://jules.google.com/task/11663338544763724773) started by @n24q02m*