### PR TITLE
[TEST] Untested public function setSetupUrl

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -101,6 +101,16 @@ describe('credential-state', () => {
       mod.setSetupUrl(null)
       expect(mod.getSetupUrl()).toBeNull()
     })
+
+    it('handles empty string', () => {
+      mod.setSetupUrl('')
+      expect(mod.getSetupUrl()).toBe('')
+    })
+
+    it('handles malformed URL', () => {
+      mod.setSetupUrl('not-a-url')
+      expect(mod.getSetupUrl()).toBe('not-a-url')
+    })
   })
 
   describe('resolveCredentialState', () => {


### PR DESCRIPTION
This PR adds unit tests for the `setSetupUrl` function in `src/credential-state.ts`. It covers standard URLs, empty strings, and malformed URLs to ensure robust code coverage and state management.

---
*PR created automatically by Jules for task [5693571110139186491](https://jules.google.com/task/5693571110139186491) started by @n24q02m*