### PR TITLE
[CLEANUP] Use of 'any' Type: enhanceError

### DIFF
--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -293,3 +293,24 @@ describe('createUnknownActionError', () => {
     expect(error.suggestion).toBe('Supported actions: bar, baz')
   })
 })
+
+describe('enhanceError normalization', () => {
+  it('normalizes string errors', () => {
+    const result = enhanceError('string error')
+    expect(result.message).toBe('string error')
+    expect(result.code).toBe('UNKNOWN_ERROR')
+  })
+
+  it('normalizes null/undefined errors', () => {
+    const result = enhanceError(null)
+    expect(result.message).toBe('Unknown error')
+
+    const result2 = enhanceError(undefined)
+    expect(result2.message).toBe('Unknown error')
+  })
+
+  it('normalizes number errors', () => {
+    const result = enhanceError(500)
+    expect(result.message).toBe('500')
+  })
+})

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -3,6 +3,16 @@
  * AI-friendly error messages and suggestions for email operations
  */
 
+export interface RawError {
+  message?: string
+  code?: string | number
+  name?: string
+  status?: number
+  responseCode?: number
+  authenticationFailed?: boolean
+  [key: string]: unknown
+}
+
 export class EmailMCPError extends Error {
   constructor(
     message: string,
@@ -28,7 +38,7 @@ export class EmailMCPError extends Error {
 /**
  * Sanitize error object to remove sensitive information (passwords, tokens)
  */
-function sanitizeErrorDetails(error: unknown): unknown {
+export function sanitizeErrorDetails(error: unknown): unknown {
   if (error === null || typeof error !== 'object') {
     return error
   }
@@ -53,8 +63,11 @@ export function enhanceError(error: unknown): EmailMCPError {
     return error
   }
 
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
-  const message = typeof errObj.message === 'string' ? errObj.message : 'Unknown error occurred'
+  // Normalize error into RawError
+  const errObj: RawError =
+    error !== null && typeof error === 'object' ? (error as RawError) : { message: String(error || 'Unknown error') }
+
+  const message = errObj.message || 'Unknown error occurred'
 
   // IMAP authentication errors
   if (
@@ -98,7 +111,7 @@ export function enhanceError(error: unknown): EmailMCPError {
 
   // SMTP errors
   if (typeof errObj.responseCode === 'number') {
-    return handleSmtpError(error)
+    return handleSmtpError(errObj)
   }
 
   // Configuration errors
@@ -122,9 +135,8 @@ export function enhanceError(error: unknown): EmailMCPError {
 /**
  * Handle SMTP-specific errors
  */
-function handleSmtpError(error: unknown): EmailMCPError {
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
-  const code = errObj.responseCode as number
+function handleSmtpError(error: RawError): EmailMCPError {
+  const code = error.responseCode as number
 
   switch (code) {
     case 535:
@@ -151,7 +163,7 @@ function handleSmtpError(error: unknown): EmailMCPError {
 
     default:
       return new EmailMCPError(
-        (typeof errObj.message === 'string' ? errObj.message : undefined) || `SMTP error ${code}`,
+        error.message || `SMTP error ${code}`,
         `SMTP_${code}`,
         'Check the SMTP error code and try again.',
         sanitizeErrorDetails(error)
@@ -269,10 +281,10 @@ export function suggestFixes(error: EmailMCPError): string[] {
 /**
  * Wrap async function with error handling
  */
-export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(
-  fn: T
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+export function withErrorHandling<Args extends unknown[], R>(
+  fn: (...args: Args) => Promise<R>
+): (...args: Args) => Promise<R> {
+  return async (...args: Args): Promise<R> => {
     try {
       return await fn(...args)
     } catch (error) {


### PR DESCRIPTION
This PR removes the use of the 'any' type in the \`enhanceError\` function and the \`withErrorHandling\` utility. It introduces a \`RawError\` interface to safely handle errors from external libraries like IMAP and SMTP, and implements a normalization pattern to handle various input types (strings, null/undefined, numbers). Comprehensive tests have been added to verify these changes.

---
*PR created automatically by Jules for task [5631333136902648951](https://jules.google.com/task/5631333136902648951) started by @n24q02m*