### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1130,6 +1130,9 @@ describe('initiateOutlookDeviceCode', () => {
 
     await expect(initiateOutlookDeviceCode('bad@outlook.com')).rejects.toThrow('Unknown client ID')
   })
+  it('throws if email is empty', async () => {
+    await expect(initiateOutlookDeviceCode('')).rejects.toThrow('Email is required')
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -357,6 +357,9 @@ export async function initiateOutlookDeviceCode(
   email: string,
   onComplete?: () => void
 ): Promise<{ verificationUri: string; userCode: string; expiresIn: number; interval: number }> {
+  if (!email) {
+    throw new Error('Email is required')
+  }
   const emailKey = email.toLowerCase()
   const existing = pendingAuths.get(emailKey)
   if (existing && existing.expiresAt > Date.now()) {


### PR DESCRIPTION
This PR adds input validation to the `initiateOutlookDeviceCode` function in `src/tools/helpers/oauth2.ts` to ensure it throws an 'Email is required' error when an empty or falsy email is provided. It also includes a new test case in `src/tools/helpers/oauth2.test.ts` to verify this behavior.

---
*PR created automatically by Jules for task [3915705098082167465](https://jules.google.com/task/3915705098082167465) started by @n24q02m*