### PR TITLE
[CLEANUP] Use of 'any' Type: formatAddress

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,8 +3,14 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import {
+  type FetchMessageObject,
+  ImapFlow,
+  type ListResponse,
+  type MessageAddressObject,
+  type SearchObject
+} from 'imapflow'
+import { type AddressObject, type Attachment, type SimpleParserOptions, simpleParser } from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -236,13 +242,23 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+export function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
-  if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+
+  if (Array.isArray(addr)) {
+    return addr
+      .map((a) => formatAddress(a))
+      .filter(Boolean)
+      .join(', ')
   }
+
+  if (addr.text) return addr.text
+
+  if (Array.isArray(addr.value)) {
+    return addr.value.map((a) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+  }
+
   return ''
 }
 
@@ -365,7 +381,7 @@ export async function searchEmails(
       // This ensures the IMAP connection and mailbox lock are released as quickly as possible.
       // We use `mapLimit` with a concurrency of 5 instead of a sequential for...of loop or unbounded Promise.all
       // to improve performance without blocking the event loop or causing memory spikes from CPU-heavy MIME parsing.
-      const summaries = await mapLimit(emails, 5, async (msg: any) => {
+      const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {
         const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
         return {
@@ -377,7 +393,7 @@ export async function searchEmails(
           from: msg.envelope?.from?.[0]
             ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
             : '',
-          to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
+          to: msg.envelope?.to?.map((a: MessageAddressObject) => a.address).join(', ') || '',
           date: msg.envelope?.date?.toISOString() || '',
           flags: Array.from((msg.flags as Set<string> | string[]) || []),
           snippet
@@ -447,7 +463,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,
@@ -529,7 +545,7 @@ export async function trashEmails(
 export async function listFolders(account: AccountConfig): Promise<FolderInfo[]> {
   return withConnection(account, async (client) => {
     const mailboxes = await client.list()
-    return mailboxes.map((mb: any) => ({
+    return mailboxes.map((mb: ListResponse) => ({
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),


### PR DESCRIPTION
This PR removes several instances of the `any` type in `src/tools/helpers/imap-client.ts`, improving type safety and maintainability.

Key changes:
- Refactored `formatAddress` to use `AddressObject` from `mailparser`.
- Added support for `AddressObject[]` and recursive formatting in `formatAddress`.
- Exported `formatAddress` for better testability and potential reuse.
- Replaced `any` with `FetchMessageObject`, `ListResponse`, and `MessageAddressObject` from `imapflow`.
- Replaced `any` with `Attachment` from `mailparser`.
- Verified changes with existing tests and a temporary test suite for the new `formatAddress` logic.
- Ran `bun run check:fix` to ensure code style and type safety.

---
*PR created automatically by Jules for task [14202418506820070672](https://jules.google.com/task/14202418506820070672) started by @n24q02m*