### PR TITLE
[SECURITY] Unvalidated JSON Parsing in Credential Store

### DIFF
--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -194,7 +194,7 @@ export async function loadUserCredentials(userId: string): Promise<AccountConfig
       new Uint8Array(ciphertext)
     )
     const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-    if (!isValidAccountConfigs(parsed.accounts)) {
+    if (!parsed || typeof parsed !== 'object' || !isValidAccountConfigs(parsed.accounts)) {
       throw new Error('Invalid account configuration in stored credentials')
     }
     return parsed.accounts
@@ -242,7 +242,12 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
         new Uint8Array(ciphertext)
       )
       const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-      if (typeof parsed.userId === 'string' && isValidAccountConfigs(parsed.accounts)) {
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof parsed.userId === 'string' &&
+        isValidAccountConfigs(parsed.accounts)
+      ) {
         result.set(parsed.userId, parsed.accounts)
       }
     } catch (err: unknown) {

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -103,7 +103,10 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     const tokenFile = join(homedir(), '.better-email-mcp', 'tokens.json')
 
     const data = await readFile(tokenFile, 'utf-8')
-    const store: Record<string, unknown> = JSON.parse(data)
+    const store: unknown = JSON.parse(data)
+    if (!store || typeof store !== 'object') {
+      throw new Error('Invalid token store format: not an object')
+    }
     const emails = Object.keys(store).filter((key) => key.includes('@'))
     if (emails.length > 0) {
       const credentials = emails.map((email) => `${email}:oauth2`).join(',')

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -36,7 +36,7 @@ function getVersion(): string {
       const pkgPath = join(dir, 'package.json')
       if (existsSync(pkgPath)) {
         const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
-        if (pkg.name === '@n24q02m/better-email-mcp') {
+        if (pkg && typeof pkg === 'object' && pkg.name === '@n24q02m/better-email-mcp') {
           return pkg.version ?? '0.0.0'
         }
       }


### PR DESCRIPTION
This PR addresses a security vulnerability where `JSON.parse` results were used without validation.

I have updated the following modules to ensure that parsed JSON payloads are non-null objects before any property access:
- `src/auth/per-user-credential-store.ts`: Validated `loadUserCredentials` and `loadAllUserCredentials`.
- `src/credential-state.ts`: Validated `resolveCredentialState` when loading tokens.
- `src/init-server.ts`: Validated `getVersion` when reading `package.json`.

The `src/tools/helpers/oauth2.ts` module was already using the `isValidTokenStore` type guard for validation.

Verified with existing test suites:
- `src/auth/per-user-credential-store.test.ts`
- `src/credential-state.test.ts`
- `src/init-server.test.ts`
- `src/tools/helpers/oauth2.test.ts`

All tests passed and code style is enforced via Biome.

---
*PR created automatically by Jules for task [2628481763808964602](https://jules.google.com/task/2628481763808964602) started by @n24q02m*