### PR TITLE
[FIX] Clear cached tokens on form submit to force device-code flow

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -185,7 +185,7 @@ function buildOptions(args: {
         // out accounts with ``.oauth2`` set and silently returns ``null`` →
         // the form shows "Setup complete" without ever displaying the Microsoft
         // device-code step (UX bug reported 2026-04-24).
-        account.oauth2 = undefined
+        delete account.oauth2
         outlookAccounts.push(account)
       } else {
         imapAccounts.push(account)


### PR DESCRIPTION
This PR fixes a UX bug where stale OAuth2 tokens caused the Outlook setup to skip the device-code flow, showing "Setup complete" prematurely. 

The fix ensures that every time the credential form is submitted, any cached `oauth2` property on the account object is removed using `delete`. This forces `initiateOutlookOAuth` to trigger a fresh device-code flow.

Changes:
- Modified `src/transports/http.ts` to use `delete account.oauth2` for Outlook/OAuth2 accounts in the `onCredentialsSaved` path.
- Restored the regression test in `src/transports/http.test.ts` to verify this behavior.

---
*PR created automatically by Jules for task [9611006070982358539](https://jules.google.com/task/9611006070982358539) started by @n24q02m*