### PR TITLE
🎨 Palette: [UX improvement] Fix missing validation errors on form submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,9 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+
+## 2025-05-26 - Native Form Validation on Submit
+
+**Learning:** When using `novalidate` on a form to provide custom inline validation feedback, the native validation is bypassed when the user submits the form. As a result, the custom `invalid` event handlers are not triggered, and invalid inputs are not highlighted, creating a poor user experience.
+
+**Action:** Always manually call `form.checkValidity()` in the form's `submit` event listener to ensure that all inputs are validated and custom `invalid` event handlers are fired. Additionally, programmatically focus the first invalid element to maintain accessibility and ensure the user's attention is directed to the first error.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -722,6 +722,15 @@ export function renderEmailCredentialForm(
                 evt.preventDefault();
                 statusBox.style.display = "none";
 
+                if (!form.checkValidity()) {
+                    // Find the first invalid element and focus it for accessibility
+                    var firstInvalid = form.querySelector("input:invalid, select:invalid, textarea:invalid");
+                    if (firstInvalid && firstInvalid instanceof HTMLElement) {
+                        firstInvalid.focus();
+                    }
+                    return;
+                }
+
                 var collected = collectAccounts();
 
                 if (collected.accounts.length === 0) {


### PR DESCRIPTION
💡 **What:** Added an explicit `form.checkValidity()` call to the form submission handler and implemented focus management for the first invalid input element.

🎯 **Why:** Forms that use `novalidate` bypass native validation triggers on submission. This caused our custom `invalid` events (which handle inline error rendering) not to fire if a user clicked "Connect" before touching an invalid field. Focusing the first invalid field immediately directs the user to what needs fixing.

📸 **Before/After:**
*Before:* Clicking "Connect" with an empty required field did nothing visibly. The form wouldn't submit, but no errors were shown, leaving the user confused.
*After:* Clicking "Connect" triggers inline error messages (e.g. "This field is required.") and automatically moves the cursor focus to the invalid field.

♻️ **Accessibility:** Improves keyboard navigation and screen-reader experience. Instead of a silent failure, the error is immediately announced, and the focus state shifts seamlessly to the exact location of the issue.

---
*PR created automatically by Jules for task [8589897140676847931](https://jules.google.com/task/8589897140676847931) started by @n24q02m*