### PR TITLE
[TEST] Missing error path test in registry.ts

### DIFF
--- a/src/tools/registry-error-path.test.ts
+++ b/src/tools/registry-error-path.test.ts
@@ -147,6 +147,62 @@ describe('registry.ts coverage - error and edge paths', () => {
       expect(result.isError).toBe(true)
       expect(result.content[0].text).toContain('Error: Unknown error occurred')
     })
+
+    it('should handle generic Error objects in the main catch block', async () => {
+      const { attachments } = await import('./composite/attachments.js')
+      vi.mocked(attachments).mockRejectedValue(new Error('Generic error message'))
+
+      const { callToolHandler } = setupHandler([{ email: 'test@example.com' }])
+
+      const result = await callToolHandler({
+        params: {
+          name: 'attachments',
+          arguments: { action: 'get', messageId: '123', fileName: 'test.txt' }
+        }
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('Error: Generic error message')
+    })
+
+    it('should handle JSON.stringify failures in the main catch block', async () => {
+      const { attachments } = await import('./composite/attachments.js')
+      const circular: any = {}
+      circular.self = circular
+      vi.mocked(attachments).mockResolvedValue(circular)
+
+      const { callToolHandler } = setupHandler([{ email: 'test@example.com' }])
+
+      const result = await callToolHandler({
+        params: {
+          name: 'attachments',
+          arguments: { action: 'get', messageId: '123', fileName: 'test.txt' }
+        }
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('Error:')
+      // JSON.stringify circular error message varies by node version but contains "circular"
+      expect(result.content[0].text.toLowerCase()).toContain('circular')
+    })
+
+    it('should handle IMAP authentication errors in the main catch block', async () => {
+      const { messages } = await import('./composite/messages.js')
+      vi.mocked(messages).mockRejectedValue(new Error('AUTHENTICATIONFAILED'))
+
+      const { callToolHandler } = setupHandler([{ email: 'test@example.com' }])
+
+      const result = await callToolHandler({
+        params: {
+          name: 'messages',
+          arguments: { action: 'search', query: 'ALL' }
+        }
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('Error: Email authentication failed')
+      expect(result.content[0].text).toContain('Suggestion: Check that your email and App Password are correct')
+    })
   })
 
   describe('config__open_relay', () => {


### PR DESCRIPTION
This PR adds missing error path tests for `src/tools/registry.ts` to ensure robust error handling and improve test coverage.

### Changes:
- Added `should handle generic Error objects in the main catch block` test case.
- Added `should handle JSON.stringify failures in the main catch block` test case (using a circular structure).
- Added `should handle IMAP authentication errors in the main catch block` test case (verifying `enhanceError` integration).

### Verification:
- Ran `bun x vitest run --coverage src/tools/registry.ts` and confirmed 100% line coverage.
- All tests in `src/tools/registry-error-path.test.ts` pass.
- Ran `bun run check:fix` and confirmed no linting/formatting issues.

---
*PR created automatically by Jules for task [5760820038366624479](https://jules.google.com/task/5760820038366624479) started by @n24q02m*