### PR TITLE
[FIX] Clear cached tokens on form submit to force device-code flow

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -185,7 +185,7 @@ function buildOptions(args: {
         // out accounts with ``.oauth2`` set and silently returns ``null`` →
         // the form shows "Setup complete" without ever displaying the Microsoft
         // device-code step (UX bug reported 2026-04-24).
-        account.oauth2 = undefined
+        delete account.oauth2
         outlookAccounts.push(account)
       } else {
         imapAccounts.push(account)


### PR DESCRIPTION
In `src/transports/http.ts`, the `onCredentialsSaved` function now explicitly clears the `oauth2` property from Outlook/OAuth2 accounts using the `delete` operator. This ensures that `initiateOutlookOAuth` always triggers a fresh Microsoft device-code flow for every credential form submission, even if `parseCredentials` (via `loadStoredTokens`) had previously populated the property with stale or cached tokens.

This addresses a UX bug where the form would prematurely show "Setup complete" without displaying the required device-code UI.

Verified with targeted regression test and full test suite.

---
*PR created automatically by Jules for task [8379315282405022236](https://jules.google.com/task/8379315282405022236) started by @n24q02m*