### PR TITLE
[CLEANUP] Use of 'any' Type: enhanceError

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -46,6 +46,24 @@ function sanitizeErrorDetails(error: unknown): unknown {
 }
 
 /**
+ * Interface for objects that can be enhanced into EmailMCPError
+ */
+interface EmailErrorLike {
+  message?: string
+  code?: string | number
+  responseCode?: number
+  authenticationFailed?: boolean
+  [key: string]: unknown
+}
+
+/**
+ * Type guard for EmailErrorLike objects
+ */
+function isEmailErrorLike(error: unknown): error is EmailErrorLike {
+  return error !== null && typeof error === 'object'
+}
+
+/**
  * Enhance email-related errors with helpful context
  */
 export function enhanceError(error: unknown): EmailMCPError {
@@ -53,7 +71,7 @@ export function enhanceError(error: unknown): EmailMCPError {
     return error
   }
 
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
+  const errObj = isEmailErrorLike(error) ? error : {}
   const message = typeof errObj.message === 'string' ? errObj.message : 'Unknown error occurred'
 
   // IMAP authentication errors
@@ -98,7 +116,7 @@ export function enhanceError(error: unknown): EmailMCPError {
 
   // SMTP errors
   if (typeof errObj.responseCode === 'number') {
-    return handleSmtpError(error)
+    return handleSmtpError(errObj)
   }
 
   // Configuration errors
@@ -122,8 +140,7 @@ export function enhanceError(error: unknown): EmailMCPError {
 /**
  * Handle SMTP-specific errors
  */
-function handleSmtpError(error: unknown): EmailMCPError {
-  const errObj = error !== null && typeof error === 'object' ? (error as Record<string, unknown>) : {}
+function handleSmtpError(errObj: EmailErrorLike): EmailMCPError {
   const code = errObj.responseCode as number
 
   switch (code) {
@@ -154,7 +171,7 @@ function handleSmtpError(error: unknown): EmailMCPError {
         (typeof errObj.message === 'string' ? errObj.message : undefined) || `SMTP error ${code}`,
         `SMTP_${code}`,
         'Check the SMTP error code and try again.',
-        sanitizeErrorDetails(error)
+        sanitizeErrorDetails(errObj)
       )
   }
 }
@@ -269,10 +286,10 @@ export function suggestFixes(error: EmailMCPError): string[] {
 /**
  * Wrap async function with error handling
  */
-export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(
-  fn: T
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+export function withErrorHandling<Args extends unknown[], R>(
+  fn: (...args: Args) => Promise<R>
+): (...args: Args) => Promise<R> {
+  return async (...args: Args): Promise<R> => {
     try {
       return await fn(...args)
     } catch (error) {


### PR DESCRIPTION
Removed all 'any' type usages from `src/tools/helpers/errors.ts`.

Key changes:
- Introduced `EmailErrorLike` interface to represent error objects handled by `enhanceError`.
- Implemented `isEmailErrorLike` type-guard to safely handle `unknown` error inputs.
- Refactored `withErrorHandling` to use proper generics (`Args extends unknown[], R`) instead of `any`.
- Updated `handleSmtpError` to use the new interface for better type safety.
- Ensured all 600 tests pass and linting is clean.

---
*PR created automatically by Jules for task [13763921183199245835](https://jules.google.com/task/13763921183199245835) started by @n24q02m*