### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1130,6 +1130,9 @@ describe('initiateOutlookDeviceCode', () => {
 
     await expect(initiateOutlookDeviceCode('bad@outlook.com')).rejects.toThrow('Unknown client ID')
   })
+  it('throws if email is empty', async () => {
+    await expect(initiateOutlookDeviceCode('')).rejects.toThrow('Email is required')
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -357,7 +357,12 @@ export async function initiateOutlookDeviceCode(
   email: string,
   onComplete?: () => void
 ): Promise<{ verificationUri: string; userCode: string; expiresIn: number; interval: number }> {
+  if (!email) {
+    throw new Error('Email is required')
+  }
+
   const emailKey = email.toLowerCase()
+
   const existing = pendingAuths.get(emailKey)
   if (existing && existing.expiresAt > Date.now()) {
     return {


### PR DESCRIPTION
This PR addresses a missing edge case in `src/tools/helpers/oauth2.ts` where calling `initiateOutlookDeviceCode` with an empty email string was not explicitly handled. 

Changes:
- Modified `initiateOutlookDeviceCode` to throw an `Error('Email is required')` if the `email` argument is falsy.
- Added a corresponding test case in `src/tools/helpers/oauth2.test.ts`.
- Verified the fix by running the full test suite and performing lint/format checks.

---
*PR created automatically by Jules for task [8782205082866771339](https://jules.google.com/task/8782205082866771339) started by @n24q02m*