### PR TITLE
[CLEANUP] Use of 'any' Type: formatAddress

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,8 +3,8 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import { type FetchMessageObject, ImapFlow, type ListResponse, type SearchObject } from 'imapflow'
+import { type AddressObject, type Attachment, type SimpleParserOptions, simpleParser } from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -236,12 +236,18 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
+  if (Array.isArray(addr)) {
+    return addr
+      .map((a) => formatAddress(a))
+      .filter(Boolean)
+      .join(', ')
+  }
   if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+  if (addr.value && Array.isArray(addr.value)) {
+    return addr.value.map((a) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
   }
   return ''
 }
@@ -365,7 +371,7 @@ export async function searchEmails(
       // This ensures the IMAP connection and mailbox lock are released as quickly as possible.
       // We use `mapLimit` with a concurrency of 5 instead of a sequential for...of loop or unbounded Promise.all
       // to improve performance without blocking the event loop or causing memory spikes from CPU-heavy MIME parsing.
-      const summaries = await mapLimit(emails, 5, async (msg: any) => {
+      const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {
         const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
         return {
@@ -377,7 +383,7 @@ export async function searchEmails(
           from: msg.envelope?.from?.[0]
             ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
             : '',
-          to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
+          to: msg.envelope?.to?.map((a: { address?: string }) => a.address).join(', ') || '',
           date: msg.envelope?.date?.toISOString() || '',
           flags: Array.from((msg.flags as Set<string> | string[]) || []),
           snippet
@@ -447,7 +453,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,
@@ -529,7 +535,7 @@ export async function trashEmails(
 export async function listFolders(account: AccountConfig): Promise<FolderInfo[]> {
   return withConnection(account, async (client) => {
     const mailboxes = await client.list()
-    return mailboxes.map((mb: any) => ({
+    return mailboxes.map((mb: ListResponse) => ({
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),


### PR DESCRIPTION
This PR replaces several usages of the `any` type in `src/tools/helpers/imap-client.ts` with more specific and accurate types from the `mailparser` and `imapflow` libraries.

Key changes:
- `formatAddress`: Now accepts `AddressObject | AddressObject[] | string | undefined | null` and handles arrays recursively.
- `readEmail`: The `attachments` mapping now uses the `Attachment` type.
- `searchEmails`: The `msg` parameter in the `mapLimit` callback now uses `FetchMessageObject`.
- `listFolders`: The `mb` parameter in the `mailboxes.map` callback now uses `ListResponse`.
- Added `AddressObject` and `Attachment` to `mailparser` imports.
- Added `FetchMessageObject` and `ListResponse` to `imapflow` imports.

These changes improve type safety and maintainability of the IMAP client helper module. All tests passed and type checks are clean.

---
*PR created automatically by Jules for task [13046526177256948741](https://jules.google.com/task/13046526177256948741) started by @n24q02m*