### PR TITLE
[SECURITY] Unvalidated JSON Parsing in Credential Store

### DIFF
--- a/src/auth/per-user-credential-store.security.test.ts
+++ b/src/auth/per-user-credential-store.security.test.ts
@@ -1,0 +1,72 @@
+import { randomBytes } from 'node:crypto'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  _deriveKey,
+  _getSecret,
+  _paths,
+  _resetSecretCache,
+  hashUserId,
+  loadAllUserCredentials,
+  loadUserCredentials
+} from './per-user-credential-store.js'
+
+describe('per-user-credential-store security', () => {
+  const testDir = join(tmpdir(), `per-user-security-${randomBytes(4).toString('hex')}`)
+
+  beforeEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+    mkdirSync(testDir, { recursive: true })
+    _paths.DATA_DIR = join(testDir, 'users')
+    _paths.SECRET_PATH = join(testDir, '.user-secret')
+    _resetSecretCache()
+  })
+
+  async function createEncryptedFile(userId: string, payload: string) {
+    const dirHash = hashUserId(userId)
+    const userDir = join(_paths.DATA_DIR, dirHash)
+    mkdirSync(userDir, { recursive: true })
+
+    const secret = await _getSecret()
+    const key = await _deriveKey(secret, dirHash)
+    const iv = crypto.getRandomValues(new Uint8Array(12))
+    const plaintext = new TextEncoder().encode(payload)
+    const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+    const combined = Buffer.concat([iv, Buffer.from(encrypted)])
+    writeFileSync(join(userDir, 'credentials.enc'), combined)
+  }
+
+  it('loadUserCredentials should handle null from JSON.parse', async () => {
+    await createEncryptedFile('null-user', 'null')
+
+    // Should NOT throw TypeError: Cannot read properties of null
+    // It currently DOES throw TypeError, which is caught and rethrown in loadUserCredentials
+    try {
+      await loadUserCredentials('null-user')
+    } catch (err: any) {
+      expect(err.name).not.toBe('TypeError')
+    }
+  })
+
+  it('loadAllUserCredentials should handle malformed JSON entries', async () => {
+    await createEncryptedFile('bad-json', '[]') // Array instead of object
+
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Should not crash, should just skip.
+    // Currently it catches TypeError and logs it.
+    const all = await loadAllUserCredentials()
+    expect(all.has('bad-json')).toBe(false)
+
+    // If it was a TypeError, it means it crashed during property access
+    if (spy.mock.calls.length > 0) {
+      expect(spy.mock.calls[0][1].name).not.toBe('TypeError')
+    }
+
+    spy.mockRestore()
+  })
+})

--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -116,13 +116,13 @@ export function hashUserId(userId: string): string {
 }
 
 function isValidServerConfig(obj: unknown): obj is import('../tools/helpers/config.js').ServerConfig {
-  if (!obj || typeof obj !== 'object') return false
+  if (!obj || typeof obj !== 'object' || obj === null) return false
   const s = obj as Record<string, unknown>
   return typeof s.host === 'string' && typeof s.port === 'number' && typeof s.secure === 'boolean'
 }
 
 function isValidOAuth2Tokens(obj: unknown): obj is import('../tools/helpers/oauth2.js').OAuth2Tokens {
-  if (!obj || typeof obj !== 'object') return false
+  if (!obj || typeof obj !== 'object' || obj === null) return false
   const t = obj as Record<string, unknown>
   return (
     typeof t.accessToken === 'string' &&
@@ -133,7 +133,7 @@ function isValidOAuth2Tokens(obj: unknown): obj is import('../tools/helpers/oaut
 }
 
 function isValidAccountConfig(obj: unknown): obj is AccountConfig {
-  if (!obj || typeof obj !== 'object') return false
+  if (!obj || typeof obj !== 'object' || obj === null) return false
   const a = obj as Record<string, unknown>
   const basic = typeof a.id === 'string' && typeof a.email === 'string' && typeof a.password === 'string'
   if (!basic) return false
@@ -194,7 +194,7 @@ export async function loadUserCredentials(userId: string): Promise<AccountConfig
       new Uint8Array(ciphertext)
     )
     const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-    if (!isValidAccountConfigs(parsed.accounts)) {
+    if (!parsed || typeof parsed !== 'object' || !isValidAccountConfigs(parsed.accounts)) {
       throw new Error('Invalid account configuration in stored credentials')
     }
     return parsed.accounts
@@ -242,7 +242,12 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
         new Uint8Array(ciphertext)
       )
       const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-      if (typeof parsed.userId === 'string' && isValidAccountConfigs(parsed.accounts)) {
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof parsed.userId === 'string' &&
+        isValidAccountConfigs(parsed.accounts)
+      ) {
         result.set(parsed.userId, parsed.accounts)
       }
     } catch (err: unknown) {

--- a/src/credential-state.security.test.ts
+++ b/src/credential-state.security.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock all external dependencies BEFORE importing the module under test
+vi.mock('@n24q02m/mcp-core/storage', () => ({
+  resolveConfig: vi.fn()
+}))
+
+vi.mock('@n24q02m/mcp-core', () => ({
+  writeConfig: vi.fn().mockResolvedValue(undefined),
+  deleteConfig: vi.fn().mockResolvedValue(undefined),
+  tryOpenBrowser: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+  readdir: vi.fn(),
+  rm: vi.fn()
+}))
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn().mockReturnValue('/tmp/test-home')
+}))
+
+vi.mock('node:path', () => ({
+  join: vi.fn((...args: string[]) => args.join('/'))
+}))
+
+import { readFile } from 'node:fs/promises'
+import { resolveConfig } from '@n24q02m/mcp-core/storage'
+
+describe('credential-state security', () => {
+  let mod: typeof import('./credential-state.js')
+
+  beforeEach(async () => {
+    vi.resetModules()
+    delete process.env.EMAIL_CREDENTIALS
+    mod = await import('./credential-state.js')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('resolveCredentialState should handle null from JSON.parse', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: '' } as any)
+    vi.mocked(readFile).mockResolvedValue('null')
+
+    // Current implementation will try to call Object.keys(null)
+    // which throws TypeError
+    const result = await mod.resolveCredentialState()
+    expect(result).toBe('awaiting_setup')
+  })
+
+  it('resolveCredentialState should handle non-object from JSON.parse', async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: '' } as any)
+    vi.mocked(readFile).mockResolvedValue('123')
+
+    const result = await mod.resolveCredentialState()
+    expect(result).toBe('awaiting_setup')
+  })
+})

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -103,7 +103,8 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     const tokenFile = join(homedir(), '.better-email-mcp', 'tokens.json')
 
     const data = await readFile(tokenFile, 'utf-8')
-    const store: Record<string, unknown> = JSON.parse(data)
+    const store: unknown = JSON.parse(data)
+    if (!store || typeof store !== 'object' || Array.isArray(store)) return state
     const emails = Object.keys(store).filter((key) => key.includes('@'))
     if (emails.length > 0) {
       const credentials = emails.map((email) => `${email}:oauth2`).join(',')


### PR DESCRIPTION
This PR addresses a security vulnerability where results from JSON.parse were used without validation, potentially leading to TypeErrors if the input was 'null' or a primitive.

Key changes:
- Added non-null object checks after JSON.parse in src/auth/per-user-credential-store.ts.
- Added similar validation in src/credential-state.ts for tokens.json parsing.
- Hardened internal type guards in per-user-credential-store.ts.
- Added security regression tests.

---
*PR created automatically by Jules for task [1186530035209128174](https://jules.google.com/task/1186530035209128174) started by @n24q02m*