### PR TITLE
[FIX] Fix form polling JS for Outlook OAuth

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1,6 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getMarkSetupComplete, setState } from '../../credential-state.js'
+
+vi.mock('../../credential-state.js', () => ({
+  getMarkSetupComplete: vi.fn(),
+  setState: vi.fn()
+}))
 
 vi.mock('@n24q02m/mcp-core', () => ({
   tryOpenBrowser: vi.fn().mockResolvedValue(true)
@@ -1216,5 +1222,23 @@ describe('saveOutlookTokens', () => {
       expiresAt: 1000000 + 3600, // default 1 hour
       clientId: 'default-cid'
     })
+  })
+
+  it('signals setup completionto the form and updates state', async () => {
+    const markComplete = vi.fn()
+    vi.mocked(getMarkSetupComplete).mockReturnValue(markComplete)
+
+    await saveOutlookTokens({ email: 'complete@outlook.com', access_token: 'at' })
+
+    expect(setState).toHaveBeenCalledWith('configured')
+    expect(markComplete).toHaveBeenCalledWith('outlook')
+  })
+
+  it('does not throw if markSetupCompleteFn is missing', async () => {
+    vi.mocked(getMarkSetupComplete).mockReturnValue(null)
+
+    await saveOutlookTokens({ email: 'no-hook@outlook.com', access_token: 'at' })
+
+    expect(setState).toHaveBeenCalledWith('configured')
   })
 })

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -11,6 +11,7 @@ import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
+import { getMarkSetupComplete, setState } from '../../credential-state.js'
 import { isSafeUrl } from './security.js'
 
 // Microsoft OAuth2 endpoints — "consumers" tenant for personal Microsoft accounts
@@ -315,6 +316,12 @@ function startBackgroundPoll(
           expiresAt: now + data.expires_in,
           clientId
         })
+        setState('configured')
+        try {
+          getMarkSetupComplete()?.('outlook')
+        } catch {
+          // Best-effort
+        }
         pendingAuths.delete(emailKey)
         if (onComplete) {
           try {
@@ -491,6 +498,12 @@ export async function saveOutlookTokens(tokens: Record<string, unknown>): Promis
     expiresAt: now + expiresIn,
     clientId: typeof tokens.client_id === 'string' ? tokens.client_id : getClientId()
   })
+  setState('configured')
+  try {
+    getMarkSetupComplete()?.('outlook')
+  } catch {
+    // Best-effort
+  }
 }
 
 /**


### PR DESCRIPTION
This PR fixes a regression where the Outlook OAuth credential form would spin indefinitely even after successful authorization. The fix involves explicitly signaling setup completion by calling `setState('configured')` and `getMarkSetupComplete()?.('outlook')` in all Outlook OAuth completion paths within `src/tools/helpers/oauth2.ts`, including the background polling and the delegated token saving function.

Specific changes:
- Updated `src/tools/helpers/oauth2.ts` to import `setState` and `getMarkSetupComplete`.
- Modified `startBackgroundPoll` to trigger completion signals when tokens are saved.
- Modified `saveOutlookTokens` to trigger completion signals when tokens are saved.
- Added test cases in `src/tools/helpers/oauth2.test.ts` to verify these signals are sent.

---
*PR created automatically by Jules for task [2794821118477975717](https://jules.google.com/task/2794821118477975717) started by @n24q02m*