### PR TITLE
[FIX] Invoke markSetupCompleteFn after saving tokens

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -22,8 +22,13 @@ vi.mock('node:os', () => ({
 }))
 
 const mockTryOpenBrowser = vi.mocked(tryOpenBrowser)
+vi.mock('../../credential-state.js', () => ({
+  setState: vi.fn(),
+  getMarkSetupComplete: vi.fn()
+}))
 
 import { readFile } from 'node:fs/promises'
+import { getMarkSetupComplete, setState } from '../../credential-state.js'
 
 const mockReadFile = vi.mocked(readFile)
 const mockExistsSync = vi.mocked(existsSync)
@@ -1137,6 +1142,25 @@ describe('initiateOutlookDeviceCode', () => {
 // ============================================================================
 
 describe('saveOutlookTokens', () => {
+  it('triggers setup completion signals after saving tokens', async () => {
+    const markComplete = vi.fn()
+    vi.mocked(getMarkSetupComplete).mockReturnValue(markComplete)
+    const tokens = { email: 'user@outlook.com', access_token: 'at-123' }
+
+    await saveOutlookTokens(tokens)
+
+    expect(setState).toHaveBeenCalledWith('configured')
+    expect(markComplete).toHaveBeenCalledWith('outlook')
+  })
+
+  it('does not throw if completion hook is missing', async () => {
+    vi.mocked(getMarkSetupComplete).mockReturnValue(null)
+    const tokens = { email: 'user@outlook.com' }
+
+    await expect(saveOutlookTokens(tokens)).resolves.not.toThrow()
+    expect(setState).toHaveBeenCalledWith('configured')
+  })
+
   const originalOutlookEmail = process.env.OUTLOOK_EMAIL
   const originalClientId = process.env.OUTLOOK_CLIENT_ID
 

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -11,6 +11,7 @@ import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
+import { getMarkSetupComplete, setState } from '../../credential-state.js'
 import { isSafeUrl } from './security.js'
 
 // Microsoft OAuth2 endpoints — "consumers" tenant for personal Microsoft accounts
@@ -491,6 +492,13 @@ export async function saveOutlookTokens(tokens: Record<string, unknown>): Promis
     expiresAt: now + expiresIn,
     clientId: typeof tokens.client_id === 'string' ? tokens.client_id : getClientId()
   })
+
+  setState('configured')
+  try {
+    getMarkSetupComplete()?.('outlook')
+  } catch {
+    // Best-effort -- ignore hook errors.
+  }
 }
 
 /**


### PR DESCRIPTION
Ensure the credential form spinner stops after Microsoft token save by invoking getMarkSetupComplete()?.("outlook") and setState("configured") in saveOutlookTokens. This fixes a UX bug where the form would stay stuck on "Waiting for Microsoft authorization..." even after tokens were persisted to disk.

---
*PR created automatically by Jules for task [6436524329805126381](https://jules.google.com/task/6436524329805126381) started by @n24q02m*