### PR TITLE
🎨 Palette: Programmatic focus management for invalid forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,7 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+
+## 2024-06-08 - Programmatic validation with novalidate forms
+**Learning:** When adding custom validation styling/messages, the `novalidate` attribute stops the browser from showing its native validation tooltips and auto-focusing on invalid fields. If you only handle `invalid` events on inputs to show custom messages without doing anything on `submit`, accessibility degrades significantly because screen readers and keyboard users lose their focus point on failed submission.
+**Action:** Always call `form.checkValidity()` in the form's `submit` handler to trigger validation messages, and manually set focus back to the first invalid field (`input:invalid, select:invalid, textarea:invalid`) when `checkValidity()` returns false.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -722,6 +722,14 @@ export function renderEmailCredentialForm(
                 evt.preventDefault();
                 statusBox.style.display = "none";
 
+                if (!form.checkValidity()) {
+                    var firstInvalid = form.querySelector("input:invalid, select:invalid, textarea:invalid");
+                    if (firstInvalid && typeof firstInvalid.focus === "function") {
+                        (firstInvalid as HTMLElement).focus();
+                    }
+                    return;
+                }
+
                 var collected = collectAccounts();
 
                 if (collected.accounts.length === 0) {


### PR DESCRIPTION
💡 **What:** Added programmatic validation to the form submission handler that calls `checkValidity()` and focuses the first invalid field (`input:invalid, select:invalid, textarea:invalid`).

🎯 **Why:** Because the form uses `novalidate` to permit custom inline error styling, the browser's default behavior of showing a tooltip and auto-focusing the invalid element on submit is bypassed. Without explicit programmatic focus management on failed submit, screen reader and keyboard-only users lose context of where they are and why the submission failed.

📸 **Before/After:** No visual changes.

♻️ **Accessibility:** Ensures that keyboard and screen-reader users are immediately directed to the problematic field when form validation fails, adhering to accessible focus management practices.

---
*PR created automatically by Jules for task [12069104789438831414](https://jules.google.com/task/12069104789438831414) started by @n24q02m*