### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate search keywords

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+
+## 2026-06-09 - [Extract inline static arrays in hot paths]
+**Learning:** In functions that parse user input or are called frequently (like `buildSearchCriteria` in `src/tools/helpers/imap-client.ts`), iterating over inline arrays like `['SINCE', 'BEFORE']` causes the JavaScript engine to allocate a new array object on every single function invocation, even if the array values never change.
+**Action:** Always pre-allocate static arrays and objects by extracting them to module-scoped constants using `as const` (e.g., `const DATE_KEYWORDS = ['SINCE', 'BEFORE'] as const`). This eliminates redundant allocations and reduces garbage collection pressure on hot paths.

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -131,6 +131,10 @@ const KV_MATCHERS = {
   TO: /\bTO\s+("[^"]+"|'[^']+'|\S+)/i
 } as const
 
+// ⚡ Bolt: Pre-allocate static arrays to prevent redundant allocations during query parsing
+const DATE_KEYWORDS = ['SINCE', 'BEFORE'] as const
+const KV_KEYWORDS = ['FROM', 'TO'] as const
+
 function buildSearchCriteria(query: string): SearchObject {
   const trimmed = query.trim()
   if (!trimmed) return {}
@@ -151,7 +155,7 @@ function buildSearchCriteria(query: string): SearchObject {
   }
 
   // 2. Extract date clauses: SINCE YYYY-MM-DD, BEFORE YYYY-MM-DD
-  for (const keyword of ['SINCE', 'BEFORE'] as const) {
+  for (const keyword of DATE_KEYWORDS) {
     const { valid, invalid } = DATE_MATCHERS[keyword]
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
@@ -168,7 +172,7 @@ function buildSearchCriteria(query: string): SearchObject {
   }
 
   // 3. Extract FROM / TO (single token or quoted string)
-  for (const keyword of ['FROM', 'TO'] as const) {
+  for (const keyword of KV_KEYWORDS) {
     const kvMatch = remaining.match(KV_MATCHERS[keyword])
     if (kvMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject


### PR DESCRIPTION
💡 What: Extracted inline static arrays `['SINCE', 'BEFORE']` and `['FROM', 'TO']` into module-scoped constants (`DATE_KEYWORDS` and `KV_KEYWORDS`) in `buildSearchCriteria`.

🎯 Why: In `src/tools/helpers/imap-client.ts`, the `buildSearchCriteria` function instantiates new arrays on every invocation during the parsing of IMAP search query terms. Moving these to module constants prevents redundant memory allocations and garbage collection pressure every time a search query is parsed.

📊 Impact: Eliminates redundant array allocations in the search query parsing loop.

🔬 Measurement: Verified by reviewing `src/tools/helpers/imap-client.ts` array initializations and running the full test suite (`bun run test`).

---
*PR created automatically by Jules for task [4408032029261000259](https://jules.google.com/task/4408032029261000259) started by @n24q02m*