### PR TITLE
🎨 Palette: Fix form validation focus for screen reader and keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,7 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+
+## $(date +%Y-%m-%d) - Improve form validation focus
+**Learning:** Custom form validation logic on a form with `novalidate` can cause accessibility and UX issues. If `form.checkValidity()` is not called explicitly on submit, users might miss error fields because focus isn't directed to them.
+**Action:** Always call `form.checkValidity()` on custom form submissions with `novalidate` and explicitly call `.focus()` on the first invalid field (`form.querySelector('input:invalid, select:invalid, textarea:invalid')`).

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -720,6 +720,13 @@ export function renderEmailCredentialForm(
 
             form.addEventListener("submit", function (evt) {
                 evt.preventDefault();
+
+                if (!form.checkValidity()) {
+                    var firstInvalid = form.querySelector("input:invalid, select:invalid, textarea:invalid");
+                    if (firstInvalid) firstInvalid.focus();
+                    return;
+                }
+
                 statusBox.style.display = "none";
 
                 var collected = collectAccounts();


### PR DESCRIPTION
**What:**
Added explicit HTML5 validation trigger (`form.checkValidity()`) and focused the first invalid element inside the custom form submit handler.

**Why:**
The form uses the `novalidate` attribute to support custom inline validation error styling. Previously, clicking the "Connect" button directly without interacting with required fields caused the custom submit logic to silently drop empty accounts rather than informing the user. It also failed to return the user's keyboard focus or screen reader cursor to the exact field that needs correction, leading to poor accessibility.

**Accessibility Improvements:**
- Screen readers will now announce standard form validation errors if a user attempts to submit the form prematurely.
- Keyboard users are immediately placed into the context of the invalid field that needs input.

**Testing:**
Ran unit tests `bun run test`, type-checks and formatting checks `bun run check`.
Created an ephemeral playwright script locally to verify the behavior. Screenshot confirms the invalid state is shown and `document.activeElement` correctly returns the empty email input.

---
*PR created automatically by Jules for task [2878844030268683581](https://jules.google.com/task/2878844030268683581) started by @n24q02m*