### PR TITLE
fix: add Comparison section to README capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ mcp-name: io.github.n24q02m/better-email-mcp
 - [Status](#status)
 - [Documentation](#documentation)
 - [Tools](#tools)
+- [Comparison](#comparison)
 - [Remote (HTTP Mode)](#remote-http-mode)
 - [Outlook OAuth Device Code (HTTP mode)](#outlook-oauth-device-code-http-mode)
 - [Configuration](#configuration)
@@ -126,6 +127,20 @@ Full docs at **[mcp.n24q02m.com/servers/better-email-mcp/setup/](https://mcp.n24
 | `email://docs/send` | Send/compose reference |
 | `email://docs/config` | Credential setup and runtime configuration reference |
 | `email://docs/help` | Full documentation |
+
+## Comparison
+
+How better-email-mcp stacks up against direct competitors in each pillar:
+
+| Capability | better-email-mcp | [email-mcp](https://github.com/codefuturist/email-mcp) | [Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) | [mcp-mail-server](https://github.com/yunfeizhu/mcp-mail-server) |
+|---|---|---|---|---|
+| IMAP/SMTP (provider-agnostic) | Yes | Yes | No (Gmail API only) | Yes |
+| Multi-account | Yes (comma-separated creds) | Yes | No (single global credential) | No (single account per instance) |
+| App Passwords | Yes (no OAuth setup) | Yes | No (OAuth2 only) | Yes |
+| Auto-discovery from email address | Yes | Yes (8 providers) | n/a (Gmail only) | No (manual host/port) |
+| Bundled Outlook OAuth (no user Azure app) | Yes (device-code, Thunderbird-pattern client) | partial (OAuth2 XOAUTH2, experimental) | No (user-supplied Google OAuth) | No |
+| Attachments (list + download) | Yes | Yes | Yes | Yes |
+| HTTP multi-user mode (per-JWT-sub) | Yes (OAuth 2.1, self-hostable) | No (stdio only) | No (stdio only) | No (stdio only) |
 
 ## Remote (HTTP Mode)
 


### PR DESCRIPTION
## What

Adds a `## Comparison` section to the README, matching the Tier-1 house style used by `wet-mcp` and `mnemo-mcp` (capability matrix vs named real competitors). Placed after `## Tools`, before `## Remote (HTTP Mode)`, and added to the Table of contents.

## Capability matrix

| Capability | better-email-mcp | email-mcp | Gmail-MCP-Server | mcp-mail-server |
|---|---|---|---|---|
| IMAP/SMTP (provider-agnostic) | Yes | Yes | No (Gmail API only) | Yes |
| Multi-account | Yes (comma-separated creds) | Yes | No (single global credential) | No (single account per instance) |
| App Passwords | Yes (no OAuth setup) | Yes | No (OAuth2 only) | Yes |
| Auto-discovery from email address | Yes | Yes (8 providers) | n/a (Gmail only) | No (manual host/port) |
| Bundled Outlook OAuth (no user Azure app) | Yes (device-code, Thunderbird-pattern client) | partial (OAuth2 XOAUTH2, experimental) | No (user-supplied Google OAuth) | No |
| Attachments (list + download) | Yes | Yes | Yes | Yes |
| HTTP multi-user mode (per-JWT-sub) | Yes (OAuth 2.1, self-hostable) | No (stdio only) | No (stdio only) | No (stdio only) |

## Anti-fabrication notes

Our capabilities derived from this repo's `src/tools/registry.ts` (7 tools) + README (multi-account, App Passwords, auto-discovery, bundled Outlook device-code client `d56f8c71-...`, per-JWT-sub HTTP mode). No invented features.

All three competitors are verified-real GitHub projects; every cell traces to their documented capabilities (or `n/a`/`No` where a feature is absent).

### Competitor sources + verification

- **codefuturist/email-mcp** — https://github.com/codefuturist/email-mcp — docs state full IMAP+SMTP, multiple accounts, App Password auth, "OAuth2 XOAUTH2 authentication for Gmail and Microsoft 365 (experimental)", provider auto-detection across 8 providers (Gmail/Outlook/Yahoo/iCloud/Fastmail/ProtonMail/Zoho/GMX). stdio transport only — no HTTP/multi-user mode.
- **GongRzhe/Gmail-MCP-Server** — https://github.com/GongRzhe/Gmail-MCP-Server — "Full integration with Gmail API" only (no IMAP/SMTP, no other providers). OAuth2 only (no App Passwords). Single global credential store (`~/.gmail-mcp/credentials.json`), no multi-account. Local/stdio only.
- **yunfeizhu/mcp-mail-server** — https://github.com/yunfeizhu/mcp-mail-server — IMAP search/read/manage + SMTP send with HTML/attachments; App Passwords recommended. Single account via `EMAIL_USER`/`EMAIL_PASS` env (no multi-account). No OAuth, no auto-discovery (manual host/port). Local stdio only. Documented providers: Gmail + Outlook.

House-style reference: [wet-mcp Comparison](https://github.com/n24q02m/wet-mcp#comparison), [mnemo-mcp Comparison](https://github.com/n24q02m/mnemo-mcp#comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
