### PR TITLE
[FIX] Long Function: buildOptions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+## 2025-05-14 - [Refactoring] Refactored buildOptions for maintainability
+ **Learning:** Large functions with nested closures (like `onCredentialsSaved` in `buildOptions`) are difficult to test and read. Extracting them into named top-level functions with clear parameters improves clarity.
+ **Action:** Proactively identify functions exceeding 50 lines that handle multiple concerns (validation, partitioning, persistence) and refactor them into a modular 'orchestrator + helpers' pattern.

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -137,6 +137,116 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[]): Promise<N
 }
 
 /**
+ * Partition accounts into Outlook (OAuth2) and standard IMAP groups.
+ * Forces a fresh device-code flow for Outlook by clearing cached tokens.
+ */
+function partitionAccounts(accounts: AccountConfig[]): {
+  outlookAccounts: AccountConfig[]
+  imapAccounts: AccountConfig[]
+} {
+  const outlookAccounts: AccountConfig[] = []
+  const imapAccounts: AccountConfig[] = []
+  for (const account of accounts) {
+    if (isOutlookDomain(account.email) || account.authType === 'oauth2') {
+      // Force fresh device-code flow for every form submit by clearing any
+      // cached tokens that ``parseCredentials`` may have populated via
+      // ``loadStoredTokens``. Without this, ``initiateOutlookOAuth`` filters
+      // out accounts with ``.oauth2`` set and silently returns ``null`` →
+      // the form shows "Setup complete" without ever displaying the Microsoft
+      // device-code step (UX bug reported 2026-04-24).
+      account.oauth2 = undefined
+      outlookAccounts.push(account)
+    } else {
+      imapAccounts.push(account)
+    }
+  }
+  return { outlookAccounts, imapAccounts }
+}
+
+/**
+ * Persistence: per-user (multi-user JWT-sub) + shared config.enc fallback.
+ * Per-user store guarantees isolation in multi-user deployments. Shared
+ * config.enc lets single-user self-host installs survive process restarts
+ * and lets tool calls outside an HTTP request scope (e.g. internal calls)
+ * still see the saved credentials.
+ */
+async function persistCredentials(args: {
+  accounts: AccountConfig[]
+  raw: string
+  sub?: string | null
+  onAccountsLoaded: (accounts: AccountConfig[]) => void
+}): Promise<NextStep | null> {
+  const { accounts, raw, sub, onAccountsLoaded } = args
+  if (sub) {
+    try {
+      await credStore.save(sub, { accounts })
+    } catch (err) {
+      console.error(`[${SERVER_NAME}] Failed to save per-user credentials for sub=${sub}: ${(err as Error).message}`)
+      return { type: 'error', text: 'Failed to save credentials. Please retry.' }
+    }
+    console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured for sub=${sub} (per-user scope)`)
+  }
+
+  try {
+    await writeConfig(SERVER_NAME, { EMAIL_CREDENTIALS: raw })
+  } catch (err) {
+    console.error(`[${SERVER_NAME}] Failed to persist credentials: ${(err as Error).message}`)
+  }
+  process.env.EMAIL_CREDENTIALS = raw
+  onAccountsLoaded(accounts)
+  console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
+  return null
+}
+
+/** Orchestrate credential validation and persistence. */
+async function handleCredentialsSaved(
+  creds: Record<string, string>,
+  context: SubjectContext,
+  onAccountsLoaded: (accounts: AccountConfig[]) => void
+): Promise<NextStep | null> {
+  const raw = creds?.EMAIL_CREDENTIALS?.trim()
+  if (!raw) {
+    return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }
+  }
+
+  let accounts: AccountConfig[]
+  try {
+    accounts = await parseCredentials(raw)
+  } catch (err) {
+    return {
+      type: 'error',
+      text: `Failed to parse credentials: ${(err as Error)?.message ?? 'invalid format'}`
+    }
+  }
+
+  if (accounts.length === 0) {
+    return {
+      type: 'error',
+      text: 'No valid accounts parsed. Expected email:app-password (multi-account: email1:pass1,email2:pass2)'
+    }
+  }
+
+  const { outlookAccounts, imapAccounts } = partitionAccounts(accounts)
+
+  const imapResult = await validateImapAccounts(imapAccounts)
+  if (imapResult) return imapResult
+
+  const persistResult = await persistCredentials({
+    accounts,
+    raw,
+    sub: context?.sub,
+    onAccountsLoaded
+  })
+  if (persistResult) return persistResult
+
+  const outlookResult = await initiateOutlookOAuth(outlookAccounts)
+  if (outlookResult) return outlookResult
+
+  setState('configured')
+  return null
+}
+
+/**
  * Build `RunHttpServerOptions` for the email HTTP mode. Per-user credentials
  * are keyed by the JWT `sub` from `SubjectContext`; the shared `config.enc`
  * is also written so single-user self-host deployments work the same way.
@@ -149,83 +259,8 @@ function buildOptions(args: {
 }): RunHttpServerOptions {
   const { port, host, onAccountsLoaded } = args
 
-  const onCredentialsSaved = async (
-    creds: Record<string, string>,
-    context: SubjectContext
-  ): Promise<NextStep | null> => {
-    const raw = creds?.EMAIL_CREDENTIALS?.trim()
-    if (!raw) {
-      return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }
-    }
-
-    let accounts: AccountConfig[]
-    try {
-      accounts = await parseCredentials(raw)
-    } catch (err) {
-      return {
-        type: 'error',
-        text: `Failed to parse credentials: ${(err as Error)?.message ?? 'invalid format'}`
-      }
-    }
-
-    if (accounts.length === 0) {
-      return {
-        type: 'error',
-        text: 'No valid accounts parsed. Expected email:app-password (multi-account: email1:pass1,email2:pass2)'
-      }
-    }
-
-    const outlookAccounts: AccountConfig[] = []
-    const imapAccounts: AccountConfig[] = []
-    for (const account of accounts) {
-      if (isOutlookDomain(account.email) || account.authType === 'oauth2') {
-        // Force fresh device-code flow for every form submit by clearing any
-        // cached tokens that ``parseCredentials`` may have populated via
-        // ``loadStoredTokens``. Without this, ``initiateOutlookOAuth`` filters
-        // out accounts with ``.oauth2`` set and silently returns ``null`` →
-        // the form shows "Setup complete" without ever displaying the Microsoft
-        // device-code step (UX bug reported 2026-04-24).
-        account.oauth2 = undefined
-        outlookAccounts.push(account)
-      } else {
-        imapAccounts.push(account)
-      }
-    }
-
-    const imapResult = await validateImapAccounts(imapAccounts)
-    if (imapResult) return imapResult
-
-    // Persistence: per-user (multi-user JWT-sub) + shared config.enc fallback.
-    // Per-user store guarantees isolation in multi-user deployments. Shared
-    // config.enc lets single-user self-host installs survive process restarts
-    // and lets tool calls outside an HTTP request scope (e.g. internal calls)
-    // still see the saved credentials.
-    const sub = context?.sub
-    if (sub) {
-      try {
-        await credStore.save(sub, { accounts })
-      } catch (err) {
-        console.error(`[${SERVER_NAME}] Failed to save per-user credentials for sub=${sub}: ${(err as Error).message}`)
-        return { type: 'error', text: 'Failed to save credentials. Please retry.' }
-      }
-      console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured for sub=${sub} (per-user scope)`)
-    }
-
-    try {
-      await writeConfig(SERVER_NAME, { EMAIL_CREDENTIALS: raw })
-    } catch (err) {
-      console.error(`[${SERVER_NAME}] Failed to persist credentials: ${(err as Error).message}`)
-    }
-    process.env.EMAIL_CREDENTIALS = raw
-    onAccountsLoaded(accounts)
-    console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
-
-    const outlookResult = await initiateOutlookOAuth(outlookAccounts)
-    if (outlookResult) return outlookResult
-
-    setState('configured')
-    return null
-  }
+  const onCredentialsSaved = (creds: Record<string, string>, context: SubjectContext) =>
+    handleCredentialsSaved(creds, context, onAccountsLoaded)
 
   return {
     serverName: SERVER_NAME,


### PR DESCRIPTION
Extracted logic from the long buildOptions function in src/transports/http.ts into several helper functions: partitionAccounts, persistCredentials, and handleCredentialsSaved. This improves readability and maintainability by separating concerns like account partitioning, persistence, and orchestration.

---
*PR created automatically by Jules for task [8858386302568890060](https://jules.google.com/task/8858386302568890060) started by @n24q02m*