### PR TITLE
[CLEANUP] Use of 'any' Type: sanitizeErrorDetails

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -33,14 +33,14 @@ function sanitizeErrorDetails(error: unknown): unknown {
     return error
   }
 
-  const errObj = error as Record<string, unknown>
   const safe: Record<string, unknown> = {}
+  const props = ['message', 'name', 'code', 'status', 'responseCode'] as const
 
-  if ('message' in errObj) safe.message = errObj.message
-  if ('name' in errObj) safe.name = errObj.name
-  if ('code' in errObj) safe.code = errObj.code
-  if ('status' in errObj) safe.status = errObj.status
-  if ('responseCode' in errObj) safe.responseCode = errObj.responseCode
+  for (const prop of props) {
+    if (prop in error && (error as Record<string, unknown>)[prop] !== undefined) {
+      safe[prop] = (error as Record<string, unknown>)[prop]
+    }
+  }
 
   return safe
 }
@@ -269,10 +269,10 @@ export function suggestFixes(error: EmailMCPError): string[] {
 /**
  * Wrap async function with error handling
  */
-export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(
-  fn: T
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+export function withErrorHandling<Args extends unknown[], R>(
+  fn: (...args: Args) => Promise<R>
+): (...args: Args) => Promise<R> {
+  return async (...args: Args): Promise<R> => {
     try {
       return await fn(...args)
     } catch (error) {


### PR DESCRIPTION
This PR addresses the use of 'any' types in `src/tools/helpers/errors.ts`.

Key changes:
- Refactored `withErrorHandling` to use `unknown[]` and a generic return type `R` instead of `any`, ensuring full type safety for wrapped asynchronous functions.
- Refined `sanitizeErrorDetails` to use a property allow-list loop and the `in` operator, ensuring safe extraction of common error properties from `unknown` objects while avoiding sensitive data leakage.
- Removed all remaining instances of `any` in the file.
- Verified all changes with existing tests and linting/type-check suites.

---
*PR created automatically by Jules for task [10428534892654818118](https://jules.google.com/task/10428534892654818118) started by @n24q02m*