### PR TITLE
[PERF] Cache bigrams for valid options

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+
+## 2024-05-20 - [Cache lowercased strings and bigrams for static options]
+**Learning:** In `findClosestMatch`, performing `option.toLowerCase()` and re-calculating bigrams for static `validOptions` on every call was redundant. While bigrams were previously cached by the lowercased string, getting that lowercased string still required a `.toLowerCase()` call per option per invocation.
+**Action:** Implement a unified cache keyed by the original option string that stores both the lowercased version and the bigram Set. This eliminates redundant string operations and `Map` lookups, providing a cleaner O(N+M) path.

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -159,8 +159,9 @@ function handleSmtpError(error: unknown): EmailMCPError {
   }
 }
 
-// ⚡ Bolt: Cache bigrams for static valid options to avoid recomputing them on every request.
-const validOptionBigramCache = new Map<string, Set<string>>()
+// ⚡ Bolt: Cache lowercased strings and bigrams for static valid options to avoid recomputing them.
+type CachedOption = { lower: string; bigrams: Set<string> }
+const validOptionCache = new Map<string, CachedOption>()
 
 /**
  * Find the closest matching string from a list of valid options.
@@ -180,17 +181,21 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   for (let i = 0; i < lower.length - 1; i++) inputBigrams.add(lower.slice(i, i + 2))
 
   for (const option of validOptions) {
-    const optionLower = option.toLowerCase()
-    if (optionLower.startsWith(lower) || lower.startsWith(optionLower)) {
-      return option
+    // ⚡ Bolt: Use cached lowercased string and bigrams if available, otherwise compute and cache them.
+    // This avoids redundant toLowerCase() calls and Set allocations.
+    let cached = validOptionCache.get(option)
+    if (!cached) {
+      const lowercased = option.toLowerCase()
+      const bigrams = new Set<string>()
+      for (let i = 0; i < lowercased.length - 1; i++) bigrams.add(lowercased.slice(i, i + 2))
+      cached = { lower: lowercased, bigrams }
+      validOptionCache.set(option, cached)
     }
 
-    // ⚡ Bolt: Use cached bigrams if available, otherwise compute and cache them.
-    let optionBigrams = validOptionBigramCache.get(optionLower)
-    if (!optionBigrams) {
-      optionBigrams = new Set<string>()
-      for (let i = 0; i < optionLower.length - 1; i++) optionBigrams.add(optionLower.slice(i, i + 2))
-      validOptionBigramCache.set(optionLower, optionBigrams)
+    const { lower: optionLower, bigrams: optionBigrams } = cached
+
+    if (optionLower.startsWith(lower) || lower.startsWith(optionLower)) {
+      return option
     }
 
     let overlap = 0


### PR DESCRIPTION
This PR optimizes the fuzzy matching logic in `findClosestMatch` used for error suggestions and tool matching.

### Changes
- **Cache Optimization**: Replaced the bigram-only cache with a comprehensive `validOptionCache` that stores both the lowercased version and the bigram Set for each option.
- **Redundancy Reduction**: Eliminated redundant `toLowerCase()` calls and multiple Map lookups inside the matching loop.
- **Complexity**: Maintained O(N+M) complexity while reducing the constant factor for each iteration.

### Verification
- Ran `bun run test src/tools/helpers/errors.test.ts` (45/45 passed).
- Verified linting and type-checking with `bun run check`.
- Updated `.jules/bolt.md` with the performance learning.

---
*PR created automatically by Jules for task [2109222053032426829](https://jules.google.com/task/2109222053032426829) started by @n24q02m*