### PR TITLE
[CLEANUP] Use of 'any' Type: formatAddress

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -4,7 +4,13 @@
  */
 
 import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import {
+  type AddressObject,
+  type Attachment,
+  type EmailAddress,
+  type SimpleParserOptions,
+  simpleParser
+} from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -236,17 +242,21 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
+  if (Array.isArray(addr)) {
+    return addr
+      .map((a) => formatAddress(a))
+      .filter(Boolean)
+      .join(', ')
+  }
   if (addr.text) return addr.text
   if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+    return addr.value.map((a: EmailAddress) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
   }
   return ''
 }
-
-// ============================================================================
 // Sent Folder
 // ============================================================================
 
@@ -447,7 +457,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,


### PR DESCRIPTION
This PR addresses the use of the `any` type in the `formatAddress` function within `src/tools/helpers/imap-client.ts`.

### Changes:
- Imported `AddressObject`, `EmailAddress`, and `Attachment` types from `mailparser`.
- Updated `formatAddress` signature to accept `AddressObject | AddressObject[] | string | undefined | null`.
- Improved `formatAddress` implementation to handle `AddressObject[]` by recursively formatting and joining them.
- Updated the attachment mapping in `readEmail` to use the `Attachment` type instead of `any`.
- Verified that all 75 tests in `src/tools/helpers/imap-client.test.ts` pass and the code is correctly formatted and linted.

---
*PR created automatically by Jules for task [13236488005039649798](https://jules.google.com/task/13236488005039649798) started by @n24q02m*