### PR TITLE
[TEST] Missing edge case test in html-utils.ts

### DIFF
--- a/src/tools/helpers/html-utils.test.ts
+++ b/src/tools/helpers/html-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { escapeHtml, fastExtractSnippet, htmlToCleanText } from './html-utils.js'
+import { escapeHtml, fastExtractSnippet, htmlToCleanText, sanitizeHtml } from './html-utils.js'
 
 describe('escapeHtml', () => {
   it('escapes &, <, >, ", and \'', () => {
@@ -231,5 +231,27 @@ describe('fastExtractSnippet', () => {
     expect(result).toContain('A')
     expect(result).toContain('B')
     expect(result).toContain('C')
+  })
+})
+
+describe('sanitizeHtml', () => {
+  it('sanitizes HTML with default options', () => {
+    const dirty =
+      '<p>Hello <script>alert("xss")</script> <img src="test.jpg"> <a href="javascript:alert(1)">Link</a></p>'
+    const clean = sanitizeHtml(dirty)
+    expect(clean).toContain('<p>Hello')
+    expect(clean).toContain('<img src="test.jpg"')
+    expect(clean).not.toContain('<script>')
+    expect(clean).not.toContain('javascript:')
+  })
+
+  it('handles very large strings without crashing (1MB performance test)', () => {
+    const largeString = `<p>${'a'.repeat(1024 * 1024)}</p>`
+    const start = Date.now()
+    const clean = sanitizeHtml(largeString)
+    const duration = Date.now() - start
+
+    expect(clean).toContain('aaaaaaaa')
+    expect(duration).toBeLessThan(5000) // Ensure it finishes within 5 seconds
   })
 })

--- a/src/tools/helpers/html-utils.ts
+++ b/src/tools/helpers/html-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { compile } from 'html-to-text'
+import sanitize from 'sanitize-html'
 
 const ENTITY_MAP: Record<string, string> = {
   '&nbsp;': ' ',
@@ -121,4 +122,18 @@ export function fastExtractSnippet(html: string, maxLength = 200): string {
 
   if (text.length <= maxLength) return text
   return `${text.substring(0, maxLength)}...`
+}
+
+/**
+ * Centralized HTML sanitization options for emails
+ */
+export const EMAIL_SANITIZE_OPTIONS: sanitize.IOptions = {
+  allowedTags: sanitize.defaults.allowedTags.concat(['img'])
+}
+
+/**
+ * Sanitize HTML content using centralized options
+ */
+export function sanitizeHtml(html: string, options: sanitize.IOptions = EMAIL_SANITIZE_OPTIONS): string {
+  return sanitize(html, options)
 }

--- a/src/tools/helpers/smtp-client.ts
+++ b/src/tools/helpers/smtp-client.ts
@@ -5,9 +5,9 @@
 
 import { marked } from 'marked'
 import { createTransport } from 'nodemailer'
-import sanitizeHtml from 'sanitize-html'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
+import { EMAIL_SANITIZE_OPTIONS, sanitizeHtml } from './html-utils.js'
 import { ensureValidToken } from './oauth2.js'
 
 export interface SendEmailOptions {
@@ -50,13 +50,10 @@ function createSmtpTransport(account: AccountConfig) {
   })
 }
 
-// ⚡ Bolt: Extract `marked` and `sanitize-html` options into module-scoped constants.
-// This prevents recreating configuration objects and evaluating `Array.prototype.concat`
-// on every function call, significantly reducing allocation overhead during high-frequency email parsing.
+// ⚡ Bolt: Extract `marked` options into module-scoped constants.
+// This prevents recreating configuration objects on every function call,
+// significantly reducing allocation overhead during high-frequency email parsing.
 const MARKED_OPTIONS: import('marked').MarkedOptions = { async: false, breaks: true }
-const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
-  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img'])
-}
 
 /**
  * Convert markdown text to simple HTML for email.
@@ -66,7 +63,7 @@ export function textToHtml(text: string): string {
   // marked.parse can return a Promise if async: true, but we use async: false
   const rawHtml = marked.parse(text, MARKED_OPTIONS) as string
 
-  return sanitizeHtml(rawHtml, SANITIZE_OPTIONS)
+  return sanitizeHtml(rawHtml, EMAIL_SANITIZE_OPTIONS)
 }
 
 /**


### PR DESCRIPTION
This PR adds a performance test for the `sanitizeHtml` function in `html-utils.ts` to ensure it handles very large strings (1MB) efficiently and without crashing. 

Additionally, it centralizes the HTML sanitization logic by:
1. Exporting a standard `sanitizeHtml` wrapper and `EMAIL_SANITIZE_OPTIONS` from `html-utils.ts`.
2. Refactoring `smtp-client.ts` to use these centralized utilities instead of defining its own local sanitization logic.

All tests passed, and linting/formatting checks were successful.

---
*PR created automatically by Jules for task [6907502094664926298](https://jules.google.com/task/6907502094664926298) started by @n24q02m*