### PR TITLE
🛡️ Sentinel: Fix Unvalidated JSON Parsing in Credential Store

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,7 @@
 **Vulnerability:** The `deriveKey` function in `src/auth/per-user-credential-store.ts` used a generic `process.env.VITEST` check to downgrade PBKDF2 iterations from 600,000 to 1,000. This could potentially allow an attacker to downgrade security in production by setting the `VITEST` environment variable.
 **Learning:** Security-sensitive parameters like cryptographic iteration counts should rely on strict environment checks (e.g., `NODE_ENV === 'test'`) rather than generic or easily spoofable variables.
 **Prevention:** Use `process.env.NODE_ENV === 'test'` for test-only security downgrades and allow sensitive parameters to be explicitly configured via function arguments to avoid reliance on global state.
+## 2025-05-15 - Unvalidated JSON Parsing in Credential Store
+ **Vulnerability:** Unvalidated `JSON.parse` results could lead to `TypeError` (e.g., when parsing `null`) or logic errors (e.g., when parsing primitives) when properties like `.accounts` are accessed.
+ **Learning:** Always validate that the result of `JSON.parse` is a non-null object before accessing properties, especially for data coming from storage or external sources.
+ **Prevention:** Use type guards or schema validation (like Zod) immediately after `JSON.parse` to ensure the payload matches the expected structure.

--- a/src/auth/per-user-credential-store.test.ts
+++ b/src/auth/per-user-credential-store.test.ts
@@ -446,5 +446,24 @@ describe('per-user-credential-store', () => {
 
       await expect(loadUserCredentials(userId)).rejects.toThrow('Invalid account configuration')
     })
+
+    it('should throw when loading individual user with null JSON', async () => {
+      const userId = 'null-user'
+      const dirHash = hashUserId(userId)
+      const userDir = join(_paths.DATA_DIR, dirHash)
+      mkdirSync(userDir, { recursive: true })
+
+      const secret = await _getSecret()
+      const key = await _deriveKey(secret, dirHash)
+      const iv = crypto.getRandomValues(new Uint8Array(12))
+      const payload = 'null'
+      const plaintext = new TextEncoder().encode(payload)
+      const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+      const combined = Buffer.concat([iv, Buffer.from(encrypted)])
+      const { writeFileSync } = await import('node:fs')
+      writeFileSync(join(userDir, 'credentials.enc'), combined)
+
+      await expect(loadUserCredentials(userId)).rejects.toThrow('Invalid account configuration')
+    })
   })
 })

--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -194,7 +194,7 @@ export async function loadUserCredentials(userId: string): Promise<AccountConfig
       new Uint8Array(ciphertext)
     )
     const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-    if (!isValidAccountConfigs(parsed.accounts)) {
+    if (!parsed || typeof parsed !== 'object' || !isValidAccountConfigs(parsed.accounts)) {
       throw new Error('Invalid account configuration in stored credentials')
     }
     return parsed.accounts
@@ -242,7 +242,12 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
         new Uint8Array(ciphertext)
       )
       const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-      if (typeof parsed.userId === 'string' && isValidAccountConfigs(parsed.accounts)) {
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof parsed.userId === 'string' &&
+        isValidAccountConfigs(parsed.accounts)
+      ) {
         result.set(parsed.userId, parsed.accounts)
       }
     } catch (err: unknown) {


### PR DESCRIPTION
Analyzed and fixed a security vulnerability where `JSON.parse` results were used without validation in `src/auth/per-user-credential-store.ts`.

Summary of changes:
1.  Modified `loadUserCredentials` to check that the parsed JSON result is a non-null object before accessing `.accounts`.
2.  Modified `loadAllUserCredentials` to safely handle parsed results, skipping corrupted entries that parse to non-objects.
3.  Added a new test case to `src/auth/per-user-credential-store.test.ts` to verify that `null` JSON payloads are handled gracefully.
4.  Recorded the security learning in `.jules/sentinel.md`.

All tests passed, and linting/type-checking were successful.

---
*PR created automatically by Jules for task [12793323205028795806](https://jules.google.com/task/12793323205028795806) started by @n24q02m*