### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1135,6 +1135,9 @@ describe('initiateOutlookDeviceCode', () => {
 
     await expect(initiateOutlookDeviceCode('bad@outlook.com')).rejects.toThrow('Unknown client ID')
   })
+  it('throws if email is missing', async () => {
+    await expect(initiateOutlookDeviceCode('')).rejects.toThrow('Email is required')
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -358,6 +358,7 @@ export async function initiateOutlookDeviceCode(
   email: string,
   onComplete?: () => void
 ): Promise<{ verificationUri: string; userCode: string; expiresIn: number; interval: number }> {
+  if (!email) throw new Error('Email is required')
   const emailKey = email.toLowerCase()
   const existing = pendingAuths.get(emailKey)
   if (existing && existing.expiresAt > Date.now()) {


### PR DESCRIPTION
Added validation to ensure email is provided in initiateOutlookDeviceCode and added a corresponding test case for the empty string edge case in src/tools/helpers/oauth2.test.ts. This addresses the missing edge case and prevents potential runtime issues with empty identifiers.

---
*PR created automatically by Jules for task [4374451839571131256](https://jules.google.com/task/4374451839571131256) started by @n24q02m*