### PR TITLE
[FIX] Long Function: parseSingleCredential

### DIFF
--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -162,26 +162,51 @@ function parsePasswordAndHost(parts: string[]): {
 
   // Mutable tail; pop SMTP, then IMAP, then rest is password.
   const tail = parts.slice(1)
-  let smtpSecurity: SmtpSecurity | undefined
-  let smtpHost: string | undefined
-  let smtpPort: number | undefined
-  let imapHost: string | undefined
-  let imapPort: number | undefined
+  const smtp = extractSmtpSegments(tail)
+  const imap = extractImapSegments(tail)
+  const password = tail.join(':')
+
+  return {
+    password,
+    customImapHost: imap.host,
+    customImapPort: imap.port,
+    customSmtpHost: smtp.host,
+    customSmtpPort: smtp.port,
+    customSmtpSecurity: smtp.security
+  }
+}
+
+/**
+ * Helper: an "all-digit" segment looks like a port attempt (even if value
+ * is out-of-range, in which case parsePort returns undefined and the
+ * caller falls back to the protocol-default port).
+ */
+function isPortSegment(s: string): boolean {
+  return /^\d+$/.test(s)
+}
+
+/**
+ * Extract SMTP segments from the tail of the credential string.
+ * This includes optional host, port, and security keyword.
+ */
+function extractSmtpSegments(tail: string[]): {
+  host?: string
+  port?: number
+  security?: SmtpSecurity
+} {
+  let security: SmtpSecurity | undefined
+  let host: string | undefined
+  let port: number | undefined
 
   // 1. Optional SMTP security keyword at end (only valid when an SMTP host
   //    can also be detected; otherwise the keyword belongs to the password).
   //    We tentatively pop + restore if SMTP host parsing fails.
   let popped_security = false
   if (tail.length >= 4 && isSmtpSecurity(tail.at(-1)!)) {
-    smtpSecurity = tail.at(-1)!.toLowerCase() as SmtpSecurity
+    security = tail.at(-1)!.toLowerCase() as SmtpSecurity
     tail.pop()
     popped_security = true
   }
-
-  // Helper: an "all-digit" segment looks like a port attempt (even if value
-  // is out-of-range, in which case parsePort returns undefined and the
-  // caller falls back to the protocol-default port).
-  const isPortSegment = (s: string) => /^\d+$/.test(s)
 
   // 2. SMTP host + port (host:port pair). Detected only when tail has BOTH:
   //    - tail.at(-1) is all-digit (a port attempt)
@@ -191,46 +216,47 @@ function parsePasswordAndHost(parts: string[]): {
   const canHaveSmtpHostPort =
     tail.length >= 5 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!) && looksLikeHost(tail.at(-4) ?? '') // ensure there's an IMAP host before
   if (canHaveSmtpHostPort) {
-    smtpPort = parsePort(tail.at(-1)!) // may be undefined if out-of-range → buildSmtpConfig defaults
+    port = parsePort(tail.at(-1)!) // may be undefined if out-of-range → buildSmtpConfig defaults
     tail.pop()
-    smtpHost = tail.pop()
+    host = tail.pop()
   }
 
   // 3. SMTP host without explicit port (only valid when security was popped
   //    OR when there's an explicit IMAP host:port already detected).
-  if (!smtpHost && popped_security && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
-    smtpHost = tail.pop()
+  if (!host && popped_security && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
+    host = tail.pop()
   }
 
   // If security keyword was tentatively popped but no SMTP host was found,
   // restore it — the keyword is part of the password.
-  if (popped_security && !smtpHost) {
-    tail.push(smtpSecurity!)
-    smtpSecurity = undefined
+  if (popped_security && !host) {
+    tail.push(security!)
+    security = undefined
   }
 
-  // 4. IMAP host + port (port may be out-of-range; resolveServerConfig
-  //    falls back to default 993 when port is undefined).
+  return { host, port, security }
+}
+
+/**
+ * Extract IMAP segments from the tail of the credential string.
+ * This includes optional host and port.
+ */
+function extractImapSegments(tail: string[]): { host?: string; port?: number } {
+  let host: string | undefined
+  let port: number | undefined
+
+  // IMAP host + port (port may be out-of-range; resolveServerConfig
+  // falls back to default 993 when port is undefined).
   if (tail.length >= 3 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!)) {
-    imapPort = parsePort(tail.at(-1)!)
+    port = parsePort(tail.at(-1)!)
     tail.pop()
-    imapHost = tail.pop()
+    host = tail.pop()
   } else if (looksLikeHost(tail.at(-1)!)) {
     // Trailing host segment, default IMAP port
-    imapHost = tail.pop()
+    host = tail.pop()
   }
 
-  // 5. Whatever remains (after the email shift) is the password.
-  const password = tail.join(':')
-
-  return {
-    password,
-    customImapHost: imapHost,
-    customImapPort: imapPort,
-    customSmtpHost: smtpHost,
-    customSmtpPort: smtpPort,
-    customSmtpSecurity: smtpSecurity
-  }
+  return { host, port }
 }
 
 /**
@@ -333,24 +359,20 @@ function resolveServerConfig(
 }
 
 /**
- * Parse a single credential entry
+ * Handle logic for OAuth2-only (Outlook) email-only entry
  */
-async function parseSingleCredential(entry: string): Promise<AccountConfig | null> {
-  const trimmed = entry.trim()
-  if (!trimmed) return null
+async function handleOAuth2OnlyEntry(email: string): Promise<AccountConfig | null> {
+  const account = await createOAuth2Account(email)
+  if (account) return account
 
-  const parts = trimmed.split(':')
-  const email = parts[0]!.trim()
+  console.error('Skipping invalid credential entry (expected email:password)')
+  return null
+}
 
-  // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
-  if (parts.length < 2) {
-    const account = await createOAuth2Account(email)
-    if (account) return account
-
-    console.error('Skipping invalid credential entry (expected email:password)')
-    return null
-  }
-
+/**
+ * Handle logic for standard email:password entries (with optional host overrides)
+ */
+async function handlePasswordEntry(email: string, parts: string[]): Promise<AccountConfig | null> {
   const { password, customImapHost, customImapPort, customSmtpHost, customSmtpPort, customSmtpSecurity } =
     parsePasswordAndHost(parts)
 
@@ -381,6 +403,24 @@ async function parseSingleCredential(entry: string): Promise<AccountConfig | nul
   }
 
   return account
+}
+
+/**
+ * Parse a single credential entry
+ */
+async function parseSingleCredential(entry: string): Promise<AccountConfig | null> {
+  const trimmed = entry.trim()
+  if (!trimmed) return null
+
+  const parts = trimmed.split(':')
+  const email = parts[0]!.trim()
+
+  // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
+  if (parts.length < 2) {
+    return handleOAuth2OnlyEntry(email)
+  }
+
+  return handlePasswordEntry(email, parts)
 }
 
 /**


### PR DESCRIPTION
The `parseSingleCredential` function and its helper `parsePasswordAndHost` were identified as being too long and complex, handling multiple credential string formats in a single flow.

This PR refactors these functions by delegating different parsing strategies to separate helper functions:
- `handleOAuth2OnlyEntry`: Processes email-only entries for OAuth2 providers (Outlook).
- `handlePasswordEntry`: Processes standard email:password entries with optional host/port overrides.
- `extractSmtpSegments`: Parses custom SMTP configuration from the credential string segments.
- `extractImapSegments`: Parses custom IMAP configuration from the credential string segments.

These changes improve maintainability and readability without altering the existing functionality, as verified by the full test suite.

---
*PR created automatically by Jules for task [11764422140180375081](https://jules.google.com/task/11764422140180375081) started by @n24q02m*