### PR TITLE
[CLEANUP] Use of 'any' Type: buildSearchCriteria

### DIFF
--- a/final_touches.py
+++ b/final_touches.py
@@ -1,0 +1,40 @@
+import sys
+
+file_path = 'src/tools/helpers/imap-client.ts'
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Refine formatAddress for better robustness and type safety
+new_format_address = """function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
+  if (!addr) return ''
+  if (typeof addr === 'string') return addr
+
+  if (Array.isArray(addr)) {
+    return addr.map((a) => formatAddress(a)).filter(Boolean).join(', ')
+  }
+
+  if (addr.text) return addr.text
+
+  if (addr.value && Array.isArray(addr.value)) {
+    return addr.value
+      .map((a: EmailAddress) => {
+        if (a.name && a.address) return `${a.name} <${a.address}>`
+        return a.address || a.name || ''
+      })
+      .filter(Boolean)
+      .join(', ')
+  }
+  return ''
+}"""
+
+import re
+content = re.sub(r'function formatAddress\(addr: AddressObject \| AddressObject\[\] \| string \| undefined \| null\): string \{.*?\}', new_format_address, content, flags=re.DOTALL)
+
+# Remove unnecessary cast in searchEmails
+content = content.replace(
+    'flags: Array.from((msg.flags as Set<string> | string[]) || []),',
+    'flags: Array.from(msg.flags || []),'
+)
+
+with open(file_path, 'w') as f:
+    f.write(content)

--- a/fix_format_address.py
+++ b/fix_format_address.py
@@ -1,0 +1,49 @@
+import sys
+import re
+
+file_path = 'src/tools/helpers/imap-client.ts'
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Define the correctly implemented function
+correct_implementation = """/**
+ * Format email address from parsed address object
+ */
+function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
+  if (!addr) return ''
+  if (typeof addr === 'string') return addr
+
+  if (Array.isArray(addr)) {
+    return addr.map((a) => formatAddress(a)).filter(Boolean).join(', ')
+  }
+
+  if (addr.text) return addr.text
+
+  if (addr.value && Array.isArray(addr.value)) {
+    return addr.value
+      .map((a: EmailAddress) => {
+        if (a.name && a.address) return `${a.name} <${a.address}>`
+        return a.address || a.name || ''
+      })
+      .filter(Boolean)
+      .join(', ')
+  }
+  return ''
+}"""
+
+# Find the start of formatAddress and replace until the end of the messed up version
+start_pattern = r'/\*\*\s+\* Format email address from parsed address object\s+\*/'
+# We'll search for the messed up ending to find the limit
+end_marker = r'return \'\'\s+\}\s+<\$\{a\.address\}>` : a\.address\)\)\.join\(\', \'\)\s+\}\s+\}'
+
+# Since the previous regex failed to clean up properly, let's just find the markers and replace
+match_start = re.search(start_pattern, content)
+match_end = re.search(end_marker, content)
+
+if match_start and match_end:
+    new_content = content[:match_start.start()] + correct_implementation + content[match_end.end():]
+    with open(file_path, 'w') as f:
+        f.write(new_content)
+    print("Successfully fixed formatAddress")
+else:
+    print("Could not find markers to fix formatAddress")

--- a/fix_format_address_v2.py
+++ b/fix_format_address_v2.py
@@ -1,0 +1,52 @@
+import sys
+
+file_path = 'src/tools/helpers/imap-client.ts'
+with open(file_path, 'r') as f:
+    lines = f.readlines()
+
+# Correct implementation lines
+correct_impl = [
+    "/**\n",
+    " * Format email address from parsed address object\n",
+    " */\n",
+    "function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {\n",
+    "  if (!addr) return ''\n",
+    "  if (typeof addr === 'string') return addr\n",
+    "\n",
+    "  if (Array.isArray(addr)) {\n",
+    "    return addr.map((a) => formatAddress(a)).filter(Boolean).join(', ')\n",
+    "  }\n",
+    "\n",
+    "  if (addr.text) return addr.text\n",
+    "\n",
+    "  if (addr.value && Array.isArray(addr.value)) {\n",
+    "    return addr.value\n",
+    "      .map((a: EmailAddress) => {\n",
+    "        if (a.name && a.address) return `${a.name} <${a.address}>`\n",
+    "        return a.address || a.name || ''\n",
+    "      })\n",
+    "      .filter(Boolean)\n",
+    "      .join(', ')\n",
+    "  }\n",
+    "  return ''\n",
+    "}\n"
+]
+
+new_lines = []
+skip = False
+for i, line in enumerate(lines):
+    if "/**" in line and i + 1 < len(lines) and "Format email address from parsed address object" in lines[i+1]:
+        new_lines.extend(correct_impl)
+        skip = True
+    elif skip:
+        if "// ============================================================================" in line:
+            new_lines.append("\n")
+            new_lines.append(line)
+            skip = False
+        else:
+            continue
+    else:
+        new_lines.append(line)
+
+with open(file_path, 'w') as f:
+    f.writelines(new_lines)

--- a/fix_imap.py
+++ b/fix_imap.py
@@ -1,0 +1,15 @@
+import sys
+
+file_path = 'src/tools/helpers/imap-client.ts'
+with open(file_path, 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+for line in lines:
+    if ';(criteria as any)[criteriaKey] = kvMatch[1]!.replace(/^["\']|["\']$/g, \'\')' in line:
+        new_lines.append('      Object.assign(criteria, { [criteriaKey]: kvMatch[1]!.replace(/^["\']|["\']$/g, \'\') })\n')
+    else:
+        new_lines.append(line)
+
+with open(file_path, 'w') as f:
+    f.writelines(new_lines)

--- a/fix_mailbox_type.py
+++ b/fix_mailbox_type.py
@@ -1,0 +1,14 @@
+import sys
+
+file_path = 'src/tools/helpers/imap-client.ts'
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Replace MailboxObject with ListResponse in import
+content = content.replace('type MailboxObject', 'type ListResponse')
+
+# Replace MailboxObject with ListResponse in listFolders
+content = content.replace('mb: MailboxObject', 'mb: ListResponse')
+
+with open(file_path, 'w') as f:
+    f.write(content)

--- a/refactor_others.py
+++ b/refactor_others.py
@@ -1,0 +1,40 @@
+import sys
+
+file_path = 'src/tools/helpers/imap-client.ts'
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Refactor formatAddress
+content = content.replace(
+    'function formatAddress(addr: any): string {',
+    'function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {'
+)
+content = content.replace(
+    'return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(\', \')',
+    'return addr.value.map((a: EmailAddress) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(\', \')'
+)
+
+# Refactor searchEmails mapper
+content = content.replace(
+    'const summaries = await mapLimit(emails, 5, async (msg: any) => {',
+    'const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {'
+)
+content = content.replace(
+    'to: msg.envelope?.to?.map((a: any) => a.address).join(\', \') || \'\',',
+    'to: msg.envelope?.to?.map((a: MessageAddressObject) => a.address).join(\', \') || \'\','
+)
+
+# Refactor readEmail attachment mapping
+content = content.replace(
+    'attachments: (parsed.attachments || []).map((att: any) => ({',
+    'attachments: (parsed.attachments || []).map((att: Attachment) => ({'
+)
+
+# Refactor listFolders mapping
+content = content.replace(
+    'return mailboxes.map((mb: any) => ({',
+    'return mailboxes.map((mb: MailboxObject) => ({'
+)
+
+with open(file_path, 'w') as f:
+    f.write(content)

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,8 +3,20 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import {
+  type FetchMessageObject,
+  ImapFlow,
+  type ListResponse,
+  type MessageAddressObject,
+  type SearchObject
+} from 'imapflow'
+import {
+  type AddressObject,
+  type Attachment,
+  type EmailAddress,
+  type SimpleParserOptions,
+  simpleParser
+} from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -145,7 +157,7 @@ function buildSearchCriteria(query: string): SearchObject {
   //    Check longer prefixes first to avoid partial matches (UNFLAGGED before FLAGGED, etc.)
   for (const { pattern, key, value } of FLAG_MATCHERS) {
     if (pattern.test(remaining)) {
-      ;(criteria as any)[key] = value
+      Object.assign(criteria, { [key]: value })
       remaining = remaining.replace(pattern, ' ').trim()
     }
   }
@@ -156,7 +168,7 @@ function buildSearchCriteria(query: string): SearchObject {
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = new Date(dateMatch[1]!)
+      Object.assign(criteria, { [criteriaKey]: new Date(dateMatch[1]!) })
       remaining = remaining.replace(dateMatch[0], ' ').trim()
     } else if (invalid.test(remaining)) {
       throw new EmailMCPError(
@@ -172,7 +184,7 @@ function buildSearchCriteria(query: string): SearchObject {
     const kvMatch = remaining.match(KV_MATCHERS[keyword])
     if (kvMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      ;(criteria as any)[criteriaKey] = kvMatch[1]!.replace(/^["']|["']$/g, '')
+      Object.assign(criteria, { [criteriaKey]: kvMatch[1]!.replace(/^["']|["']$/g, '') })
       remaining = remaining.replace(kvMatch[0], ' ').trim()
     }
   }
@@ -236,12 +248,27 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
+
+  if (Array.isArray(addr)) {
+    return addr
+      .map((a) => formatAddress(a))
+      .filter(Boolean)
+      .join(', ')
+  }
+
   if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+
+  if (addr.value && Array.isArray(addr.value)) {
+    return addr.value
+      .map((a: EmailAddress) => {
+        if (a.name && a.address) return `${a.name} <${a.address}>`
+        return a.address || a.name || ''
+      })
+      .filter(Boolean)
+      .join(', ')
   }
   return ''
 }
@@ -365,7 +392,7 @@ export async function searchEmails(
       // This ensures the IMAP connection and mailbox lock are released as quickly as possible.
       // We use `mapLimit` with a concurrency of 5 instead of a sequential for...of loop or unbounded Promise.all
       // to improve performance without blocking the event loop or causing memory spikes from CPU-heavy MIME parsing.
-      const summaries = await mapLimit(emails, 5, async (msg: any) => {
+      const summaries = await mapLimit(emails, 5, async (msg: FetchMessageObject) => {
         const snippet = msg.source ? await extractSnippet(msg.source) : ''
 
         return {
@@ -377,9 +404,9 @@ export async function searchEmails(
           from: msg.envelope?.from?.[0]
             ? `${msg.envelope.from[0].name || ''} <${msg.envelope.from[0].address || ''}>`.trim()
             : '',
-          to: msg.envelope?.to?.map((a: any) => a.address).join(', ') || '',
+          to: msg.envelope?.to?.map((a: MessageAddressObject) => a.address).join(', ') || '',
           date: msg.envelope?.date?.toISOString() || '',
-          flags: Array.from((msg.flags as Set<string> | string[]) || []),
+          flags: Array.from(msg.flags || []),
           snippet
         }
       })
@@ -447,7 +474,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,
@@ -529,7 +556,7 @@ export async function trashEmails(
 export async function listFolders(account: AccountConfig): Promise<FolderInfo[]> {
   return withConnection(account, async (client) => {
     const mailboxes = await client.list()
-    return mailboxes.map((mb: any) => ({
+    return mailboxes.map((mb: ListResponse) => ({
       name: mb.name,
       path: mb.path,
       flags: Array.from(mb.flags || []),


### PR DESCRIPTION
This PR removes the use of the `any` type in `src/tools/helpers/imap-client.ts`, specifically in `buildSearchCriteria`, `formatAddress`, `searchEmails`, `readEmail`, and `listFolders`. 

Key changes:
- Refactored `buildSearchCriteria` to use `Object.assign` for type-safe dynamic property assignment to `SearchObject`, eliminating `any` assertions.
- Updated `formatAddress` to be more robust and type-safe using `AddressObject`, `EmailAddress`, and recursive handling for arrays.
- Replaced `any` in `searchEmails`, `readEmail`, and `listFolders` with specific types from `imapflow` and `mailparser` (`FetchMessageObject`, `ListResponse`, `Attachment`, `MessageAddressObject`).
- Updated imports to include the necessary type definitions from `imapflow` and `mailparser`.
- Verified changes with `bun run check` (type-checking and linting) and `bun run test` (unit tests).

---
*PR created automatically by Jules for task [9367930261202194712](https://jules.google.com/task/9367930261202194712) started by @n24q02m*