### PR TITLE
[FIX] Potential flaky test using setTimeout in http.test.ts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+## 2025-05-14 - [Performance/Flakiness] Deterministic synchronization in HTTP server tests
+ **Learning:** In asynchronous tests involving signal handlers (like SIGINT/SIGTERM), waiting only for the server startup call (e.g., `runHttpServer`) can cause race conditions if the signal handler attachment happens later.
+ **Action:** Always use `vi.waitFor` to ensure both the server is initialized AND signal handlers are truthy before attempting to trigger a shutdown or proceed with assertions.

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -103,7 +103,10 @@ describe('http transport', () => {
     const startPromise = startHttp()
 
     // Wait for the server to start
-    await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+    await vi.waitFor(() => {
+      expect(sigintHandler).toBeTruthy()
+      expect(runHttpServer).toHaveBeenCalled()
+    })
 
     if (fn) await fn()
 
@@ -141,7 +144,10 @@ describe('http transport', () => {
     beforeEach(async () => {
       // Start server and capture the callback
       startHttp()
-      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+      await vi.waitFor(() => {
+        expect(sigintHandler).toBeTruthy()
+        expect(runHttpServer).toHaveBeenCalled()
+      })
       onCredentialsSaved = vi.mocked(runHttpServer).mock.calls[0][1].onCredentialsSaved
     })
 
@@ -383,7 +389,10 @@ describe('http transport', () => {
       vi.mocked(loadConfig).mockResolvedValue(mockAccounts as any)
 
       const startPromise = startHttp()
-      await vi.waitFor(() => expect(runHttpServer).toHaveBeenCalled())
+      await vi.waitFor(() => {
+        expect(sigintHandler).toBeTruthy()
+        expect(runHttpServer).toHaveBeenCalled()
+      })
 
       const factory = vi.mocked(runHttpServer).mock.calls[0][0]
 


### PR DESCRIPTION
This PR improves the reliability of the HTTP transport tests by making the synchronization deterministic.

Key changes:
- Updated `runStartHttpAndTriggerShutdown` helper to wait for both `sigintHandler` and `runHttpServer`.
- Updated `beforeEach` block in `onCredentialsSaved` tests to ensure proper setup before assertions.
- Updated `serverFactory` test for consistent synchronization.

These changes ensure that signal handlers are correctly attached before any shutdown is triggered, eliminating potential flakiness in the test suite.

---
*PR created automatically by Jules for task [13761573231580908785](https://jules.google.com/task/13761573231580908785) started by @n24q02m*