### PR TITLE
[SECURITY] Unvalidated JSON Parsing in OAuth Token Store

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** The `deriveKey` function in `src/auth/per-user-credential-store.ts` used a generic `process.env.VITEST` check to downgrade PBKDF2 iterations from 600,000 to 1,000. This could potentially allow an attacker to downgrade security in production by setting the `VITEST` environment variable.
 **Learning:** Security-sensitive parameters like cryptographic iteration counts should rely on strict environment checks (e.g., `NODE_ENV === 'test'`) rather than generic or easily spoofable variables.
 **Prevention:** Use `process.env.NODE_ENV === 'test'` for test-only security downgrades and allow sensitive parameters to be explicitly configured via function arguments to avoid reliance on global state.
+
+## 2025-02-11 - Unvalidated JSON Parsing in OAuth Token Store
+ **Vulnerability:** Unchecked `JSON.parse` output when loading the OAuth2 token store or encrypted configurations.
+ **Learning:** Accessing properties on unvalidated `JSON.parse` results can cause runtime crashes (TypeErrors) if the file is malformed or contains unexpected primitive values.
+ **Prevention:** Use robust type guards (`isValidTokenStore`, `isValidAccountConfigs`) immediately after parsing. Ensure these guards check for `null`, `Array.isArray`, and validate internal field types and constraints (e.g., non-empty strings for tokens, positive numbers for expiration).

--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -194,7 +194,7 @@ export async function loadUserCredentials(userId: string): Promise<AccountConfig
       new Uint8Array(ciphertext)
     )
     const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-    if (!isValidAccountConfigs(parsed.accounts)) {
+    if (!parsed || typeof parsed !== 'object' || !isValidAccountConfigs(parsed.accounts)) {
       throw new Error('Invalid account configuration in stored credentials')
     }
     return parsed.accounts
@@ -242,7 +242,12 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
         new Uint8Array(ciphertext)
       )
       const parsed = JSON.parse(new TextDecoder().decode(decrypted))
-      if (typeof parsed.userId === 'string' && isValidAccountConfigs(parsed.accounts)) {
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof parsed.userId === 'string' &&
+        isValidAccountConfigs(parsed.accounts)
+      ) {
         result.set(parsed.userId, parsed.accounts)
       }
     } catch (err: unknown) {

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -22,6 +22,7 @@ vi.mock('./tools/helpers/config.js', () => ({
 vi.mock('./tools/helpers/oauth2.js', () => ({
   ensureValidToken: vi.fn(),
   isOutlookDomain: vi.fn().mockReturnValue(false),
+  isValidTokenStore: vi.fn().mockReturnValue(true),
   _getPendingAuths: vi.fn().mockReturnValue(new Set())
 }))
 

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -103,7 +103,11 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     const tokenFile = join(homedir(), '.better-email-mcp', 'tokens.json')
 
     const data = await readFile(tokenFile, 'utf-8')
-    const store: Record<string, unknown> = JSON.parse(data)
+    const { isValidTokenStore } = await import('./tools/helpers/oauth2.js')
+    const store: unknown = JSON.parse(data)
+    if (!isValidTokenStore(store)) {
+      throw new Error('Invalid token store')
+    }
     const emails = Object.keys(store).filter((key) => key.includes('@'))
     if (emails.length > 0) {
       const credentials = emails.map((email) => `${email}:oauth2`).join(',')

--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -160,8 +160,8 @@ describe('loadStoredTokens', () => {
     const tokens: OAuth2Tokens = {
       accessToken: 'at',
       refreshToken: 'rt',
-      expiresAt: 0,
-      clientId: 'c'
+      expiresAt: 1,
+      clientId: 'c-valid'
     }
     mockReadFile.mockResolvedValue(JSON.stringify({ 'user@outlook.com': tokens }))
 
@@ -224,7 +224,9 @@ describe('saveTokens', () => {
   })
 
   it('merges with existing tokens', () => {
-    const existing = { 'other@hotmail.com': { accessToken: 'old', refreshToken: 'old', expiresAt: 0, clientId: 'c' } }
+    const existing = {
+      'other@hotmail.com': { accessToken: 'old', refreshToken: 'old', expiresAt: 1, clientId: 'c-valid' }
+    }
 
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return true
@@ -391,7 +393,7 @@ describe('ensureValidToken', () => {
       oauth2: {
         accessToken: 'old',
         refreshToken: 'old-rt',
-        expiresAt: 0,
+        expiresAt: 1,
         clientId: 'cid'
       }
     }
@@ -535,7 +537,7 @@ describe('ensureValidToken', () => {
       oauth2: {
         accessToken: 'old',
         refreshToken: 'keep-this-rt',
-        expiresAt: 0,
+        expiresAt: 1,
         clientId: 'cid'
       }
     }
@@ -876,15 +878,15 @@ describe('loadStoredTokens validation', () => {
   })
 
   it('isValidTokens validates structure correctly', () => {
-    expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c' })).toBe(true)
-    expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: '1', clientId: 'c' })).toBe(false)
-    expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', clientId: 'c' })).toBe(false)
+    expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c-valid' })).toBe(true)
+    expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: '1', clientId: 'c-valid' })).toBe(false)
+    expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', clientId: 'c-valid' })).toBe(false)
     expect(isValidTokens(null)).toBe(false)
     expect(isValidTokens('not-an-object')).toBe(false)
   })
 
   it('isValidTokenStore validates store correctly', () => {
-    const valid = { 'a@b.com': { accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c' } }
+    const valid = { 'a@b.com': { accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c-valid' } }
     expect(isValidTokenStore(valid)).toBe(true)
     expect(isValidTokenStore({ ...valid, 'x@y.com': { bad: true } })).toBe(false)
     expect(isValidTokenStore([])).toBe(false)

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -79,9 +79,14 @@ export function isValidTokens(data: unknown): data is OAuth2Tokens {
   const d = data as Record<string, unknown>
   return (
     typeof d.accessToken === 'string' &&
+    d.accessToken.length > 0 &&
     typeof d.refreshToken === 'string' &&
+    d.refreshToken.length > 0 &&
     typeof d.expiresAt === 'number' &&
-    typeof d.clientId === 'string'
+    !Number.isNaN(d.expiresAt) &&
+    d.expiresAt > 0 &&
+    typeof d.clientId === 'string' &&
+    d.clientId.length > 0
   )
 }
 


### PR DESCRIPTION
This PR addresses a security vulnerability where `JSON.parse` results were accessed without proper validation, potentially leading to runtime crashes or logic errors if data files were malformed.

Key changes:
- Hardened `isValidTokens` and `isValidTokenStore` in `src/tools/helpers/oauth2.ts` with strict length and value checks.
- Integrated `isValidTokenStore` into `src/credential-state.ts` for safe token loading.
- Added non-null object checks before property access in `src/auth/per-user-credential-store.ts`.
- Updated test suites to accommodate and verify the new validation logic.

---
*PR created automatically by Jules for task [15365133177146866513](https://jules.google.com/task/15365133177146866513) started by @n24q02m*