### PR TITLE
🎨 Palette: Add focus management to form validation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,7 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+
+## 2024-06-10 - Adding form validation for novalidate forms
+**Learning:** For forms that use the `novalidate` attribute to disable default browser tooltips and allow custom inline error styling, standard validation logic needs to be manually triggered on submission. Otherwise, users who bypass individual field interactions and directly submit the form will receive no feedback or indication of missing fields, breaking accessibility and form submission UX.
+**Action:** Always call `form.checkValidity()` in the form's `submit` event listener to explicitly evaluate constraints. On failure, query for the first invalid element (e.g. `form.querySelector('input:invalid')`) and programmatically apply `.focus()` so that screen readers and keyboard users are immediately guided to the error.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -722,6 +722,14 @@ export function renderEmailCredentialForm(
                 evt.preventDefault();
                 statusBox.style.display = "none";
 
+                if (!form.checkValidity()) {
+                    var firstInvalid = form.querySelector("input:invalid, select:invalid, textarea:invalid");
+                    if (firstInvalid && firstInvalid instanceof HTMLElement) {
+                        firstInvalid.focus();
+                    }
+                    return;
+                }
+
                 var collected = collectAccounts();
 
                 if (collected.accounts.length === 0) {


### PR DESCRIPTION
The credential form uses the `novalidate` attribute to support custom styling and to prevent the default browser validation bubbles. However, doing so disables the native behavior where the browser automatically halts submission and focuses the first invalid field. 

Previously, clicking "Connect" on an invalid form would not trigger any validation events or focus shifts unless the user had already interacted with the required fields.

This PR fixes this by manually calling `form.checkValidity()` inside the `submit` event listener. If validation fails, it programmatically queries for the first invalid element (`input:invalid, select:invalid, textarea:invalid`) and applies `.focus()` to it (with strict `instanceof HTMLElement` checks to satisfy TypeScript). 

This micro-UX improvement ensures screen-reader and keyboard users are seamlessly guided to correct their input errors upon submission.

---
*PR created automatically by Jules for task [17567430089913514056](https://jules.google.com/task/17567430089913514056) started by @n24q02m*