### PR TITLE
[FIX] Invoke markSetupCompleteFn after saving tokens

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -25,7 +25,13 @@ import { ImapFlow } from 'imapflow'
 import { InMemoryCredStore } from '../auth/in-memory-cred-store.js'
 import { subjectContext } from '../auth/subject-context.js'
 import { renderEmailCredentialForm } from '../credential-form.js'
-import { resolveCredentialState, setMarkSetupComplete, setSetupUrl, setState } from '../credential-state.js'
+import {
+  getMarkSetupComplete,
+  resolveCredentialState,
+  setMarkSetupComplete,
+  setSetupUrl,
+  setState
+} from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
@@ -102,6 +108,7 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[]): Promise<N
   const first = outlookPending[0] as AccountConfig
   try {
     const device = await initiateOutlookDeviceCode(first.email, () => {
+      getMarkSetupComplete()?.('outlook')
       console.error(`[${SERVER_NAME}] Outlook OAuth2 completed for ${first.email}`)
     })
     setState('setup_in_progress')


### PR DESCRIPTION
The Outlook OAuth2 device code flow completes in the background. While the background poll in `oauth2.ts` already signals completion, the architectural requirement (as noted in the regression tests) is that the transport layer's callback should also explicitly signal completion for the 'outlook' key. This change adds the missing `getMarkSetupComplete()?.('outlook')` call to the `onComplete` callback in `src/transports/http.ts`.

---
*PR created automatically by Jules for task [1671257518846634388](https://jules.google.com/task/1671257518846634388) started by @n24q02m*