### PR TITLE
[CLEANUP] Use of 'any' Type: formatAddress

### DIFF
--- a/apply_patch.py
+++ b/apply_patch.py
@@ -1,0 +1,38 @@
+import sys
+
+def apply_merge_diff(file_path, patch_path):
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    with open(patch_path, 'r') as f:
+        patch = f.read()
+
+    search_start = patch.find('<<<<<<< SEARCH')
+    search_end = patch.find('=======')
+    replace_start = search_end + len('=======')
+    replace_end = patch.find('>>>>>>> REPLACE')
+
+    if search_start == -1 or search_end == -1 or replace_end == -1:
+        print("Invalid patch format")
+        return False
+
+    search_text = patch[search_start + len('<<<<<<< SEARCH'):search_end].strip('\n')
+    replace_text = patch[replace_start:replace_end].strip('\n')
+
+    if search_text not in content:
+        print("Search text not found in file")
+        # Let's see what's actually there to debug
+        # print(f"DEBUG: Looking for:\n'{search_text}'")
+        return False
+
+    new_content = content.replace(search_text, replace_text)
+
+    with open(file_path, 'w') as f:
+        f.write(new_content)
+    return True
+
+if __name__ == "__main__":
+    if apply_merge_diff(sys.argv[1], sys.argv[2]):
+        print("Patch applied successfully")
+    else:
+        sys.exit(1)

--- a/src/tools/helpers/imap-client.test.ts
+++ b/src/tools/helpers/imap-client.test.ts
@@ -622,6 +622,16 @@ describe('formatAddress edge cases', () => {
     expect(result.from).toBe('john@test.com')
   })
 
+  it('formats array of AddressObject', async () => {
+    setupReadEmail({
+      to: [{ text: 'To 1 <to1@test.com>' }, { value: [{ name: 'To 2', address: 'to2@test.com' }] }]
+    })
+
+    const result = await readEmail(account, 1, 'INBOX')
+
+    expect(result.to).toBe('To 1 <to1@test.com>, To 2 <to2@test.com>')
+  })
+
   it('formats value array with multiple entries', async () => {
     setupReadEmail({
       to: {

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -4,7 +4,13 @@
  */
 
 import { ImapFlow, type SearchObject } from 'imapflow'
-import { type SimpleParserOptions, simpleParser } from 'mailparser'
+import {
+  type AddressObject,
+  type Attachment,
+  type EmailAddress,
+  type SimpleParserOptions,
+  simpleParser
+} from 'mailparser'
 import type { AccountConfig } from './config.js'
 import { EmailMCPError } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
@@ -236,13 +242,26 @@ async function extractSnippet(source: string | Buffer, maxLength = 200): Promise
 /**
  * Format email address from parsed address object
  */
-function formatAddress(addr: any): string {
+function formatAddress(addr: AddressObject | AddressObject[] | string | undefined | null): string {
   if (!addr) return ''
   if (typeof addr === 'string') return addr
-  if (addr.text) return addr.text
-  if (Array.isArray(addr.value)) {
-    return addr.value.map((a: any) => (a.name ? `${a.name} <${a.address}>` : a.address)).join(', ')
+
+  if (Array.isArray(addr)) {
+    return addr
+      .map((a) => formatAddress(a))
+      .filter(Boolean)
+      .join(', ')
   }
+
+  if (addr.text) return addr.text
+
+  if (Array.isArray(addr.value)) {
+    return addr.value
+      .map((a: EmailAddress) => (a.name ? `${a.name} <${a.address}>` : a.address))
+      .filter(Boolean)
+      .join(', ')
+  }
+
   return ''
 }
 
@@ -447,7 +466,7 @@ export async function readEmail(account: AccountConfig, uid: number, folder: str
     date: parsed.date?.toISOString() || '',
     flags: Array.from(fetchResult.flags || []),
     body_text: bodyText,
-    attachments: (parsed.attachments || []).map((att: any) => ({
+    attachments: (parsed.attachments || []).map((att: Attachment) => ({
       filename: att.filename || 'unnamed',
       content_type: att.contentType || 'application/octet-stream',
       size: att.size || 0,


### PR DESCRIPTION
Refactored 'formatAddress' and attachment mapping in 'imap-client.ts' to use proper TypeScript types from 'mailparser', eliminating the use of 'any' and improving type safety. Added a test case for handling arrays of address objects.

---
*PR created automatically by Jules for task [5698034850423130222](https://jules.google.com/task/5698034850423130222) started by @n24q02m*