### PR TITLE
[FIX] Long Function: parseSingleCredential

### DIFF
--- a/src/tools/helpers/config.ts
+++ b/src/tools/helpers/config.ts
@@ -123,10 +123,79 @@ function looksLikeHost(segment: string): boolean {
   return segment.includes('.') || segment.toLowerCase() === 'localhost'
 }
 
+/**
+ * Whether a segment looks like a port attempt
+ */
+const isPortSegment = (s: string) => /^\d+$/.test(s)
+
 export type SmtpSecurity = 'tls' | 'ssl' | 'starttls' | 'none'
 
 function isSmtpSecurity(segment: string): segment is SmtpSecurity {
   return /^(tls|ssl|starttls|none)$/i.test(segment)
+}
+
+/**
+ * Extract SMTP segments from the tail of the credential string
+ */
+function extractSmtpSegments(tail: string[]): {
+  smtpHost?: string
+  smtpPort?: number
+  smtpSecurity?: SmtpSecurity
+} {
+  let smtpSecurity: SmtpSecurity | undefined
+  let smtpHost: string | undefined
+  let smtpPort: number | undefined
+
+  // 1. Optional SMTP security keyword at end
+  let poppedSecurity = false
+  if (tail.length >= 4 && isSmtpSecurity(tail.at(-1)!)) {
+    smtpSecurity = tail.at(-1)!.toLowerCase() as SmtpSecurity
+    tail.pop()
+    poppedSecurity = true
+  }
+
+  // 2. SMTP host + port
+  const canHaveSmtpHostPort =
+    tail.length >= 5 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!) && looksLikeHost(tail.at(-4) ?? '')
+  if (canHaveSmtpHostPort) {
+    smtpPort = parsePort(tail.at(-1)!)
+    tail.pop()
+    smtpHost = tail.pop()
+  }
+
+  // 3. SMTP host without explicit port
+  if (!smtpHost && poppedSecurity && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
+    smtpHost = tail.pop()
+  }
+
+  // If security keyword was tentatively popped but no SMTP host was found, restore it
+  if (poppedSecurity && !smtpHost) {
+    tail.push(smtpSecurity!)
+    smtpSecurity = undefined
+  }
+
+  return { smtpHost, smtpPort, smtpSecurity }
+}
+
+/**
+ * Extract IMAP segments from the tail of the credential string
+ */
+function extractImapSegments(tail: string[]): {
+  imapHost?: string
+  imapPort?: number
+} {
+  let imapHost: string | undefined
+  let imapPort: number | undefined
+
+  if (tail.length >= 3 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!)) {
+    imapPort = parsePort(tail.at(-1)!)
+    tail.pop()
+    imapHost = tail.pop()
+  } else if (looksLikeHost(tail.at(-1)!)) {
+    imapHost = tail.pop()
+  }
+
+  return { imapHost, imapPort }
 }
 
 /**
@@ -162,65 +231,11 @@ function parsePasswordAndHost(parts: string[]): {
 
   // Mutable tail; pop SMTP, then IMAP, then rest is password.
   const tail = parts.slice(1)
-  let smtpSecurity: SmtpSecurity | undefined
-  let smtpHost: string | undefined
-  let smtpPort: number | undefined
-  let imapHost: string | undefined
-  let imapPort: number | undefined
 
-  // 1. Optional SMTP security keyword at end (only valid when an SMTP host
-  //    can also be detected; otherwise the keyword belongs to the password).
-  //    We tentatively pop + restore if SMTP host parsing fails.
-  let popped_security = false
-  if (tail.length >= 4 && isSmtpSecurity(tail.at(-1)!)) {
-    smtpSecurity = tail.at(-1)!.toLowerCase() as SmtpSecurity
-    tail.pop()
-    popped_security = true
-  }
+  const { smtpHost, smtpPort, smtpSecurity } = extractSmtpSegments(tail)
+  const { imapHost, imapPort } = extractImapSegments(tail)
 
-  // Helper: an "all-digit" segment looks like a port attempt (even if value
-  // is out-of-range, in which case parsePort returns undefined and the
-  // caller falls back to the protocol-default port).
-  const isPortSegment = (s: string) => /^\d+$/.test(s)
-
-  // 2. SMTP host + port (host:port pair). Detected only when tail has BOTH:
-  //    - tail.at(-1) is all-digit (a port attempt)
-  //    - tail.at(-2) is a host
-  //    AND there's another preceding host (the IMAP host) — otherwise the
-  //    "host:port" we see IS the IMAP host:port and there's no SMTP suffix.
-  const canHaveSmtpHostPort =
-    tail.length >= 5 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!) && looksLikeHost(tail.at(-4) ?? '') // ensure there's an IMAP host before
-  if (canHaveSmtpHostPort) {
-    smtpPort = parsePort(tail.at(-1)!) // may be undefined if out-of-range → buildSmtpConfig defaults
-    tail.pop()
-    smtpHost = tail.pop()
-  }
-
-  // 3. SMTP host without explicit port (only valid when security was popped
-  //    OR when there's an explicit IMAP host:port already detected).
-  if (!smtpHost && popped_security && tail.length >= 3 && looksLikeHost(tail.at(-1)!)) {
-    smtpHost = tail.pop()
-  }
-
-  // If security keyword was tentatively popped but no SMTP host was found,
-  // restore it — the keyword is part of the password.
-  if (popped_security && !smtpHost) {
-    tail.push(smtpSecurity!)
-    smtpSecurity = undefined
-  }
-
-  // 4. IMAP host + port (port may be out-of-range; resolveServerConfig
-  //    falls back to default 993 when port is undefined).
-  if (tail.length >= 3 && isPortSegment(tail.at(-1)!) && looksLikeHost(tail.at(-2)!)) {
-    imapPort = parsePort(tail.at(-1)!)
-    tail.pop()
-    imapHost = tail.pop()
-  } else if (looksLikeHost(tail.at(-1)!)) {
-    // Trailing host segment, default IMAP port
-    imapHost = tail.pop()
-  }
-
-  // 5. Whatever remains (after the email shift) is the password.
+  // Whatever remains (after the email shift) is the password.
   const password = tail.join(':')
 
   return {
@@ -333,24 +348,20 @@ function resolveServerConfig(
 }
 
 /**
- * Parse a single credential entry
+ * Handle an OAuth2-only (email-only) entry
  */
-async function parseSingleCredential(entry: string): Promise<AccountConfig | null> {
-  const trimmed = entry.trim()
-  if (!trimmed) return null
+async function handleOAuth2OnlyEntry(email: string): Promise<AccountConfig | null> {
+  const account = await createOAuth2Account(email)
+  if (account) return account
 
-  const parts = trimmed.split(':')
-  const email = parts[0]!.trim()
+  console.error('Skipping invalid credential entry (expected email:password)')
+  return null
+}
 
-  // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
-  if (parts.length < 2) {
-    const account = await createOAuth2Account(email)
-    if (account) return account
-
-    console.error('Skipping invalid credential entry (expected email:password)')
-    return null
-  }
-
+/**
+ * Handle a standard password-based entry
+ */
+async function handlePasswordEntry(email: string, parts: string[]): Promise<AccountConfig | null> {
   const { password, customImapHost, customImapPort, customSmtpHost, customSmtpPort, customSmtpSecurity } =
     parsePasswordAndHost(parts)
 
@@ -381,6 +392,24 @@ async function parseSingleCredential(entry: string): Promise<AccountConfig | nul
   }
 
   return account
+}
+
+/**
+ * Parse a single credential entry
+ */
+async function parseSingleCredential(entry: string): Promise<AccountConfig | null> {
+  const trimmed = entry.trim()
+  if (!trimmed) return null
+
+  const parts = trimmed.split(':')
+  const email = parts[0]!.trim()
+
+  // Outlook/Hotmail/Live: email-only entry is valid (OAuth2, no password needed)
+  if (parts.length < 2) {
+    return handleOAuth2OnlyEntry(email)
+  }
+
+  return handlePasswordEntry(email, parts)
 }
 
 /**


### PR DESCRIPTION
Refactored parseSingleCredential and parsePasswordAndHost in src/tools/helpers/config.ts by delegating parsing logic to separate helper functions. This improves readability and maintainability of the complex credential string parsing logic.

---
*PR created automatically by Jules for task [353119991173454170](https://jules.google.com/task/353119991173454170) started by @n24q02m*