### PR TITLE
[FIX] Fix form polling JS for Outlook OAuth

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+
+## 2026-05-04 - [FIX] Fix form polling JS for Outlook OAuth
+**Learning:** The frontend credential form relies on a specific signaling mechanism (`getMarkSetupComplete()?.('outlook')`) to stop the "Waiting for Microsoft authorization..." spinner. In multi-account or complex transport scenarios, the `onComplete` callback must explicitly invoke this signaling even if the underlying OAuth helper also does it, as the transport layer (HTTP) is the one that wired the `markSetupCompleteFn`.
+**Action:** Always ensure that `onComplete` callbacks for OAuth flows in transport layers (like `src/transports/http.ts`) call `getMarkSetupComplete()?.('outlook')` to satisfy frontend polling status checks.

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -258,8 +258,7 @@ describe('http transport', () => {
       const markComplete = vi.fn()
       vi.mocked(initiateOutlookDeviceCode).mockImplementation(async (_email, callback) => {
         completionCallback = async () => {
-          setState('configured')
-          markComplete('outlook')
+          setState('configured') // Simulated from oauth2.ts background poll
           if (callback) await callback()
         }
         return {
@@ -275,6 +274,7 @@ describe('http transport', () => {
       // tokens and ``saveTokens`` persists them).
       await completionCallback()
 
+      // setState('configured') is called both in oauth2.ts (mocked) and http.ts
       expect(setState).toHaveBeenCalledWith('configured')
       expect(markComplete).toHaveBeenCalledWith('outlook')
     })
@@ -290,7 +290,7 @@ describe('http transport', () => {
       let completionCallback: any
       vi.mocked(initiateOutlookDeviceCode).mockImplementation(async (_email, callback) => {
         completionCallback = async () => {
-          setState('configured')
+          setState('configured') // Simulated from oauth2.ts background poll
           if (callback) await callback()
         }
         return {
@@ -302,7 +302,7 @@ describe('http transport', () => {
 
       await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
-      expect(() => completionCallback()).not.toThrow()
+      await completionCallback()
       expect(setState).toHaveBeenCalledWith('configured')
     })
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -25,7 +25,13 @@ import { ImapFlow } from 'imapflow'
 import { InMemoryCredStore } from '../auth/in-memory-cred-store.js'
 import { subjectContext } from '../auth/subject-context.js'
 import { renderEmailCredentialForm } from '../credential-form.js'
-import { resolveCredentialState, setMarkSetupComplete, setSetupUrl, setState } from '../credential-state.js'
+import {
+  getMarkSetupComplete,
+  resolveCredentialState,
+  setMarkSetupComplete,
+  setSetupUrl,
+  setState
+} from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
@@ -103,6 +109,7 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[]): Promise<N
   try {
     const device = await initiateOutlookDeviceCode(first.email, () => {
       console.error(`[${SERVER_NAME}] Outlook OAuth2 completed for ${first.email}`)
+      getMarkSetupComplete()?.('outlook')
     })
     setState('setup_in_progress')
     return {


### PR DESCRIPTION
This PR fixes a regression where the Outlook OAuth credential form would spin indefinitely even after successful authorization. The fix involves explicitly invoking the setup completion signal ('outlook') in the transport layer's onComplete callback, ensuring the /setup-status endpoint correctly reports completion to the frontend polling logic.

- Updated src/transports/http.ts to invoke getMarkSetupComplete()?.('outlook') in initiateOutlookOAuth.
- Updated src/transports/http.test.ts to properly test the signal flow through the callback.

---
*PR created automatically by Jules for task [18075497273335201205](https://jules.google.com/task/18075497273335201205) started by @n24q02m*