### PR TITLE
[SECURITY] Unvalidated JSON Parsing in Credential Store

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,8 @@
  **Vulnerability:** Unchecked `JSON.parse` output when loading the OAuth2 token store or encrypted configurations.
  **Learning:** Accessing properties on unvalidated `JSON.parse` results can cause runtime crashes (TypeErrors) if the file is malformed or contains unexpected primitive values.
  **Prevention:** Use robust type guards (`isValidTokenStore`, `isValidAccountConfigs`) immediately after parsing. Ensure these guards check for `null`, `Array.isArray`, and validate internal field types and constraints (e.g., non-empty strings for tokens, positive numbers for expiration).
+
+## 2026-05-01 - Fix Unvalidated JSON Parsing in Credential Store
+**Vulnerability:** The `per-user-credential-store.ts` module was parsing decrypted JSON payloads from disk without validating the schema before use. This could lead to runtime errors or prototype pollution if the stored files were corrupted or maliciously modified (though they are encrypted).
+**Learning:** Even encrypted data stored on disk should be treated as untrusted upon retrieval. Cryptographic integrity ensures the data hasn't changed since it was written, but it doesn't guarantee the data was valid when written or that the schema hasn't evolved in a breaking way.
+**Prevention:** Always use type guards or schema validation libraries (like Zod) immediately after `JSON.parse()`. Enforce strict checks for required fields, non-empty strings, and proper types (e.g., positive integers for ports).

--- a/code_review_request.txt
+++ b/code_review_request.txt
@@ -1,0 +1,7 @@
+I have strengthened the JSON parsing validation in the credential store to prevent unvalidated data from being used.
+
+Changes:
+- Updated `isValidServerConfig`, `isValidOAuth2Tokens`, and `isValidAccountConfig` in `src/auth/per-user-credential-store.ts` to enforce non-empty strings for critical fields and positive integers for ports.
+- Modified `loadAllUserCredentials` in `src/auth/per-user-credential-store.ts` to throw an error if the decrypted JSON fails schema validation, which is then caught and logged.
+- Added comprehensive unit tests in `src/auth/per-user-credential-store.test.ts` to verify the new validation logic.
+- Updated `.jules/sentinel.md` to document the security fix.

--- a/src/auth/per-user-credential-store.test.ts
+++ b/src/auth/per-user-credential-store.test.ts
@@ -422,6 +422,10 @@ describe('per-user-credential-store', () => {
       writeFileSync(join(invalidDir, 'credentials.enc'), combined)
 
       const all = await loadAllUserCredentials()
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load credentials from bad-server:'),
+        expect.any(Error)
+      )
       expect(all.has('bad-server')).toBe(false)
       spy.mockRestore()
     })
@@ -438,6 +442,75 @@ describe('per-user-credential-store', () => {
       const key = await _deriveKey(secret, dirHash)
       const iv = crypto.getRandomValues(new Uint8Array(12))
       const payload = JSON.stringify({ userId, accounts: [{ email: 'missing-fields' }] })
+      const plaintext = new TextEncoder().encode(payload)
+      const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+      const combined = Buffer.concat([iv, Buffer.from(encrypted)])
+      const { writeFileSync } = await import('node:fs')
+      writeFileSync(join(userDir, 'credentials.enc'), combined)
+
+      await expect(loadUserCredentials(userId)).rejects.toThrow('Invalid account configuration')
+    })
+
+    it('should throw when id is an empty string', async () => {
+      const userId = 'empty-id-user'
+      const dirHash = hashUserId(userId)
+      const userDir = join(_paths.DATA_DIR, dirHash)
+      mkdirSync(userDir, { recursive: true })
+
+      const secret = await _getSecret()
+      const key = await _deriveKey(secret, dirHash)
+      const iv = crypto.getRandomValues(new Uint8Array(12))
+      const account = makeAccount('test@example.com')
+      account.id = '' // Empty id
+      const payload = JSON.stringify({ userId, accounts: [account] })
+      const plaintext = new TextEncoder().encode(payload)
+      const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+      const combined = Buffer.concat([iv, Buffer.from(encrypted)])
+      const { writeFileSync } = await import('node:fs')
+      writeFileSync(join(userDir, 'credentials.enc'), combined)
+
+      await expect(loadUserCredentials(userId)).rejects.toThrow('Invalid account configuration')
+    })
+
+    it('should throw when imap port is not a positive integer', async () => {
+      const userId = 'bad-port-user'
+      const dirHash = hashUserId(userId)
+      const userDir = join(_paths.DATA_DIR, dirHash)
+      mkdirSync(userDir, { recursive: true })
+
+      const secret = await _getSecret()
+      const key = await _deriveKey(secret, dirHash)
+      const iv = crypto.getRandomValues(new Uint8Array(12))
+      const account = makeAccount('test@example.com')
+      account.imap.port = 0 // Invalid port
+      const payload = JSON.stringify({ userId, accounts: [account] })
+      const plaintext = new TextEncoder().encode(payload)
+      const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+      const combined = Buffer.concat([iv, Buffer.from(encrypted)])
+      const { writeFileSync } = await import('node:fs')
+      writeFileSync(join(userDir, 'credentials.enc'), combined)
+
+      await expect(loadUserCredentials(userId)).rejects.toThrow('Invalid account configuration')
+    })
+
+    it('should throw when oauth2 token is missing required fields', async () => {
+      const userId = 'bad-oauth-user'
+      const dirHash = hashUserId(userId)
+      const userDir = join(_paths.DATA_DIR, dirHash)
+      mkdirSync(userDir, { recursive: true })
+
+      const secret = await _getSecret()
+      const key = await _deriveKey(secret, dirHash)
+      const iv = crypto.getRandomValues(new Uint8Array(12))
+      const account = makeAccount('test@example.com')
+      account.authType = 'oauth2'
+      account.oauth2 = {
+        accessToken: '', // Empty token
+        refreshToken: 'refresh',
+        expiresAt: 123456789,
+        clientId: 'client'
+      }
+      const payload = JSON.stringify({ userId, accounts: [account] })
       const plaintext = new TextEncoder().encode(payload)
       const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
       const combined = Buffer.concat([iv, Buffer.from(encrypted)])

--- a/src/auth/per-user-credential-store.ts
+++ b/src/auth/per-user-credential-store.ts
@@ -118,7 +118,14 @@ export function hashUserId(userId: string): string {
 function isValidServerConfig(obj: unknown): obj is import('../tools/helpers/config.js').ServerConfig {
   if (!obj || typeof obj !== 'object') return false
   const s = obj as Record<string, unknown>
-  return typeof s.host === 'string' && typeof s.port === 'number' && typeof s.secure === 'boolean'
+  return (
+    typeof s.host === 'string' &&
+    s.host.length > 0 &&
+    typeof s.port === 'number' &&
+    Number.isInteger(s.port) &&
+    s.port > 0 &&
+    typeof s.secure === 'boolean'
+  )
 }
 
 function isValidOAuth2Tokens(obj: unknown): obj is import('../tools/helpers/oauth2.js').OAuth2Tokens {
@@ -126,16 +133,25 @@ function isValidOAuth2Tokens(obj: unknown): obj is import('../tools/helpers/oaut
   const t = obj as Record<string, unknown>
   return (
     typeof t.accessToken === 'string' &&
+    t.accessToken.length > 0 &&
     typeof t.refreshToken === 'string' &&
+    t.refreshToken.length > 0 &&
     typeof t.expiresAt === 'number' &&
-    typeof t.clientId === 'string'
+    t.expiresAt > 0 &&
+    typeof t.clientId === 'string' &&
+    t.clientId.length > 0
   )
 }
 
 function isValidAccountConfig(obj: unknown): obj is AccountConfig {
   if (!obj || typeof obj !== 'object') return false
   const a = obj as Record<string, unknown>
-  const basic = typeof a.id === 'string' && typeof a.email === 'string' && typeof a.password === 'string'
+  const basic =
+    typeof a.id === 'string' &&
+    a.id.length > 0 &&
+    typeof a.email === 'string' &&
+    a.email.length > 0 &&
+    typeof a.password === 'string'
   if (!basic) return false
 
   if (a.authType !== undefined && a.authType !== 'password' && a.authType !== 'oauth2') return false
@@ -246,13 +262,16 @@ export async function loadAllUserCredentials(): Promise<Map<string, AccountConfi
         parsed &&
         typeof parsed === 'object' &&
         typeof parsed.userId === 'string' &&
+        parsed.userId.length > 0 &&
         isValidAccountConfigs(parsed.accounts)
       ) {
         result.set(parsed.userId, parsed.accounts)
+      } else {
+        throw new Error(`Invalid credential schema in ${entryName}`)
       }
     } catch (err: unknown) {
       // Skip missing or corrupted entries
-      if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
+      if (err && (typeof err !== 'object' || !('code' in err) || err.code !== 'ENOENT')) {
         console.error(`Failed to load credentials from ${entry.name}:`, err)
       }
     }


### PR DESCRIPTION
Added robust schema validation for decrypted credentials in `per-user-credential-store.ts`. Updated `loadAllUserCredentials` to throw on schema violations and added unit tests to verify the fix.

---
*PR created automatically by Jules for task [16665727420123334712](https://jules.google.com/task/16665727420123334712) started by @n24q02m*