### PR TITLE
[FIX] Deep Nesting in Credential Form

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+## 2025-05-15 - Flattened logic in template-embedded JavaScript
+ **Learning:** Deep nesting within template strings containing JavaScript (like `src/credential-form.ts`) makes code extremely hard to read and maintain, as standard IDE tools for flattening/refactoring often don't work well within strings.
+ **Action:** Use early returns (`if (...) return;`) and `continue` statements in loops to keep indentation low. Flatten Promise chains by returning nested promises instead of nesting `.then()` blocks.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,6 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+## 2025-05-15 - Improved code clarity in credential form
+ **Learning:** In embedded frontend scripts, explicit state checks at the start of callbacks (e.g., polling handlers) simplify the main logic flow by eliminating large "if-success" blocks.
+ **Action:** Prioritize early exit conditions for non-target states to keep the primary success path at the top level of the function scope.

--- a/src/credential-form.test.ts
+++ b/src/credential-form.test.ts
@@ -71,7 +71,7 @@ describe('renderEmailCredentialForm', () => {
   it('polls /setup-status for outlook === "complete"', () => {
     const html = renderEmailCredentialForm(schema, { submitUrl: '/authorize?nonce=abc' })
     expect(html).toContain('/setup-status')
-    expect(html).toMatch(/s\.outlook\s*===\s*["']complete["']/)
+    expect(html).toMatch(/s.outlook !== ["']complete["']/)
   })
 
   it('no longer blocks submit when only Outlook accounts are present', () => {

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -384,15 +384,16 @@ export function renderEmailCredentialForm(
                     help.id = "help-" + key + "_" + idx;
                     help.className = "help-text";
                     describedBy.push(help.id);
-                    if (helpUrl) {
+
+                    if (!helpUrl) {
+                        help.textContent = helpText;
+                    } else {
                         var a = document.createElement("a");
                         a.setAttribute("href", helpUrl);
                         a.setAttribute("target", "_blank");
                         a.setAttribute("rel", "noopener noreferrer");
                         a.textContent = helpText;
                         help.appendChild(a);
-                    } else {
-                        help.textContent = helpText;
                     }
                     group.appendChild(help);
                 }
@@ -432,10 +433,9 @@ export function renderEmailCredentialForm(
                     var titleEl = cards[i].querySelector(".account-title");
                     if (titleEl) titleEl.textContent = "Account " + (i + 1);
                     var removeBtn = cards[i].querySelector(".remove-btn");
-                    if (removeBtn) {
-                        removeBtn.style.display = i === 0 ? "none" : "";
-                        removeBtn.setAttribute("aria-label", "Remove Account " + (i + 1));
-                    }
+                    if (!removeBtn) continue;
+                    removeBtn.style.display = i === 0 ? "none" : "";
+                    removeBtn.setAttribute("aria-label", "Remove Account " + (i + 1));
                 }
             }
 
@@ -678,26 +678,29 @@ export function renderEmailCredentialForm(
                     fetch(statusUrl)
                         .then(function (r) { return r.json(); })
                         .then(function (s) {
-                            if (s && s.outlook === "complete") {
-                                clearInterval(pollId);
-                                statusBox.className = "status-box success";
-                                while (statusBox.firstChild) statusBox.removeChild(statusBox.firstChild);
-                                var done = document.createElement("strong");
-                                done.textContent = "Setup complete!";
-                                statusBox.appendChild(done);
-                                statusBox.appendChild(document.createElement("br"));
-                                statusBox.appendChild(document.createElement("br"));
-                                submitBtn.textContent = "Connected";
-                                if (typeof pendingRedirectUrl === "string" && pendingRedirectUrl.length > 0) {
-                                    // Follow the OAuth redirect so external clients receive the
-                                    // auth code. Without this the form stalls on "close tab" and
-                                    // the client callback server hangs forever.
-                                    statusBox.appendChild(document.createTextNode("Outlook authorized. Redirecting..."));
-                                    window.location.replace(pendingRedirectUrl);
-                                } else {
-                                    statusBox.appendChild(document.createTextNode("Outlook authorized. You can close this tab."));
-                                }
+                            if (!s || s.outlook !== "complete") return;
+
+                            clearInterval(pollId);
+                            statusBox.className = "status-box success";
+                            while (statusBox.firstChild) statusBox.removeChild(statusBox.firstChild);
+
+                            var done = document.createElement("strong");
+                            done.textContent = "Setup complete!";
+                            statusBox.appendChild(done);
+                            statusBox.appendChild(document.createElement("br"));
+                            statusBox.appendChild(document.createElement("br"));
+                            submitBtn.textContent = "Connected";
+
+                            if (typeof pendingRedirectUrl === "string" && pendingRedirectUrl.length > 0) {
+                                // Follow the OAuth redirect so external clients receive the
+                                // auth code. Without this the form stalls on "close tab" and
+                                // the client callback server hangs forever.
+                                statusBox.appendChild(document.createTextNode("Outlook authorized. Redirecting..."));
+                                window.location.replace(pendingRedirectUrl);
+                                return;
                             }
+
+                            statusBox.appendChild(document.createTextNode("Outlook authorized. You can close this tab."));
                         })
                         .catch(function () {});
                 }, 3000);
@@ -762,43 +765,44 @@ export function renderEmailCredentialForm(
                     body: JSON.stringify(payload)
                 })
                     .then(function (resp) {
-                        return resp.json().then(function (data) {
-                            if (!data.ok) {
-                                showStatus("error", data.error || data.error_description || "Request failed.");
-                                formFieldset.disabled = false;
-                                submitBtn.removeAttribute("aria-busy");
-                                submitBtn.textContent = "Connect";
-                                return;
-                            }
+                        return resp.json();
+                    })
+                    .then(function (data) {
+                        if (!data.ok) {
+                            showStatus("error", data.error || data.error_description || "Request failed.");
+                            formFieldset.disabled = false;
+                            submitBtn.removeAttribute("aria-busy");
+                            submitBtn.textContent = "Connect";
+                            return;
+                        }
 
-                            // Stash the OAuth redirect target so follow-up async steps
-                            // (device code poll, future OTP) can navigate to it when
-                            // they complete instead of orphaning the client callback.
-                            if (typeof data.redirect_url === "string" && data.redirect_url.length > 0) {
-                                pendingRedirectUrl = data.redirect_url;
-                            }
+                        // Stash the OAuth redirect target so follow-up async steps
+                        // (device code poll, future OTP) can navigate to it when
+                        // they complete instead of orphaning the client callback.
+                        if (typeof data.redirect_url === "string" && data.redirect_url.length > 0) {
+                            pendingRedirectUrl = data.redirect_url;
+                        }
 
-                            if (data.next_step && data.next_step.type === "oauth_device_code") {
-                                submitBtn.innerHTML =
-                                    '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
-                                submitBtn.removeAttribute("aria-busy");
-                                renderOAuthDeviceCode(data.next_step);
-                                return;
-                            }
+                        if (data.next_step && data.next_step.type === "oauth_device_code") {
+                            submitBtn.innerHTML =
+                                '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
+                            submitBtn.removeAttribute("aria-busy");
+                            renderOAuthDeviceCode(data.next_step);
+                            return;
+                        }
 
-                            if (pendingRedirectUrl) {
-                                // No interactive next step — follow the OAuth redirect now.
-                                showStatus("success", "Credentials saved. Redirecting...");
-                                submitBtn.textContent = "Connected";
-                                submitBtn.removeAttribute("aria-busy");
-                                window.location.replace(pendingRedirectUrl);
-                                return;
-                            }
-
-                            showStatus("success", data.message || "Setup complete! You can close this tab.");
+                        if (pendingRedirectUrl) {
+                            // No interactive next step — follow the OAuth redirect now.
+                            showStatus("success", "Credentials saved. Redirecting...");
                             submitBtn.textContent = "Connected";
                             submitBtn.removeAttribute("aria-busy");
-                        });
+                            window.location.replace(pendingRedirectUrl);
+                            return;
+                        }
+
+                        showStatus("success", data.message || "Setup complete! You can close this tab.");
+                        submitBtn.textContent = "Connected";
+                        submitBtn.removeAttribute("aria-busy");
                     })
                     .catch(function (err) {
                         showStatus("error", "Network error: " + err.message);


### PR DESCRIPTION
This PR addresses the deep nesting issue in `src/credential-form.ts`. Since the JavaScript logic is embedded within a template string, deep nesting is particularly difficult to maintain.

Changes:
1. **Flattened `submit` listener**: Refactored the nested `.then()` chain in the form submission handler into a flat sequence.
2. **Flattened OAuth Polling**: Used an early return in the `/setup-status` polling handler to eliminate a large indented block.
3. **Flattened `createFieldGroup`**: Simplified help text rendering by using an `if (!helpUrl)` early branch.
4. **Flattened `updateAccountNumbers`**: Used `continue` in the account card loop to reduce indentation.
5. **Test Updates**: Updated the regex in `src/credential-form.test.ts` to match the new flattened code structure.

Verified with `bun run check` and `bun run test`.

---
*PR created automatically by Jules for task [639317073494033224](https://jules.google.com/task/639317073494033224) started by @n24q02m*