### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -561,6 +561,12 @@ describe('ensureValidToken', () => {
 // ============================================================================
 
 describe('deviceCodeAuth', () => {
+  it('throws if email is missing', async () => {
+    await expect(deviceCodeAuth('')).rejects.toThrow('Email is required')
+  })
+  it('throws if email is just whitespace', async () => {
+    await expect(deviceCodeAuth('   ')).rejects.toThrow('Email is required')
+  })
   const mockFetch = vi.fn()
   const originalEnv = process.env.OUTLOOK_CLIENT_ID
 
@@ -1127,6 +1133,34 @@ describe('initiateOutlookDeviceCode', () => {
     expect(mockWriteFileSync).toHaveBeenCalled()
   })
 
+  it('does not throw if onComplete callback fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: async () => ({
+        device_code: 'dc-cb-fail',
+        user_code: 'CB-FAIL',
+        verification_uri: 'https://microsoft.com/devicelogin',
+        expires_in: 900,
+        interval: 0.01
+      })
+    })
+    mockFetch.mockResolvedValueOnce({
+      json: async () => ({
+        access_token: 'at-ok',
+        refresh_token: 'rt-ok',
+        expires_in: 3600
+      })
+    })
+
+    const onComplete = vi.fn().mockImplementation(() => {
+      throw new Error('callback failed')
+    })
+    await initiateOutlookDeviceCode('fail-cb@outlook.com', onComplete)
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(onComplete).toHaveBeenCalled()
+  })
+
   it('throws descriptive error when Microsoft rejects the device code request', async () => {
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -1139,6 +1173,9 @@ describe('initiateOutlookDeviceCode', () => {
   })
   it('throws if email is missing', async () => {
     await expect(initiateOutlookDeviceCode('')).rejects.toThrow('Email is required')
+  })
+  it('throws if email is just whitespace', async () => {
+    await expect(initiateOutlookDeviceCode('   ')).rejects.toThrow('Email is required')
   })
 })
 

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -370,7 +370,7 @@ export async function initiateOutlookDeviceCode(
   email: string,
   onComplete?: () => void
 ): Promise<{ verificationUri: string; userCode: string; expiresIn: number; interval: number }> {
-  if (!email) throw new Error('Email is required')
+  if (!email?.trim()) throw new Error('Email is required')
   const emailKey = email.toLowerCase()
   const existing = pendingAuths.get(emailKey)
   if (existing && existing.expiresAt > Date.now()) {
@@ -520,6 +520,7 @@ export async function saveOutlookTokens(tokens: Record<string, unknown>): Promis
  * Used by `npx @n24q02m/better-email-mcp auth <email>`.
  */
 export async function deviceCodeAuth(email: string, clientId?: string): Promise<OAuth2Tokens> {
+  if (!email?.trim()) throw new Error('Email is required')
   const resolvedClientId = clientId || getClientId()
   const codeData = await requestDeviceCode(resolvedClientId)
 


### PR DESCRIPTION
Added validation and tests for empty/whitespace emails in initiateOutlookDeviceCode and deviceCodeAuth. Also added a test case for onComplete callback failure in background polling. Verified with tests and linting.

---
*PR created automatically by Jules for task [13820882503800811438](https://jules.google.com/task/13820882503800811438) started by @n24q02m*