### PR TITLE
⚡ Bolt: [performance improvement] Remove unused IMAP bodyStructure fetch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2024-05-18 - Bigram Caching for Static Valid Options
 **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead, especially since the number of valid options is small and fixed (e.g., tool names like "messages", "folders").
 **Action:** Always look for opportunities to pre-compute and cache derived data (like bigrams or regular expressions) for static, bounded sets to convert repeated allocations and string operations into fast memory lookups. A simple `Map` reduced the overhead for fuzzy matching by ~2.5x.
+
+## 2026-05-18 - [Remove Unused IMAP Fetch Data]
+**Learning:** Fetching data like `bodyStructure` from IMAP servers requires the server to parse the full MIME tree of the email and send it over the network. If this data is not used by the application, requesting it adds significant unnecessary latency and network overhead.
+**Action:** Only request IMAP properties (like `uid`, `flags`, `envelope`, `source`) that are strictly necessary for the current operation. Removed unused `bodyStructure: true` from `fetchAll` in `searchEmails`.

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -351,7 +351,6 @@ export async function searchEmails(
               uid: true,
               flags: true,
               envelope: true,
-              bodyStructure: true,
               source: { start: 0, maxLength: 512 }
             },
             { uid: true }


### PR DESCRIPTION
💡 What: Removed `bodyStructure: true` from the `client.fetchAll` options object in `src/tools/helpers/imap-client.ts`.
🎯 Why: The resulting `bodyStructure` property was never used when constructing the summary list. Fetching it unnecessarily forces the IMAP server to parse the MIME tree for every matched email and transmit it over the wire, adding significant latency.
📊 Impact: Expected performance improvement in `messages search` tool calls, especially for accounts with large emails or complex attachments, as well as reduced memory usage and network overhead.
🔬 Measurement: Can be verified by running the test suite and benchmarking the execution time of `searchEmails` on a large mailbox. No functional changes.

---
*PR created automatically by Jules for task [5348685456169804796](https://jules.google.com/task/5348685456169804796) started by @n24q02m*