### PR TITLE
🎨 Palette: Add inline validation execution and focus management for novalidate form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,9 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+
+## 2025-05-26 - Novalidate Form Submission Handling
+
+**Learning:** When using the `novalidate` attribute on a form to disable default browser popups (for custom inline error handling), intercepting the `submit` event with `preventDefault()` completely bypasses all validation events (like `invalid`). This means inputs won't show errors and keyboard users won't be directed to fix their mistakes.
+
+**Action:** In `submit` event handlers for `novalidate` forms, explicitly call `form.checkValidity()`. If false, query the first invalid element (`form.querySelector('input:invalid...')`) and call `.focus()` to programmatically trigger standard validation events and correctly route the user to the problem area.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -722,6 +722,14 @@ export function renderEmailCredentialForm(
                 evt.preventDefault();
                 statusBox.style.display = "none";
 
+                if (!form.checkValidity()) {
+                    var firstInvalid = form.querySelector('input:invalid, select:invalid, textarea:invalid');
+                    if (firstInvalid && firstInvalid instanceof HTMLElement) {
+                        firstInvalid.focus();
+                    }
+                    return;
+                }
+
                 var collected = collectAccounts();
 
                 if (collected.accounts.length === 0) {


### PR DESCRIPTION
### 💡 What
Added programmatic focus management and inline validation enforcement for the `novalidate` configuration form in `src/credential-form.ts`.

### 🎯 Why
When `novalidate` is used on a form to allow for custom inline error rendering (instead of standard browser popups), intercepting the submit event with `preventDefault()` completely skips HTML5 validation. As a result, users could submit the form empty or with invalid data without knowing which fields caused the failure, severely degrading the experience for keyboard-only and screen reader users. By invoking `form.checkValidity()` and focusing the first invalid element upon failure, users are immediately directed to correct their inputs while preserving the custom styling provided by the app.

### ♿ Accessibility
- Prevents focus loss when validation fails.
- Smoothly redirects keyboard navigation to the exact field that requires correction.
- Forces standard `invalid` events to fire so that `aria-invalid` attributes get updated and error labels are announced by screen readers correctly via `role="alert"`.

---
*PR created automatically by Jules for task [6037919578985064078](https://jules.google.com/task/6037919578985064078) started by @n24q02m*