### PR TITLE
fix: correct architecture docs to match runtime behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,12 +42,12 @@ mise run fix       # bun run check:fix
 ```
 src/
   init-server.ts                 # Entry point, env validation
-  relay-setup.ts                 # Zero-config relay: create session, poll for config
+  relay-setup.ts                 # formatCredentials() helper (relay form fields -> EMAIL_CREDENTIALS string)
   relay-schema.ts                # Relay form schema (email credential fields)
   credential-state.ts            # Single-user / stdio credential resolution from env
   auth/                          # Per-user credential store + Outlook OAuth (HTTP mode)
-    per-user-credential-store.ts # AES-256-GCM encrypted per-user credential storage
-    in-memory-cred-store.ts      # Ephemeral in-memory credential store
+    per-user-credential-store.ts # AES-256-GCM disk per-user store (DEPRECATED, no live caller)
+    in-memory-cred-store.ts      # LIVE per-user store: ephemeral in-memory, keyed by JWT sub
     outlook-device-code.ts       # Microsoft device-code OAuth flow
     subject-context.ts           # Per-request JWT-sub scope (AsyncLocalStorage)
   transports/
@@ -66,7 +66,7 @@ src/
   - Custom IMAP host: `user@custom.com:password:imap.custom.com`
   - Custom IMAP host + port: `user@custom.com:password:imap.custom.com:1993`
   - Local IMAP proxy: `user@custom.com:password:localhost:1993` (`localhost` accepted as host; per-account port)
-- **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `PUBLIC_URL` (for relay/OAuth redirect URLs). `CREDENTIAL_SECRET` optional (per-user store encryption; auto-generated to a 0600 secret file if unset). `MCP_AUTH_DISABLE=1` skips Bearer JWT verification (for deploys behind an external auth gateway).
+- **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `PUBLIC_URL` (for relay/OAuth redirect URLs). Per-user credentials are held in an in-memory store (`auth/in-memory-cred-store.ts`, keyed by JWT `sub`, cleared on restart). `CREDENTIAL_SECRET` is read only by the deprecated disk-backed `auth/per-user-credential-store.ts`, which has no live caller; the in-memory store does not use it. `MCP_AUTH_DISABLE=1` skips Bearer JWT verification (for deploys behind an external auth gateway).
 - `PORT` (default `0` = OS-assigned random port), `HOST` (optional bind address)
 - `OUTLOOK_CLIENT_ID` -- tu chon, cho self-hosted OAuth2 client
 
@@ -103,19 +103,13 @@ Two transports, selected in `init-server.ts:52-53`. There is no `MCP_MODE` env v
 
 ## Known bugs (phat hien 2026-04-18 E2E)
 
-1. **Outlook Device Code flow (local-relay mode cũ): mo 2 tab auth giong het nhau**:
-   - Chỉ affect path local-relay với Outlook đã deprecated. Remote-relay (default) dùng mcp-core delegated device_code — không duplicate.
-   - Nếu tái hiện trong remote-relay, debug: check if `tryOpenBrowser` bị call 2 lần hoặc browser auto-open + explicit link conflict.
+1. **(Obsolete)** Outlook Device Code "2 tab" duplicate auth — chỉ affect `local-relay` mode, đã bị gỡ cùng với `MCP_MODE` (xem mục Modes). HTTP mode hiện dùng mcp-core delegated device_code, không duplicate.
 
-2. **Browser UI stuck "Waiting for server..." (local-relay mode only)**:
-   - Chỉ affect `MCP_MODE=local-relay` (paste form flow)
-   - Same upstream bug nhu better-notion-mcp: `packages/core-ts/src/relay/client.ts:sendMessage('complete')` khong reach browser
-   - See `C:\Users\n24q02m-wlap\projects\mcp-core\CLAUDE.md` Known bugs #2
-   - Remote-relay không ảnh hưởng.
+2. **(Obsolete)** Browser UI stuck "Waiting for server..." — chỉ affect `MCP_MODE=local-relay` (ECDH `relay/client.ts:sendMessage('complete')` paste-form flow), đã bị gỡ. Không còn relay-client path nào live trong HTTP mode.
 
-3. **Config storage path**: TS server dung `$APPDATA\mcp\Config\config.enc` (khac Python servers `$LOCALAPPDATA\mcp\config.enc`). Khi debug/test, clean ca 2 paths + `~/.better-email-mcp/tokens.json` de reset state.
+3. **Config storage path**: stdio/single-user config ghi qua mcp-core `config-file.js` -> `config.enc` tại platformdirs `mcp` config dir (`$APPDATA\mcp\Config\config.enc` trên Windows; khac Python servers `$LOCALAPPDATA\mcp\config.enc`). Khi debug/test, clean ca 2 paths + `~/.better-email-mcp/tokens.json` de reset state.
 
-4. **Outlook token email key in remote-relay**: `saveOutlookTokens` fallback to `OUTLOOK_EMAIL` env hoac `'outlook-device-code'` khi Microsoft token response khong include email field (device code mặc định không trả email). Workaround: set `OUTLOOK_EMAIL` env var khi self-host. Long-term fix: request `openid email profile` scopes + decode id_token trong onTokenReceived.
+4. **Outlook token email key**: `saveOutlookTokens` fallback to `OUTLOOK_EMAIL` env hoac `'outlook-device-code'` khi Microsoft token response khong include email field (device code mặc định không trả email). Workaround: set `OUTLOOK_EMAIL` env var khi self-host. Long-term fix: request `openid email profile` scopes + decode id_token trong onTokenReceived.
 
 ## E2E
 
@@ -135,6 +129,6 @@ Tier policy:
 - **T2 non-interaction** (`make e2e-config CONFIG=<id>` locally) - driver pre-fills relay form from skret AWS SSM `/better-email-mcp/prod` (`ap-southeast-1`). No user gate.
 - **T2 interaction** - driver fills relay form, then prints upstream user-gate URL; user signs in / types OTP at provider. Driver enforces per-flow timeouts (device-code 900s, oauth-redirect 300s, browser-form 600s) and emits `[poll] elapsed=Xs remaining=Ys status=<body>` every 30s. On timeout, container logs + last `setup-status` are saved to `<tmp>/e2e-diag/` BEFORE teardown for post-mortem.
 
-Multi-user remote mode (deployment property; not a separate config) uses `CREDENTIAL_SECRET` to encrypt the per-user credential store (`auth/per-user-credential-store.ts:78`). It is optional — if unset, a 32-byte secret is generated and persisted to a 0600 secret file. Provide it via the skret namespace to keep per-user stores decryptable across container restarts.
+Multi-user remote mode (deployment property; not a separate config) keys per-user credentials by JWT `sub` in an in-memory store (`auth/in-memory-cred-store.ts`, TC-NearZK), cleared on restart — users re-submit after a restart. The disk-backed `auth/per-user-credential-store.ts` (AES-256-GCM + PBKDF2 from `CREDENTIAL_SECRET`) is deprecated and has no live caller.
 
 References: `mcp-core/scripts/e2e/matrix.yaml`, `~/.claude/skills/mcp-dev/references/e2e-full-matrix.md` (harness-readiness gate), `~/.claude/skills/mcp-dev/references/secrets-skret.md` (per-server credential layout), `~/.claude/skills/mcp-dev/references/multi-user-pattern.md` (per-JWT-sub isolation).

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ mcp-name: io.github.n24q02m/better-email-mcp
 Full docs at **[mcp.n24q02m.com/servers/better-email-mcp/setup/](https://mcp.n24q02m.com/servers/better-email-mcp/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/better-email-mcp/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
-- [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
+- [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio (default) and HTTP (opt-in, multi-user with OAuth 2.1)
 - [Multi-user setup](https://mcp.n24q02m.com/get-started/multi-user/) -- per-JWT-sub credential model
 
 **Install with AI agent** -- paste this to your AI coding agent:
@@ -165,11 +165,10 @@ Single multi-user mode (relay form for App-Password providers + bundled Outlook 
 docker run -p 8080:8080 \
   -e PORT=8080 \
   -e PUBLIC_URL=https://your-domain.com \
-  -e CREDENTIAL_SECRET=$(openssl rand -hex 32) \
   n24q02m/better-email-mcp:latest
 ```
 
-Users provide their own email credentials through the OAuth flow / paste form. No server-side `EMAIL_CREDENTIALS` needed. Outlook OAuth uses the bundled public Azure client (`d56f8c71-9f7c-43f4-9934-be29cb6e77b0`, Thunderbird-pattern) -- no user-side Azure app registration needed.
+Users provide their own email credentials through the OAuth flow / paste form. No server-side `EMAIL_CREDENTIALS` needed. Per-user credentials are held in an in-memory store (cleared on restart); users re-submit after a restart. Outlook OAuth uses the bundled public Azure client (`d56f8c71-9f7c-43f4-9934-be29cb6e77b0`, Thunderbird-pattern) -- no user-side Azure app registration needed.
 
 ## Outlook OAuth Device Code (HTTP mode)
 
@@ -192,7 +191,7 @@ In **stdio mode**, Outlook accounts use an **App Password** instead (Outlook Acc
 | `EMAIL_USER` | Alternative (stdio, single-account) | - | Email address. Used with `EMAIL_APP_PASSWORD` as a per-field alternative to `EMAIL_CREDENTIALS`; merged into `EMAIL_CREDENTIALS` at boot |
 | `EMAIL_APP_PASSWORD` | Alternative (stdio, single-account) | - | App password (Gmail/Yahoo/iCloud) or Outlook App Password; used with `EMAIL_USER` |
 | `PUBLIC_URL` | No (http) | - | Server's public URL for relay / OAuth redirect links |
-| `CREDENTIAL_SECRET` | No (http) | auto-generated | Secret used to encrypt the per-user credential store; if unset, a random 32-byte secret is generated and persisted to a 0600 file |
+| `CREDENTIAL_SECRET` | No (http) | - | Reserved for the deprecated disk-backed per-user store. The live HTTP multi-user store is in-memory (`InMemoryCredStore`, cleared on restart) and does not read this variable |
 | `PORT` | No | `0` (OS-assigned) | Server port (http mode); set explicitly (e.g. `8080`) to bind a fixed port |
 | `HOST` | No | - | Bind address (http mode) |
 | `MCP_AUTH_DISABLE` | No (http) | - | Set to `1` to skip Bearer JWT verification when behind an external auth gateway |
@@ -267,9 +266,9 @@ This plugin implements **TC-NearZK** (in-memory, ephemeral). See the [mcp-core t
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|
-| HTTP n24q02m-hosted (default) | In-memory `Map<sub, OAuthToken>` | In-process only | Server process (cleared on restart) |
+| HTTP remote (hosted) | In-memory `Map<sub, OAuthToken>` | In-process only | Server process (cleared on restart) |
 | HTTP self-host | Same as hosted | Same | Only you (admin = user) |
-| stdio proxy | `~/.better-email-mcp/config.json` | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
+| stdio | platformdirs `mcp` config dir (`config.enc`; e.g. `%APPDATA%\mcp\Config\config.enc` on Windows) | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
 
 ## License
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -3,7 +3,7 @@
 Manage email credential setup and runtime configuration.
 
 ### Description
-This tool allows you to check the status of your email credentials, manually trigger the interactive relay setup process, reset your configuration, signal completion of external setup, and manage runtime caches.
+This tool allows you to check the status of your email credentials, return the setup URL, reset your configuration, signal completion of external setup, and manage runtime caches. In HTTP mode the credential form is already served at `/authorize` (use `config__open_relay` to open it); in stdio mode credentials come from env vars and there is no setup URL.
 
 ### Actions
 
@@ -16,14 +16,14 @@ Check current credential state.
 ```
 
 #### 2. setup_start
-Trigger the relay setup session and return the setup URL.
+Return the current setup URL (the credential form on `/authorize` in HTTP mode). Does not spawn a separate relay session; in stdio mode the URL is `null` (credentials come from env vars).
 ```json
 {
   "action": "setup_start",
   "force": true
 }
 ```
-*   `force`: (Optional) boolean. Set to `true` to force restarting the relay setup even if one is already in progress.
+*   `force`: (Optional) boolean. Accepted for compatibility; the current implementation does not restart a relay session.
 
 #### 3. setup_reset
 Clear all saved credentials and reset to awaiting_setup state.


### PR DESCRIPTION
Brings the architecture docs in line with how the server actually runs. Verified against the source (entry point, `transports/http.ts`, `credential-state.ts`, the mcp-core storage layer) and against the live HTTP endpoint.

## README.md
- Modes overview: replaced the removed `local-relay / remote-relay / remote-oauth` list with the two real modes — stdio (default) and opt-in HTTP multi-user (OAuth 2.1).
- `CREDENTIAL_SECRET` row: the live HTTP per-user store is `InMemoryCredStore` (in-memory, cleared on restart) and does not read this variable; it is only consumed by the deprecated disk-backed store. Removed the misleading `CREDENTIAL_SECRET` line from the self-host docker example and noted that per-user credentials are re-submitted after a restart.
- Trust Model: stdio single-user config is `config.enc` in the platformdirs `mcp` config dir (e.g. `%APPDATA%\mcp\Config\config.enc`), not `~/.better-email-mcp/config.json`; the stdio mode uses a direct transport (no proxy). Dropped the incorrect `(default)` tag on the HTTP row, since the default transport is stdio.

## CLAUDE.md
- Corrected the `relay-setup.ts` description: it exposes `formatCredentials()`; the create-session / poll-for-config relay client is not used here.
- Annotated `per-user-credential-store.ts` as deprecated/unused and `in-memory-cred-store.ts` as the live per-user store.
- HTTP-mode env note and the E2E multi-user paragraph now describe the in-memory store instead of `CREDENTIAL_SECRET` encryption.
- Config storage path note now points through mcp-core `config-file.js`.
- Marked the obsolete `local-relay`-only known bugs as obsolete and dropped stale mode qualifiers.

## src/docs/config.md (served as an MCP resource)
- `setup_start` returns the existing setup URL and does not spawn a relay session; clarified stdio vs HTTP behavior and the `force` flag.

No code logic changed.