### PR TITLE
🎨 Palette: Add copy button to OAuth device code

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -59,3 +59,6 @@
 
 **Learning:** When dynamic content like new form sections are added or removed, relying entirely on visual layout updates disrupts accessibility. If a removed element had focus, focus is typically dropped to the document `<body>`. For keyboard-only and screen reader users, this necessitates tabbing through the entire page again. Additionally, newly spawned elements aren't automatically focused.
 **Action:** Implement active programmatic focus management for all dynamic content changes. When adding elements, immediately focus their primary input. When removing focused elements, explicitly return focus to the logical preceding element (e.g., the button that triggered the creation, or a 'container' wrapper) to maintain a continuous interaction flow.
+## 2024-05-18 - Improve accessibility of code copying
+**Learning:** Adding a copy button for codes displayed in UI improves accessibility and usability.
+**Action:** Always provide a copy mechanism when user needs to copy code displayed on the screen.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -123,6 +123,18 @@ export function renderEmailCredentialForm(
         }
         .remove-btn:hover { background-color: rgba(248, 113, 113, 0.08); }
         .remove-btn:focus-visible { outline: 2px solid #f87171; outline-offset: 2px; }
+        .copy-btn {
+            background: transparent;
+            color: #6c9bd2;
+            border: 1px solid rgba(108, 155, 210, 0.5);
+            border-radius: 4px;
+            padding: 0.15rem 0.4rem;
+            margin-left: 0.5rem;
+            font-size: 0.75rem;
+            cursor: pointer;
+        }
+        .copy-btn:hover { background-color: rgba(108, 155, 210, 0.1); }
+        .copy-btn:focus-visible { outline: 2px solid #6c9bd2; outline-offset: 2px; }
         .field-group { margin-bottom: 0.875rem; }
         .field-label {
             display: flex;
@@ -649,6 +661,7 @@ export function renderEmailCredentialForm(
                 link.setAttribute("href", nextStep.verification_url);
                 link.setAttribute("target", "_blank");
                 link.setAttribute("rel", "noopener noreferrer");
+                link.setAttribute("aria-label", "Opens Microsoft sign-in page in a new tab");
                 link.style.color = "#6c9bd2";
                 link.style.fontWeight = "bold";
                 link.textContent = nextStep.verification_url;
@@ -662,6 +675,23 @@ export function renderEmailCredentialForm(
                 codeEl.style.letterSpacing = "0.1em";
                 codeEl.textContent = nextStep.user_code;
                 statusBox.appendChild(codeEl);
+
+                if (navigator.clipboard) {
+                    var copyBtn = document.createElement("button");
+                    copyBtn.type = "button";
+                    copyBtn.textContent = "Copy";
+                    copyBtn.className = "copy-btn";
+                    copyBtn.setAttribute("aria-label", "Copy code to clipboard");
+                    copyBtn.addEventListener("click", function () {
+                        navigator.clipboard.writeText(nextStep.user_code).then(function () {
+                            copyBtn.textContent = "Copied!";
+                            copyBtn.setAttribute("aria-live", "polite");
+                            setTimeout(function () { copyBtn.textContent = "Copy"; }, 2000);
+                        });
+                    });
+                    statusBox.appendChild(copyBtn);
+                }
+
                 statusBox.appendChild(document.createElement("br"));
                 statusBox.appendChild(document.createElement("br"));
 


### PR DESCRIPTION
🎨 Palette has added a micro-UX improvement to the credential form.

💡 What: A "Copy" button has been added next to the Microsoft OAuth device code in `src/credential-form.ts`. It provides clear visual feedback ("Copied!") when clicked. Additionally, an `aria-label` was added to the Microsoft sign-in link.
🎯 Why: Users previously had to manually select and copy the generated device code, which is cumbersome. The new copy button makes this interaction much smoother. The `aria-label` on the sign-in link improves accessibility for screen reader users by providing better context for the action.
♿ Accessibility:
- Added `aria-label` to the verification URL link to specify its purpose (opening the sign-in page in a new tab).
- Added `aria-label` to the new "Copy" button.
- Added `aria-live="polite"` to the "Copy" button when clicked, so screen readers announce "Copied!".

---
*PR created automatically by Jules for task [14986139453373088749](https://jules.google.com/task/14986139453373088749) started by @n24q02m*