### PR TITLE
[UX] Add prefers-reduced-motion and update dynamic aria-labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -67,3 +67,8 @@
 
 **Learning:** Masked password fields (e.g., `type="password"`) help prevent shoulder-surfing, but they can be inaccessible for users with cognitive or motor disabilities who may struggle with typing accuracy and cannot verify their input.
 **Action:** Always provide a "Show/Hide" toggle button for password input fields. Ensure the button has an accessible name (e.g., `aria-label="Show password as plain text"`) that updates dynamically when the state changes.
+
+## 2025-02-19 - Respecting OS Preferences & Stateful ARIA Labels
+
+**Learning:** When adding continuous or looped CSS animations (like loaders or spinners), users with motion sensitivities can experience discomfort or distraction if they are unable to disable them. Additionally, interactive feedback on buttons (like a "Copy" button changing text to "Copied!") may be missed by screen readers if only visual text changes and an `aria-live` attribute is not fully descriptive or if the button's accessible name doesn't update to match its new state.
+**Action:** Always wrap continuous CSS animations in a `@media (prefers-reduced-motion: reduce)` query to set `animation: none;` and provide a static fallback (e.g., solid borders instead of spinning partial borders). Furthermore, dynamically update the `aria-label` of interactive elements upon state changes (e.g., from "Copy code to clipboard" to "Code copied") to ensure screen readers announce the exact current state.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -271,6 +271,10 @@ export function renderEmailCredentialForm(
             margin-right: 0.5rem;
             vertical-align: text-bottom;
         }
+        @media (prefers-reduced-motion: reduce) {
+            .pulse { animation: none; opacity: 1; }
+            .spinner { animation: none; border-right-color: transparent; }
+        }
 
     </style>
 </head>
@@ -717,7 +721,11 @@ export function renderEmailCredentialForm(
                         navigator.clipboard.writeText(nextStep.user_code).then(function () {
                             copyBtn.textContent = "Copied!";
                             copyBtn.setAttribute("aria-live", "polite");
-                            setTimeout(function () { copyBtn.textContent = "Copy"; }, 2000);
+                            copyBtn.setAttribute("aria-label", "Code copied");
+                            setTimeout(function () {
+                                copyBtn.textContent = "Copy";
+                                copyBtn.setAttribute("aria-label", "Copy code to clipboard");
+                            }, 2000);
                         });
                     });
                     statusBox.appendChild(copyBtn);


### PR DESCRIPTION
This PR introduces two micro-UX/accessibility improvements:
1. Adds a `@media (prefers-reduced-motion: reduce)` CSS block to gracefully disable `.pulse` and `.spinner` animations for users with motion sensitivities.
2. Improves the screen reader experience for the "Copy" button by utilizing `aria-label` to provide more descriptive feedback ("Code copied" and "Copy code to clipboard") when interacted with.

---
*PR created automatically by Jules for task [11246806622478740021](https://jules.google.com/task/11246806622478740021) started by @n24q02m*