### PR TITLE
🎨 Palette: Add accessibility improvements to credential form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -67,3 +67,6 @@
 
 **Learning:** Masked password fields (e.g., `type="password"`) help prevent shoulder-surfing, but they can be inaccessible for users with cognitive or motor disabilities who may struggle with typing accuracy and cannot verify their input.
 **Action:** Always provide a "Show/Hide" toggle button for password input fields. Ensure the button has an accessible name (e.g., `aria-label="Show password as plain text"`) that updates dynamically when the state changes.
+## 2025-03-09 - [Accessibility Enhancements to credential-form.ts]
+**Learning:** When using Playwright in a headless Chromium environment to test clipboard interactions (like `navigator.clipboard.writeText`), the clipboard promise may silently fail or hang unless explicit permissions (`clipboard-read`, `clipboard-write`) are granted to the browser context, or the API is directly mocked in the page context.
+**Action:** When writing Playwright tests involving clipboard copies, either mock the clipboard API via `page.evaluate("navigator.clipboard.writeText = function() { return Promise.resolve(); };")` or initialize the context with the required permissions.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -272,6 +272,11 @@ export function renderEmailCredentialForm(
             vertical-align: text-bottom;
         }
 
+        @media (prefers-reduced-motion: reduce) {
+            .pulse, .spinner { animation: none; }
+            .field-input, .add-btn { transition: none; }
+        }
+
     </style>
 </head>
 <body>
@@ -716,8 +721,12 @@ export function renderEmailCredentialForm(
                     copyBtn.addEventListener("click", function () {
                         navigator.clipboard.writeText(nextStep.user_code).then(function () {
                             copyBtn.textContent = "Copied!";
+                            copyBtn.setAttribute("aria-label", "Code copied to clipboard");
                             copyBtn.setAttribute("aria-live", "polite");
-                            setTimeout(function () { copyBtn.textContent = "Copy"; }, 2000);
+                            setTimeout(function () {
+                                copyBtn.textContent = "Copy";
+                                copyBtn.setAttribute("aria-label", "Copy code to clipboard");
+                            }, 2000);
                         });
                     });
                     statusBox.appendChild(copyBtn);


### PR DESCRIPTION
This PR adds small touches of accessibility to the `credential-form.ts`. 
1. The `.pulse` and `.spinner` animations, as well as transitions on inputs and buttons, are disabled when `prefers-reduced-motion: reduce` is detected.
2. The `aria-label` of the copy button is dynamically updated when the code is copied, and reverted after 2 seconds to provide better feedback for screen readers.

---
*PR created automatically by Jules for task [4230414683934110865](https://jules.google.com/task/4230414683934110865) started by @n24q02m*