### PR TITLE
fix: right-size CF container memory to cut GiB-second cost

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,8 +16,8 @@
       // Re-pushing the SAME tag does NOT roll a running instance -> delete+recreate
       // the app to deploy a new image.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/better-email-mcp:beta",
-      "instance_type": "standard-1",
-      "max_instances": 100
+      "instance_type": "basic",
+      "max_instances": 10
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
## Summary

Container memory per GiB-second dominates the Cloudflare bill (~95% of cost), currently running well over the $10 budget. This is a config-only right-sizing change.

The cloud-mode MCP container is stateless and loads no local model, so it does not need 4 GiB of RAM. Drop to the 1 GiB tier and cap fan-out:

- `instance_type`: `standard-1` (4 GiB) -> `basic` (1 GiB)
- `max_instances`: `100` -> `10`

## Not changed

- `sleepAfter` stays at `20m` in `src/worker.ts` — it must remain >= the Outlook device-code window (~15m) so the device-code background poll can finish writing the refresh token to KV before the Durable Object sleeps. Lowering it would silently break Outlook auth.
- No application logic touched.

## Verification

- `wrangler deploy --dry-run` parses the config with no schema error (uploads, lists bindings + container, exits cleanly).
- `bun run check` (biome + `tsc --noEmit`) passes (only pre-existing biome.json deprecation infos, unrelated to this change).