### PR TITLE
fix: add cf:deploy script for live wrangler deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ htmlcov/
 
 # CF full-flow self-test dumped Bearer token (scripts/cf_full_flow.py --save-only)
 scripts/.email_cf_token
+
+# Temp wrangler config written by scripts/cf-deploy.js (<YOUR_ACCOUNT_ID> filled in)
+wrangler.deploy.jsonc

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "prepublishOnly": "bun run build",
     "docker:build": "docker build -t n24q02m/better-email-mcp:latest .",
     "docker:push": "docker push n24q02m/better-email-mcp:latest",
-    "docker:run": "docker run --rm -i -e EMAIL_CREDENTIALS n24q02m/better-email-mcp:latest"
+    "docker:run": "docker run --rm -i -e EMAIL_CREDENTIALS n24q02m/better-email-mcp:latest",
+    "cf:dryrun": "node scripts/cf-deploy.js -- --dry-run",
+    "cf:deploy": "node scripts/cf-deploy.js"
   },
   "bin": {
     "better-email-mcp": "bin/cli.mjs"

--- a/scripts/cf-deploy.js
+++ b/scripts/cf-deploy.js
@@ -1,0 +1,78 @@
+// scripts/cf-deploy.js - deploy the better-email-mcp Worker + Container to Cloudflare.
+//
+// wrangler.jsonc keeps live resource IDs as placeholders so they are never
+// committed (see the file header). This script fills them at deploy time into a
+// temp config (wrangler.deploy.jsonc, gitignored) and runs `wrangler deploy`:
+//   <YOUR_ACCOUNT_ID>              -> $CLOUDFLARE_ACCOUNT_ID (container image ref)
+//   <better-email-kv-namespace-id> -> $CLOUDFLARE_KV_NAMESPACE_ID (KV binding)
+//
+// Required env:
+//   CLOUDFLARE_ACCOUNT_ID       - target account id (also substituted into image ref).
+//   CLOUDFLARE_API_TOKEN        - full-access (or Workers+Containers) token for auth.
+//   CLOUDFLARE_KV_NAMESPACE_ID  - live KV namespace id for the KV binding.
+//                                 Look it up once with `wrangler kv namespace list`
+//                                 (or reuse the existing binding on the live worker).
+//
+// This is config-only: it reuses the already-pushed :beta image and preserves
+// existing `wrangler secret put` secrets. It rolls the Worker bundle (sleepAfter)
+// and the container application config (instance_type / max_instances).
+//
+// Usage:
+//   CLOUDFLARE_ACCOUNT_ID=<id> CLOUDFLARE_KV_NAMESPACE_ID=<kv> \
+//     CLOUDFLARE_API_TOKEN=<token> bun run cf:deploy
+//   bun run cf:deploy -- --dry-run        # validate without deploying
+
+import { spawnSync } from 'node:child_process'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const projectRoot = join(__dirname, '..')
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+if (!accountId) {
+  console.error('cf:deploy: CLOUDFLARE_ACCOUNT_ID is required (substituted into the image ref).')
+  process.exit(1)
+}
+if (!process.env.CLOUDFLARE_API_TOKEN) {
+  console.error('cf:deploy: CLOUDFLARE_API_TOKEN is required for wrangler auth.')
+  process.exit(1)
+}
+
+// Placeholder -> live value. KV id is optional only for --dry-run (upload-only).
+const substitutions = [
+  { placeholder: '<YOUR_ACCOUNT_ID>', value: accountId, required: true },
+  { placeholder: '<better-email-kv-namespace-id>', value: process.env.CLOUDFLARE_KV_NAMESPACE_ID, required: false }
+]
+
+const source = join(projectRoot, 'wrangler.jsonc')
+let resolved = readFileSync(source, 'utf8')
+for (const { placeholder, value, required } of substitutions) {
+  if (!resolved.includes(placeholder)) {
+    if (required) {
+      console.error(`cf:deploy: expected ${placeholder} in wrangler.jsonc; not found. Aborting.`)
+      process.exit(1)
+    }
+    continue
+  }
+  if (!value) {
+    console.warn(`cf:deploy: ${placeholder} left unfilled (set the matching env var for a real deploy).`)
+    continue
+  }
+  resolved = resolved.split(placeholder).join(value)
+  console.log(`cf:deploy: ${placeholder} -> ${value}`)
+}
+
+// Write the temp config INSIDE projectRoot: wrangler resolves `main` and other
+// paths relative to the config file's directory, so it must sit next to src/.
+const tempConfig = join(projectRoot, 'wrangler.deploy.jsonc')
+writeFileSync(tempConfig, resolved)
+
+const passthrough = process.argv.slice(2)
+const args = ['wrangler', 'deploy', '-c', tempConfig, ...passthrough]
+console.log(`cf:deploy: running npx ${args.join(' ')}`)
+
+const result = spawnSync('npx', args, { cwd: projectRoot, stdio: 'inherit', shell: process.platform === 'win32' })
+rmSync(tempConfig, { force: true })
+process.exit(result.status ?? 1)

--- a/scripts/cf-deploy.js
+++ b/scripts/cf-deploy.js
@@ -61,7 +61,7 @@ for (const { placeholder, value, required } of substitutions) {
     continue
   }
   resolved = resolved.split(placeholder).join(value)
-  console.log(`cf:deploy: ${placeholder} -> ${value}`)
+  console.log(`cf:deploy: substituted ${placeholder}`)
 }
 
 // Write the temp config INSIDE projectRoot: wrangler resolves `main` and other


### PR DESCRIPTION
## What

Adds a durable `cf:deploy` (and parity `cf:dryrun`) npm script so the right-sized CF cost config in `wrangler.jsonc` can be pushed to the live Worker + Container without hand-editing placeholders.

`scripts/cf-deploy.js` substitutes the committed placeholders into a gitignored temp config (`wrangler.deploy.jsonc`) at deploy time, then runs `wrangler deploy`:

- `<YOUR_ACCOUNT_ID>` -> `$CLOUDFLARE_ACCOUNT_ID` (container image ref)
- `<better-email-kv-namespace-id>` -> `$CLOUDFLARE_KV_NAMESPACE_ID` (KV binding)

No live resource IDs are committed (consistent with the `wrangler.jsonc` header policy). The temp config is written inside the project root so wrangler resolves `main: src/worker.ts` correctly, and is removed after the run.

## Why

The cost right-size landed in #887 (`instance_type` standard-1 -> basic, `max_instances` 100 -> 10) but only in source. This makes applying it to the live deployment a single self-documenting command instead of an ad-hoc placeholder edit.

## Deploy is config-only

Reuses the already-pushed `:beta` image and preserves existing `wrangler secret put` secrets; it rolls the Worker bundle (`sleepAfter=20m`) and the container application config (`instance_type` / `max_instances`).

## Usage

```bash
CLOUDFLARE_ACCOUNT_ID=<id> CLOUDFLARE_KV_NAMESPACE_ID=<kv> \
  CLOUDFLARE_API_TOKEN=<token> bun run cf:deploy
bun run cf:deploy -- --dry-run   # validate without deploying
```