### PR TITLE
🎨 Palette: Focus management on form item removal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -70,3 +70,6 @@
 ## 2025-03-09 - [Accessibility Enhancements to credential-form.ts]
 **Learning:** When using Playwright in a headless Chromium environment to test clipboard interactions (like `navigator.clipboard.writeText`), the clipboard promise may silently fail or hang unless explicit permissions (`clipboard-read`, `clipboard-write`) are granted to the browser context, or the API is directly mocked in the page context.
 **Action:** When writing Playwright tests involving clipboard copies, either mock the clipboard API via `page.evaluate("navigator.clipboard.writeText = function() { return Promise.resolve(); };")` or initialize the context with the required permissions.
+## 2024-05-19 - [Dynamic Form Focus Management]
+**Learning:** When removing an interactive element (like an account card) from a dynamic list in the DOM, abruptly dropping keyboard focus to a fallback action button at the bottom of the page creates a jarring navigation experience. Screen reader and keyboard users lose their context within the form list.
+**Action:** Always attempt to return focus to a logical sibling (e.g. the previous or next card's first input field) before falling back to global action buttons like "Add New". This maintains the sequential flow of form completion.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -582,11 +582,25 @@ export function renderEmailCredentialForm(
                     if (hasData && !window.confirm("This account has unsaved data. Are you sure you want to remove it?")) {
                         return;
                     }
+
+                    var prev = card.previousElementSibling;
+                    var next = card.nextElementSibling;
+                    var focusTarget = (prev && prev.classList && prev.classList.contains("account-card")) ? prev :
+                                      (next && next.classList && next.classList.contains("account-card")) ? next : null;
+
                     card.remove();
                     updateAccountNumbers();
 
-                    // Return focus to the "Add Another Account" button after a card is removed
-                    // to prevent keyboard focus from being dropped back to the document body.
+                    // UX/a11y: Return focus to the previous or next card's first input if it exists,
+                    // otherwise try the Add button. Creates a much smoother experience for keyboard users.
+                    if (focusTarget) {
+                        var firstInput = focusTarget.querySelector("input");
+                        if (firstInput && firstInput instanceof HTMLElement) {
+                            firstInput.focus();
+                            return;
+                        }
+                    }
+
                     if (addBtn) addBtn.focus();
                 });
                 header.appendChild(removeBtn);


### PR DESCRIPTION
💡 What: Added dynamic focus management when removing account cards in the multi-account form.
🎯 Why: When keyboard/screen reader users remove an account card, their context is lost if focus jumps down to the bottom "Add Another Account" button. This ruins the sequential form flow. By directing focus to the previous or next sibling card's first input, we maintain their place in the list.
📸 Before/After: Visual changes unnoticeable but keyboard navigation flow is significantly smoother.
♿ Accessibility: Improved keyboard navigation continuity and context preservation for assistive technologies.

---
*PR created automatically by Jules for task [17223945370816359652](https://jules.google.com/task/17223945370816359652) started by @n24q02m*