### PR TITLE
fix: pin CF container max_instances to 3

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,7 @@
       // the app to deploy a new image.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/better-email-mcp:beta",
       "instance_type": "basic",
-      "max_instances": 10
+      "max_instances": 3
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
Align committed CF config with the live container application.

The live CF container app `better-email-mcp-worker` was already PATCHed to `max_instances=3` (cost right-sizing), but `wrangler.jsonc` still committed `max_instances: 10` — a future `wrangler deploy` would silently regress the live cap back to 10. This pins the committed value to 3 to stop the drift.

Surgical: only the one `max_instances` number changes; `instance_type`, `image`, and all other fields untouched.