### PR TITLE
fix: bump mcp-core to 1.18.0b19 (relay model-search catalog + OAuth refresh-TTL)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": ">=1.18.0-beta.7,<2",
+        "@n24q02m/mcp-core": ">=1.18.0-beta.19,<2",
         "html-to-text": "^10.0.0",
         "imapflow": "^1.4.2",
         "mailparser": "^3.9.11",
@@ -200,7 +200,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.17", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-364I30PsYDaH9H0/37s8viV78JxjHN8ynmd8MbCQ02ZrdzgHxNGW6Tj1Jze7PGv2T1GocktI73mGrWko4zpR1w=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.19", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-GFP3tA6ijuc5NvRyLq/6EcWlu0dbNUti9eBSVqSRBrUeVeADMqtf0FlenL/6XxcyizMP3G136Ili+ndeRLt+fQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": ">=1.18.0-beta.7,<2",
+    "@n24q02m/mcp-core": ">=1.18.0-beta.19,<2",
     "html-to-text": "^10.0.0",
     "imapflow": "^1.4.2",
     "mailparser": "^3.9.11",


### PR DESCRIPTION
Bumps the `@n24q02m/mcp-core` dependency so the published `:beta` Docker image picks up mcp-core `1.18.0-beta.19`, which contains the relay model-search catalog fix and the OAuth refresh-TTL fix.

## Why
`cd.yml` only builds + publishes the Docker image when PSR cuts a release, which requires a new releasable commit. This repo had no new commit since its last beta, so re-dispatching `cd.yml` was a no-op and the `:beta` image still bundled the OLD mcp-core (lockfile pinned `1.18.0-beta.17`).

## What
- `package.json`: bump pin `@n24q02m/mcp-core` from `>=1.18.0-beta.7,<2` to `>=1.18.0-beta.19,<2`.
- `bun.lock`: re-resolved `@n24q02m/mcp-core` from `1.18.0-beta.17` to `1.18.0-beta.19`.

`bun run type-check` passes against beta.19.