### PR TITLE
[TEST] Missing edge case test in html-utils.ts

### DIFF
--- a/src/tools/helpers/html-utils.test.ts
+++ b/src/tools/helpers/html-utils.test.ts
@@ -14,6 +14,11 @@ describe('escapeHtml', () => {
     expect(escapeHtml('&&&')).toBe('&amp;&amp;&amp;')
   })
 
+  it('handles null and undefined', () => {
+    expect(escapeHtml(null)).toBe('')
+    expect(escapeHtml(undefined)).toBe('')
+  })
+
   it('returns an empty string if input is empty', () => {
     expect(escapeHtml('')).toBe('')
   })
@@ -211,6 +216,10 @@ describe('fastExtractSnippet', () => {
     expect(fastExtractSnippet('&#X41;')).toBe('A')
   })
 
+  it('handles invalid numeric entities', () => {
+    expect(fastExtractSnippet('&#ABC;')).toBe('&#ABC;')
+  })
+
   it('preserves unknown named entities', () => {
     expect(fastExtractSnippet('&unknownentity;')).toBe('&unknownentity;')
   })
@@ -288,5 +297,27 @@ describe('sanitizeHtml', () => {
     const dirty = `<img src="${longAttr}">`
     const clean = sanitizeHtml(dirty)
     expect(typeof clean).toBe('string')
+  })
+})
+
+describe('sanitizeHtml extra edge cases', () => {
+  it('handles very large strings with many tags (1MB performance test)', () => {
+    // ~1MB of HTML with many tags
+    const largeString = `<div>${'<p>text</p>'.repeat(80000)}</div>`
+    const start = Date.now()
+    const clean = sanitizeHtml(largeString)
+    const duration = Date.now() - start
+
+    expect(clean).toContain('text')
+    expect(duration).toBeLessThan(5000)
+  })
+
+  it('handles extremely deep nesting (1000 levels)', () => {
+    let deep = 'bottom'
+    for (let i = 0; i < 1000; i++) {
+      deep = `<div>${deep}</div>`
+    }
+    const clean = sanitizeHtml(deep)
+    expect(clean).toContain('bottom')
   })
 })


### PR DESCRIPTION
This PR adds missing edge case and performance tests to `src/tools/helpers/html-utils.ts`. It specifically addresses a request for a large-string performance test for `sanitizeHtml`, while also filling gaps in branch coverage for `escapeHtml` and `fastExtractSnippet`.

Tests added:
1.  **Sanitize Performance (High Density):** A 1MB HTML string containing 80,000 `<p>` tags is processed to ensure the library handles complex payloads within a 5-second threshold.
2.  **Sanitize Stability (Deep Nesting):** A 1000-level deep `<div>` structure is processed to verify resistance to stack overflow.
3.  **Escape Null/Undefined:** Verified that `escapeHtml` handles non-string inputs robustly.
4.  **Invalid Entities:** Verified that `fastExtractSnippet` gracefully handles malformed numeric entities.

All tests passed, and 100% branch coverage for the utility file has been achieved.

---
*PR created automatically by Jules for task [6297682783116759675](https://jules.google.com/task/6297682783116759675) started by @n24q02m*