### PR TITLE
[FIX] Fix form polling JS for Outlook OAuth

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -26,7 +26,13 @@ import { PerSubCredStore } from '../auth/cred-store.js'
 import { type CredStoreLike, InMemoryCredStore } from '../auth/in-memory-cred-store.js'
 import { subjectContext } from '../auth/subject-context.js'
 import { renderEmailCredentialForm } from '../credential-form.js'
-import { resolveCredentialState, setMarkSetupComplete, setSetupUrl, setState } from '../credential-state.js'
+import {
+  getMarkSetupComplete,
+  resolveCredentialState,
+  setMarkSetupComplete,
+  setSetupUrl,
+  setState
+} from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain, setOutlookTokenStore } from '../tools/helpers/oauth2.js'
@@ -124,6 +130,7 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[], sub?: stri
     const device = await initiateOutlookDeviceCode(
       first.email,
       () => {
+        getMarkSetupComplete()?.('outlook')
         console.error(`[${SERVER_NAME}] Outlook OAuth2 completed for ${first.email}`)
       },
       sub


### PR DESCRIPTION
This PR fixes a regression where the Outlook OAuth setup form would spin indefinitely even after successful authorization.

The issue was that the `onComplete` callback in the HTTP transport layer was not invoking `getMarkSetupComplete()?.('outlook')`. The credential form's client-side polling logic specifically looks for the `outlook` key to be set to `complete` to transition the UI state.

Changes:
- Added `getMarkSetupComplete` to the imports in `src/transports/http.ts`.
- Updated the `onComplete` callback in `initiateOutlookOAuth` to call `getMarkSetupComplete()?.('outlook')`.

Verified with existing tests in `src/transports/http.test.ts`.

---
*PR created automatically by Jules for task [11799417062117812246](https://jules.google.com/task/11799417062117812246) started by @n24q02m*