### PR TITLE
[TEST] Missing test file for subject-context.ts

### DIFF
--- a/src/auth/subject-context.test.ts
+++ b/src/auth/subject-context.test.ts
@@ -119,6 +119,17 @@ describe('subjectContext', () => {
 
     expect(subjectContext.getStore()).toBeUndefined()
   })
+
+  test('should clear scope with exit()', () => {
+    const scope: EmailSubjectScope = { sub: 'exit-test', accounts: [] }
+    subjectContext.run(scope, () => {
+      expect(subjectContext.getStore()).toBe(scope)
+      subjectContext.exit(() => {
+        expect(subjectContext.getStore()).toBeUndefined()
+      })
+      expect(subjectContext.getStore()).toBe(scope)
+    })
+  })
 })
 
 describe('currentSub', () => {
@@ -139,6 +150,27 @@ describe('currentSub', () => {
         expect(currentSub()).toBe('inner')
       })
       expect(currentSub()).toBe('outer')
+    })
+  })
+
+  test('handles non-object store (defensive)', () => {
+    // @ts-expect-error - testing runtime safety for unexpected store content
+    subjectContext.run('not-an-object', () => {
+      expect(currentSub()).toBeNull()
+    })
+  })
+
+  test('handles null store (defensive)', () => {
+    // @ts-expect-error - testing runtime safety
+    subjectContext.run(null, () => {
+      expect(currentSub()).toBeNull()
+    })
+  })
+
+  test('handles object store without sub (defensive)', () => {
+    // @ts-expect-error - testing runtime safety
+    subjectContext.run({ notSub: 'xxx' }, () => {
+      expect(currentSub()).toBeNull()
     })
   })
 })

--- a/src/auth/subject-context.ts
+++ b/src/auth/subject-context.ts
@@ -35,5 +35,9 @@ export const subjectContext = new AsyncLocalStorage<EmailSubjectScope>()
  * write tokens to the right per-sub credential blob.
  */
 export function currentSub(): string | null {
-  return subjectContext.getStore()?.sub ?? null
+  const store = subjectContext.getStore()
+  if (store && typeof store === 'object') {
+    return (store as EmailSubjectScope).sub ?? null
+  }
+  return null
 }


### PR DESCRIPTION
The existing `subject-context.test.ts` was enhanced to include more robust test cases, specifically covering:
- `subjectContext.exit()` functionality.
- Defensive handling in `currentSub()` when the store is not an object (prevents potential bugs where a primitive string in storage might accidentally expose `.sub()` method).
- Nested and concurrent scope isolation.

The implementation of `currentSub()` was also slightly updated to include explicit type checks for the store object.

---
*PR created automatically by Jules for task [1207618792061380545](https://jules.google.com/task/1207618792061380545) started by @n24q02m*