### PR TITLE
[FIX] Invoke markSetupCompleteFn after saving tokens

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -26,7 +26,13 @@ import { PerSubCredStore } from '../auth/cred-store.js'
 import { type CredStoreLike, InMemoryCredStore } from '../auth/in-memory-cred-store.js'
 import { subjectContext } from '../auth/subject-context.js'
 import { renderEmailCredentialForm } from '../credential-form.js'
-import { resolveCredentialState, setMarkSetupComplete, setSetupUrl, setState } from '../credential-state.js'
+import {
+  getMarkSetupComplete,
+  resolveCredentialState,
+  setMarkSetupComplete,
+  setSetupUrl,
+  setState
+} from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain, setOutlookTokenStore } from '../tools/helpers/oauth2.js'
@@ -125,6 +131,8 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[], sub?: stri
       first.email,
       () => {
         console.error(`[${SERVER_NAME}] Outlook OAuth2 completed for ${first.email}`)
+        setState('configured')
+        getMarkSetupComplete()?.('outlook')
       },
       sub
     )


### PR DESCRIPTION
Modified the `onComplete` callback in `initiateOutlookOAuth` within `src/transports/http.ts` to call `setState('configured')` and `getMarkSetupComplete()?.('outlook')` after logging the completion message. 

This ensures that the credential form spinner stops after a successful Microsoft OAuth2 device-code authorization by signaling to the form's polling logic that the setup is complete. This addresses a UX bug where the form would stay in "Waiting for Microsoft authorization..." indefinitely even after tokens were saved.

Verified by running the full test suite and checking that `src/transports/http.test.ts` passes, including the regression test for this specific issue.

---
*PR created automatically by Jules for task [17468522880677962514](https://jules.google.com/task/17468522880677962514) started by @n24q02m*