### PR TITLE
[PERF] Cache bigrams for valid options

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2025-05-18 - [V8 RegExp replacement overhead]
 **Learning:** In V8 environments (Node.js/Bun), using chained `.replace()` calls with string literal replacements is measurably faster than using a single global `.replace()` with a mapping callback for simple escaping tasks (e.g. HTML escaping). The overhead comes from V8 needing to cross the C++/JS boundary and invoke the JS callback for every regex match.
 **Action:** Always prefer chained `.replace()` with string literal replacements for simple, fixed-mapping string replacements instead of a single mapping callback, especially in hot-path or frequently called utilities.
+
+## 2026-06-23 - [Cache bigrams for valid options]
+ **Learning:** In string matching algorithms like `findClosestMatch` that compare user input against a static list of valid options, recomputing bigrams for the static options on every invocation is a significant overhead. Representing bigrams as 32-bit integers (`(char1 << 16) | char2`) instead of strings eliminates slicing and allocation overhead, further improving performance.
+ **Action:** Refactored `findClosestMatch` in `src/tools/helpers/errors.ts` to use a numeric bigram cache and pre-computed lowercased strings.

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -166,7 +166,7 @@ function handleSmtpError(error: unknown): EmailMCPError {
 }
 
 // ⚡ Bolt: Cache bigrams for static valid options to avoid recomputing them on every request.
-const validOptionBigramCache = new Map<string, Set<string>>()
+const validOptionBigramCache = new Map<string, { lower: string; bigrams: Set<number> }>()
 
 /**
  * Find the closest matching string from a list of valid options.
@@ -182,23 +182,32 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   // ⚡ Bolt: Pre-compute the input bigrams outside the loop.
   // This prevents redundant Set allocations and string slicing for the identical
   // input string on every iteration of validOptions, reducing overhead from O(N*M) to O(N+M).
-  const inputBigrams = new Set<string>()
-  for (let i = 0; i < lower.length - 1; i++) inputBigrams.add(lower.slice(i, i + 2))
+  const inputBigrams = new Set<number>()
+  for (let i = 0; i < lower.length - 1; i++) {
+    inputBigrams.add((lower.charCodeAt(i) << 16) | lower.charCodeAt(i + 1))
+  }
 
   for (const option of validOptions) {
-    const optionLower = option.toLowerCase()
+    // ⚡ Bolt: Use cached data if available, otherwise compute and cache it.
+    // Using the original option string as the key to avoid re-calling toLowerCase()
+    // on every lookup.
+    let cached = validOptionBigramCache.get(option)
+    if (!cached) {
+      const lowerStr = option.toLowerCase()
+      const bigrams = new Set<number>()
+      for (let i = 0; i < lowerStr.length - 1; i++) {
+        bigrams.add((lowerStr.charCodeAt(i) << 16) | lowerStr.charCodeAt(i + 1))
+      }
+      cached = { lower: lowerStr, bigrams }
+      validOptionBigramCache.set(option, cached)
+    }
+
+    const optionLower = cached.lower
     if (optionLower.startsWith(lower) || lower.startsWith(optionLower)) {
       return option
     }
 
-    // ⚡ Bolt: Use cached bigrams if available, otherwise compute and cache them.
-    let optionBigrams = validOptionBigramCache.get(optionLower)
-    if (!optionBigrams) {
-      optionBigrams = new Set<string>()
-      for (let i = 0; i < optionLower.length - 1; i++) optionBigrams.add(optionLower.slice(i, i + 2))
-      validOptionBigramCache.set(optionLower, optionBigrams)
-    }
-
+    const optionBigrams = cached.bigrams
     let overlap = 0
     for (const b of inputBigrams) {
       if (optionBigrams.has(b)) overlap++


### PR DESCRIPTION
Optimized the findClosestMatch function in src/tools/helpers/errors.ts to use numeric bigrams and cached lowercased strings.

Key changes:
- Refactored bigram representation from strings to numbers ((char1 << 16) | char2) to eliminate string slicing and allocation overhead.
- Updated validOptionBigramCache to store both the lowercased version of the option and its numeric bigrams.
- Used the original option string as the cache key to avoid redundant toLowerCase() calls during lookups.
- Ensured input bigrams are pre-computed once before the matching loop.

These optimizations reduce the overhead of fuzzy matching tool names and suggestions, improving responsiveness during error handling and command validation.

---
*PR created automatically by Jules for task [14612427990241520462](https://jules.google.com/task/14612427990241520462) started by @n24q02m*