### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -571,6 +571,10 @@ describe('deviceCodeAuth', () => {
   it('throws if email is just whitespace', async () => {
     await expect(deviceCodeAuth('   ')).rejects.toThrow('Email is required')
   })
+  it('throws if email is null or undefined', async () => {
+    await expect(deviceCodeAuth(null as any)).rejects.toThrow('Email is required')
+    await expect(deviceCodeAuth(undefined as any)).rejects.toThrow('Email is required')
+  })
   const mockFetch = vi.fn()
   const originalEnv = process.env.OUTLOOK_CLIENT_ID
 
@@ -1180,6 +1184,10 @@ describe('initiateOutlookDeviceCode', () => {
   })
   it('throws if email is just whitespace', async () => {
     await expect(initiateOutlookDeviceCode('   ')).rejects.toThrow('Email is required')
+  })
+  it('throws if email is null or undefined', async () => {
+    await expect(initiateOutlookDeviceCode(null as any)).rejects.toThrow('Email is required')
+    await expect(initiateOutlookDeviceCode(undefined as any)).rejects.toThrow('Email is required')
   })
 })
 


### PR DESCRIPTION
This PR adds missing edge case tests for `initiateOutlookDeviceCode` and `deviceCodeAuth` in `src/tools/helpers/oauth2.ts`.

Specifically:
- Added tests for `null` and `undefined` email inputs (using type assertions) to ensure the validation logic `!email?.trim()` correctly throws 'Email is required'.
- Verified that these tests pass alongside the existing 73 tests in the module.
- Confirmed coverage remains high.

---
*PR created automatically by Jules for task [9365878045152381084](https://jules.google.com/task/9365878045152381084) started by @n24q02m*