### PR TITLE
test(oauth2): implement and test saveOutlookTokens fallback logic

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -47,6 +47,7 @@ import {
   _getPendingAuths,
   _resetBrowserOpenDedupe,
   _resetTokenCache,
+  decodeIdTokenSubject,
   deviceCodeAuth,
   ensureValidToken,
   getClientId,
@@ -1259,6 +1260,36 @@ describe('saveOutlookTokens', () => {
     expect(written['env@outlook.com'].accessToken).toBe('at-env')
   })
 
+  it('uses tokens.sub if email and env var are missing', async () => {
+    delete process.env.OUTLOOK_EMAIL
+    const tokens = {
+      sub: 'sub-789',
+      access_token: 'at-sub'
+    }
+
+    await saveOutlookTokens(tokens)
+
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    expect(written['sub-789']).toBeDefined()
+    expect(written['sub-789'].accessToken).toBe('at-sub')
+  })
+
+  it('uses id_token subject if email, env var, and sub are missing', async () => {
+    delete process.env.OUTLOOK_EMAIL
+    const payload = Buffer.from(JSON.stringify({ sub: 'id-sub-456' })).toString('base64url')
+    const idToken = `header.${payload}.signature`
+    const tokens = {
+      id_token: idToken,
+      access_token: 'at-id'
+    }
+
+    await saveOutlookTokens(tokens)
+
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    expect(written['id-sub-456']).toBeDefined()
+    expect(written['id-sub-456'].accessToken).toBe('at-id')
+  })
+
   it('falls back to outlook-device-code if both email sources are missing', async () => {
     delete process.env.OUTLOOK_EMAIL
     const tokens = {
@@ -1376,5 +1407,31 @@ describe('Outlook token embed (per-sub config blob)', () => {
     await saveTokens('b@hotmail.com', TOK('b'), 'sub-1')
 
     expect((await loadOutlookEmails('sub-1')).sort()).toEqual(['a@outlook.com', 'b@hotmail.com'])
+  })
+})
+
+describe('decodeIdTokenSubject', () => {
+  it('returns sub if valid idToken', () => {
+    const payload = Buffer.from(JSON.stringify({ sub: 'user-123' })).toString('base64url')
+    const idToken = `header.${payload}.signature`
+    expect(decodeIdTokenSubject(idToken)).toBe('user-123')
+  })
+
+  it('returns null if not a string', () => {
+    expect(decodeIdTokenSubject(123)).toBeNull()
+  })
+
+  it('returns null if malformed JWT (not 3 parts)', () => {
+    expect(decodeIdTokenSubject('part1.part2')).toBeNull()
+  })
+
+  it('returns null if payload is not valid JSON', () => {
+    expect(decodeIdTokenSubject('header.notjson.signature')).toBeNull()
+  })
+
+  it('returns null if sub is missing in payload', () => {
+    const payload = Buffer.from(JSON.stringify({ other: 'claim' })).toString('base64url')
+    const idToken = `header.${payload}.signature`
+    expect(decodeIdTokenSubject(idToken)).toBeNull()
   })
 })

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -102,6 +102,22 @@ export function isValidTokenStore(data: unknown): data is TokenStore {
 }
 
 /** Outlook/Hotmail/Live domains that require OAuth2 */
+/**
+ * Extract the "sub" claim from an OIDC id_token without verifying signatures.
+ * id_token is a JWT (header.payload.signature).
+ */
+export function decodeIdTokenSubject(idToken: unknown): string | null {
+  if (typeof idToken !== 'string') return null
+  try {
+    const parts = idToken.split('.')
+    if (parts.length !== 3) return null
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'))
+    return typeof payload.sub === 'string' ? payload.sub : null
+  } catch {
+    return null
+  }
+}
+
 const OUTLOOK_DOMAINS = new Set(['outlook.com', 'hotmail.com', 'live.com'])
 
 /**
@@ -615,7 +631,13 @@ export async function ensureValidToken(account: { email: string; oauth2?: OAuth2
  * claim as a fallback (uncommon in device-code flows).
  */
 export async function saveOutlookTokens(tokens: Record<string, unknown>): Promise<void> {
-  const email = typeof tokens.email === 'string' ? tokens.email : (process.env.OUTLOOK_EMAIL ?? 'outlook-device-code')
+  const email =
+    (typeof tokens.email === 'string' ? tokens.email : null) ??
+    process.env.OUTLOOK_EMAIL ??
+    (typeof tokens.sub === 'string' ? tokens.sub : null) ??
+    decodeIdTokenSubject(tokens.id_token) ??
+    'outlook-device-code'
+
   const now = Math.floor(Date.now() / MS_PER_SECOND)
   const expiresIn = typeof tokens.expires_in === 'number' ? tokens.expires_in : 3600
   await saveTokens(email, {


### PR DESCRIPTION
Implemented decodeIdTokenSubject to extract subject from OIDC id_tokens and updated saveOutlookTokens to use a prioritized fallback chain: tokens.email > process.env.OUTLOOK_EMAIL > tokens.sub > id_token subject > 'outlook-device-code'. Added comprehensive unit tests and verified 100% coverage.

---
*PR created automatically by Jules for task [17664586014992251784](https://jules.google.com/task/17664586014992251784) started by @n24q02m*