### PR TITLE
🎨 Palette: [Add aria-pressed to toggle-password-btn]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -73,3 +73,8 @@
 ## 2024-05-19 - [Dynamic Form Focus Management]
 **Learning:** When removing an interactive element (like an account card) from a dynamic list in the DOM, abruptly dropping keyboard focus to a fallback action button at the bottom of the page creates a jarring navigation experience. Screen reader and keyboard users lose their context within the form list.
 **Action:** Always attempt to return focus to a logical sibling (e.g. the previous or next card's first input field) before falling back to global action buttons like "Add New". This maintains the sequential flow of form completion.
+
+## 2025-06-23 - Toggle Button Pressed State
+
+**Learning:** When creating a custom toggle button (like a "Show/Hide Password" button), simply changing the `aria-label` or text content is insufficient for screen readers to fully understand it is a stateful toggle button.
+**Action:** Always include the `aria-pressed` attribute on custom toggle buttons and ensure its value dynamically updates between `true` and `false` as the state changes to explicitly communicate the pressed state to assistive technologies.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -399,10 +399,12 @@ export function renderEmailCredentialForm(
                     toggleBtn.className = "toggle-password-btn";
                     toggleBtn.textContent = "Show";
                     toggleBtn.setAttribute("aria-label", "Show password as plain text");
+                    toggleBtn.setAttribute("aria-pressed", "false");
                     toggleBtn.addEventListener("click", function () {
                         var isPass = input.getAttribute("type") === "password";
                         input.setAttribute("type", isPass ? "text" : "password");
                         toggleBtn.textContent = isPass ? "Hide" : "Show";
+                        toggleBtn.setAttribute("aria-pressed", isPass ? "true" : "false");
                         toggleBtn.setAttribute("aria-label", isPass ? "Hide password" : "Show password as plain text");
                     });
                     wrapper.appendChild(toggleBtn);


### PR DESCRIPTION
This adds the `aria-pressed` attribute to the "Show/Hide" toggle button on password fields. When building custom toggle buttons, it's essential for screen reader users to have the pressed state communicated. The attribute is initialized to `false` and is correctly toggled to `true` when the password is shown, and vice versa.

---
*PR created automatically by Jules for task [17135873129222793903](https://jules.google.com/task/17135873129222793903) started by @n24q02m*