### PR TITLE
🎨 Palette: Add aria-pressed to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -73,3 +73,6 @@
 ## 2024-05-19 - [Dynamic Form Focus Management]
 **Learning:** When removing an interactive element (like an account card) from a dynamic list in the DOM, abruptly dropping keyboard focus to a fallback action button at the bottom of the page creates a jarring navigation experience. Screen reader and keyboard users lose their context within the form list.
 **Action:** Always attempt to return focus to a logical sibling (e.g. the previous or next card's first input field) before falling back to global action buttons like "Add New". This maintains the sequential flow of form completion.
+## 2026-06-24 - Accessibility for Password Toggle Buttons
+**Learning:** Screen reader users rely on the `aria-pressed` attribute to know the state of toggle buttons (like "Show/Hide Password"). Without it, they might not know if the password is currently visible or masked, even if the label changes.
+**Action:** Always add `aria-pressed="true|false"` to toggle buttons to accurately communicate their active state to assistive technologies, in addition to descriptive `aria-label`s.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -399,11 +399,13 @@ export function renderEmailCredentialForm(
                     toggleBtn.className = "toggle-password-btn";
                     toggleBtn.textContent = "Show";
                     toggleBtn.setAttribute("aria-label", "Show password as plain text");
+                    toggleBtn.setAttribute("aria-pressed", "false");
                     toggleBtn.addEventListener("click", function () {
                         var isPass = input.getAttribute("type") === "password";
                         input.setAttribute("type", isPass ? "text" : "password");
                         toggleBtn.textContent = isPass ? "Hide" : "Show";
                         toggleBtn.setAttribute("aria-label", isPass ? "Hide password" : "Show password as plain text");
+                        toggleBtn.setAttribute("aria-pressed", isPass ? "true" : "false");
                     });
                     wrapper.appendChild(toggleBtn);
                     group.appendChild(wrapper);


### PR DESCRIPTION
This PR implements a micro-UX enhancement by adding the `aria-pressed` attribute to the "Show/Hide Password" toggle button in the multi-account credential form. 

**Why:** Screen reader users rely on `aria-pressed` to understand the current state of a toggle button. While the button text and `aria-label` change between "Show" and "Hide", explicitly indicating the pressed state (`true` when password is shown, `false` when hidden) provides a more robust and standard accessibility experience.

**What was changed:**
- Updated `src/credential-form.ts` to set initial `aria-pressed="false"`.
- Updated the click handler to dynamically toggle `aria-pressed` based on the visibility state.
- Added a `.jules/palette.md` journal entry logging the importance of this accessibility pattern.

Tested locally, visually verified with Playwright, and ran the test suite (`bun run check` and `bun run test`). All tests pass and no test artifacts were committed.

---
*PR created automatically by Jules for task [14962962714421324110](https://jules.google.com/task/14962962714421324110) started by @n24q02m*