### PR TITLE
⚡ Bolt: Replace string bigrams with 32-bit integers in findClosestMatch

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -165,8 +165,9 @@ function handleSmtpError(error: unknown): EmailMCPError {
   }
 }
 
-// ⚡ Bolt: Cache bigrams for static valid options to avoid recomputing them on every request.
-const validOptionBigramCache = new Map<string, Set<string>>()
+// ⚡ Bolt: Cache bigrams and lowercase versions for static valid options to avoid recomputing them on every request.
+// Bigrams are represented as 32-bit integers to eliminate string slicing and allocation overhead.
+const validOptionBigramCache = new Map<string, { lower: string; bigrams: Set<number> }>()
 
 /**
  * Find the closest matching string from a list of valid options.
@@ -180,30 +181,34 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   let bestScore = 0
 
   // ⚡ Bolt: Pre-compute the input bigrams outside the loop.
-  // This prevents redundant Set allocations and string slicing for the identical
-  // input string on every iteration of validOptions, reducing overhead from O(N*M) to O(N+M).
-  const inputBigrams = new Set<string>()
-  for (let i = 0; i < lower.length - 1; i++) inputBigrams.add(lower.slice(i, i + 2))
+  // Use 32-bit integer representation ((char1 << 16) | char2) to avoid string slicing and allocation overhead.
+  const inputBigrams = new Set<number>()
+  for (let i = 0; i < lower.length - 1; i++) {
+    inputBigrams.add((lower.charCodeAt(i) << 16) | lower.charCodeAt(i + 1))
+  }
 
   for (const option of validOptions) {
-    const optionLower = option.toLowerCase()
-    if (optionLower.startsWith(lower) || lower.startsWith(optionLower)) {
-      return option
+    // ⚡ Bolt: Use original option as key to bypass redundant toLowerCase() calls
+    let cached = validOptionBigramCache.get(option)
+    if (!cached) {
+      const optionLower = option.toLowerCase()
+      const bigrams = new Set<number>()
+      for (let i = 0; i < optionLower.length - 1; i++) {
+        bigrams.add((optionLower.charCodeAt(i) << 16) | optionLower.charCodeAt(i + 1))
+      }
+      cached = { lower: optionLower, bigrams }
+      validOptionBigramCache.set(option, cached)
     }
 
-    // ⚡ Bolt: Use cached bigrams if available, otherwise compute and cache them.
-    let optionBigrams = validOptionBigramCache.get(optionLower)
-    if (!optionBigrams) {
-      optionBigrams = new Set<string>()
-      for (let i = 0; i < optionLower.length - 1; i++) optionBigrams.add(optionLower.slice(i, i + 2))
-      validOptionBigramCache.set(optionLower, optionBigrams)
+    if (cached.lower.startsWith(lower) || lower.startsWith(cached.lower)) {
+      return option
     }
 
     let overlap = 0
     for (const b of inputBigrams) {
-      if (optionBigrams.has(b)) overlap++
+      if (cached.bigrams.has(b)) overlap++
     }
-    const score = (2 * overlap) / (inputBigrams.size + optionBigrams.size)
+    const score = (2 * overlap) / (inputBigrams.size + cached.bigrams.size)
     if (score > bestScore && score > 0.4) {
       bestScore = score
       bestMatch = option


### PR DESCRIPTION
💡 What: The optimization replaces string representation of bigrams in `findClosestMatch` with 32-bit integers, by shifting characters via `(char1 << 16) | char2`. It also caches the original lowercased string alongside its bigram list.
🎯 Why: `findClosestMatch` fuzzy matches the given input strings. Before, bigrams were generated with `.slice`, taking up memory for string allocation, and using `Set<string>`. Caching lowercases also ensures we don't repeat the `.toLowerCase()` call across elements.
📊 Impact: Expected to reduce event-loop delay in repeated matching paths by bypassing string allocation, saving GC pressure.
🔬 Measurement: Verify tests run using `bun run test` on `src/tools/helpers/errors.test.ts`.

---
*PR created automatically by Jules for task [2323667026828618955](https://jules.google.com/task/2323667026828618955) started by @n24q02m*