### PR TITLE
🎨 Palette: Add aria-pressed to password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -73,3 +73,6 @@
 ## 2024-05-19 - [Dynamic Form Focus Management]
 **Learning:** When removing an interactive element (like an account card) from a dynamic list in the DOM, abruptly dropping keyboard focus to a fallback action button at the bottom of the page creates a jarring navigation experience. Screen reader and keyboard users lose their context within the form list.
 **Action:** Always attempt to return focus to a logical sibling (e.g. the previous or next card's first input field) before falling back to global action buttons like "Add New". This maintains the sequential flow of form completion.
+## 2024-06-25 - [ARIA Pressed for Toggles]
+**Learning:** "Show/Hide" password toggle buttons can confuse screen readers if they only change labels or text content. The `aria-pressed` attribute provides native toggle state feedback.
+**Action:** Ensure custom toggle buttons explicitly set and update `aria-pressed="true|false"` alongside any `aria-label` changes.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -399,11 +399,13 @@ export function renderEmailCredentialForm(
                     toggleBtn.className = "toggle-password-btn";
                     toggleBtn.textContent = "Show";
                     toggleBtn.setAttribute("aria-label", "Show password as plain text");
+                    toggleBtn.setAttribute("aria-pressed", "false");
                     toggleBtn.addEventListener("click", function () {
                         var isPass = input.getAttribute("type") === "password";
                         input.setAttribute("type", isPass ? "text" : "password");
                         toggleBtn.textContent = isPass ? "Hide" : "Show";
                         toggleBtn.setAttribute("aria-label", isPass ? "Hide password" : "Show password as plain text");
+                        toggleBtn.setAttribute("aria-pressed", isPass ? "true" : "false");
                     });
                     wrapper.appendChild(toggleBtn);
                     group.appendChild(wrapper);


### PR DESCRIPTION
💡 What: Added aria-pressed attribute to the password show/hide toggle.
🎯 Why: Provides clearer state feedback to screen reader users interacting with the password visibility toggle.
📸 Before/After: See automated frontend verification screenshots.
♿ Accessibility: Adds dynamic aria-pressed state, improving screen reader context.

---
*PR created automatically by Jules for task [3114541373409269279](https://jules.google.com/task/3114541373409269279) started by @n24q02m*