### PR TITLE
🎨 Palette: Add aria-pressed to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -73,3 +73,7 @@
 ## 2024-05-19 - [Dynamic Form Focus Management]
 **Learning:** When removing an interactive element (like an account card) from a dynamic list in the DOM, abruptly dropping keyboard focus to a fallback action button at the bottom of the page creates a jarring navigation experience. Screen reader and keyboard users lose their context within the form list.
 **Action:** Always attempt to return focus to a logical sibling (e.g. the previous or next card's first input field) before falling back to global action buttons like "Add New". This maintains the sequential flow of form completion.
+
+## 2026-06-27 - Dynamic ARIA States for Toggle Buttons
+**Learning:** Relying solely on changing `aria-label` or text content on a toggle button is often insufficient for screen readers to properly announce state changes robustly.
+**Action:** Always complement text/label changes with the `aria-pressed` attribute (toggling between "true" and "false") on toggle buttons to explicitly announce the active state.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -399,11 +399,13 @@ export function renderEmailCredentialForm(
                     toggleBtn.className = "toggle-password-btn";
                     toggleBtn.textContent = "Show";
                     toggleBtn.setAttribute("aria-label", "Show password as plain text");
+                    toggleBtn.setAttribute("aria-pressed", "false");
                     toggleBtn.addEventListener("click", function () {
                         var isPass = input.getAttribute("type") === "password";
                         input.setAttribute("type", isPass ? "text" : "password");
                         toggleBtn.textContent = isPass ? "Hide" : "Show";
                         toggleBtn.setAttribute("aria-label", isPass ? "Hide password" : "Show password as plain text");
+                        toggleBtn.setAttribute("aria-pressed", isPass ? "true" : "false");
                     });
                     wrapper.appendChild(toggleBtn);
                     group.appendChild(wrapper);


### PR DESCRIPTION
💡 What: Added the `aria-pressed` attribute to the 'Show/Hide' password toggle button, dynamically updating it to 'true' or 'false'.\n🎯 Why: Ensures screen readers robustly announce the toggled state change beyond just updating the label.\n📸 Before/After: Visuals unchanged, purely semantic.\n♿ Accessibility: Resolves an issue where state change announcement might be missed or ambiguous to screen readers.

---
*PR created automatically by Jules for task [11364980709167275159](https://jules.google.com/task/11364980709167275159) started by @n24q02m*