### PR TITLE
🎨 Palette: Add `aria-pressed` to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -73,3 +73,6 @@
 ## 2024-05-19 - [Dynamic Form Focus Management]
 **Learning:** When removing an interactive element (like an account card) from a dynamic list in the DOM, abruptly dropping keyboard focus to a fallback action button at the bottom of the page creates a jarring navigation experience. Screen reader and keyboard users lose their context within the form list.
 **Action:** Always attempt to return focus to a logical sibling (e.g. the previous or next card's first input field) before falling back to global action buttons like "Add New". This maintains the sequential flow of form completion.
+## 2025-02-19 - ARIA Pressed State for Password Toggles
+**Learning:** Screen reader users need clear context when toggling the visibility of password fields. While changing the button text or `aria-label` provides information, using `aria-pressed` robustly announces the toggled state to screen readers, improving the cognitive context of the action.
+**Action:** Always include the `aria-pressed` attribute (toggling between `true` and `false`) on "Show/Hide" password buttons to announce their active state reliably to screen readers.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -399,11 +399,13 @@ export function renderEmailCredentialForm(
                     toggleBtn.className = "toggle-password-btn";
                     toggleBtn.textContent = "Show";
                     toggleBtn.setAttribute("aria-label", "Show password as plain text");
+                    toggleBtn.setAttribute("aria-pressed", "false");
                     toggleBtn.addEventListener("click", function () {
                         var isPass = input.getAttribute("type") === "password";
                         input.setAttribute("type", isPass ? "text" : "password");
                         toggleBtn.textContent = isPass ? "Hide" : "Show";
                         toggleBtn.setAttribute("aria-label", isPass ? "Hide password" : "Show password as plain text");
+                        toggleBtn.setAttribute("aria-pressed", isPass ? "true" : "false");
                     });
                     wrapper.appendChild(toggleBtn);
                     group.appendChild(wrapper);


### PR DESCRIPTION
🎨 Palette: Added `aria-pressed` to password toggle button

💡 **What**: The Show/Hide password toggle button now actively toggles the `aria-pressed` attribute between `"true"` and `"false"`.
🎯 **Why**: Screen reader users need clear context when toggling the visibility of password fields. While changing the button text or `aria-label` provides information, using `aria-pressed` robustly announces the toggled state to screen readers, improving the cognitive context of the action.
📸 **Before/After**: Visually unchanged, but programmatically distinct.
♿ **Accessibility**: Addresses WCAG guidelines by making toggle states perceivable to assistive technology.

---
*PR created automatically by Jules for task [6820380858072121553](https://jules.google.com/task/6820380858072121553) started by @n24q02m*