### PR TITLE
[PERF] Use asynchronous file reading in saveTokens

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -7,14 +7,13 @@ vi.mock('@n24q02m/mcp-core', () => ({
 }))
 
 vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn()
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn()
 }))
 
 vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-  mkdirSync: vi.fn(),
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn()
+  existsSync: vi.fn()
 }))
 
 vi.mock('node:os', () => ({
@@ -27,14 +26,13 @@ vi.mock('../../credential-state.js', () => ({
   getMarkSetupComplete: vi.fn()
 }))
 
-import { readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { getMarkSetupComplete, setState } from '../../credential-state.js'
 
 const mockReadFile = vi.mocked(readFile)
+const mockWriteFile = vi.mocked(writeFile)
+const mockMkdir = vi.mocked(mkdir)
 const mockExistsSync = vi.mocked(existsSync)
-const mockReadFileSync = vi.mocked(readFileSync)
-const mockWriteFileSync = vi.mocked(writeFileSync)
-const mockMkdirSync = vi.mocked(mkdirSync)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -72,35 +70,35 @@ afterEach(() => {
 })
 
 describe('isOutlookDomain', () => {
-  it('detects outlook.com', () => {
+  it('detects outlook.com', async () => {
     expect(isOutlookDomain('user@outlook.com')).toBe(true)
   })
 
-  it('detects hotmail.com', () => {
+  it('detects hotmail.com', async () => {
     expect(isOutlookDomain('user@hotmail.com')).toBe(true)
   })
 
-  it('detects live.com', () => {
+  it('detects live.com', async () => {
     expect(isOutlookDomain('user@live.com')).toBe(true)
   })
 
-  it('rejects gmail.com', () => {
+  it('rejects gmail.com', async () => {
     expect(isOutlookDomain('user@gmail.com')).toBe(false)
   })
 
-  it('rejects yahoo.com', () => {
+  it('rejects yahoo.com', async () => {
     expect(isOutlookDomain('user@yahoo.com')).toBe(false)
   })
 
-  it('handles empty string', () => {
+  it('handles empty string', async () => {
     expect(isOutlookDomain('')).toBe(false)
   })
 
-  it('handles email without domain', () => {
+  it('handles email without domain', async () => {
     expect(isOutlookDomain('nodomain')).toBe(false)
   })
 
-  it('is case-insensitive via domain extraction', () => {
+  it('is case-insensitive via domain extraction', async () => {
     expect(isOutlookDomain('user@OUTLOOK.COM')).toBe(true)
   })
 })
@@ -120,12 +118,12 @@ describe('getClientId', () => {
     }
   })
 
-  it('returns OUTLOOK_CLIENT_ID from env', () => {
+  it('returns OUTLOOK_CLIENT_ID from env', async () => {
     process.env.OUTLOOK_CLIENT_ID = 'test-client-id-123'
     expect(getClientId()).toBe('test-client-id-123')
   })
 
-  it('returns bundled default when OUTLOOK_CLIENT_ID is not set', () => {
+  it('returns bundled default when OUTLOOK_CLIENT_ID is not set', async () => {
     delete process.env.OUTLOOK_CLIENT_ID
     expect(getClientId()).toBe('d56f8c71-9f7c-43f4-9934-be29cb6e77b0')
   })
@@ -201,33 +199,33 @@ describe('saveTokens', () => {
     clientId: 'cid'
   }
 
-  it('creates config directory if not exists', () => {
+  it('creates config directory if not exists', async () => {
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return false
       return false // config dir doesn't exist
     })
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining('.better-email-mcp'), {
+    expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('.better-email-mcp'), {
       recursive: true,
       mode: 0o700
     })
   })
 
-  it('writes tokens with 0600 permissions', () => {
+  it('writes tokens with 0600 permissions', async () => {
     mockExistsSync.mockReturnValue(false)
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
+    expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining('tokens.json'),
       expect.stringContaining('"user@outlook.com"'),
       { mode: 0o600 }
     )
   })
 
-  it('merges with existing tokens', () => {
+  it('merges with existing tokens', async () => {
     const existing = {
       'other@hotmail.com': { accessToken: 'old', refreshToken: 'old', expiresAt: 1, clientId: 'c-valid' }
     }
@@ -236,21 +234,21 @@ describe('saveTokens', () => {
       if (String(path).endsWith('tokens.json')) return true
       return true
     })
-    mockReadFileSync.mockReturnValue(JSON.stringify(existing))
+    mockReadFile.mockResolvedValue(JSON.stringify(existing))
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['other@hotmail.com']).toBeDefined()
     expect(written['user@outlook.com']).toEqual(tokens)
   })
 
-  it('normalizes email to lowercase', () => {
+  it('normalizes email to lowercase', async () => {
     mockExistsSync.mockReturnValue(false)
 
-    saveTokens('User@OUTLOOK.com', tokens)
+    await saveTokens('User@OUTLOOK.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual(tokens)
   })
 })
@@ -412,7 +410,7 @@ describe('ensureValidToken', () => {
 
     await ensureValidToken(account)
 
-    expect(mockWriteFileSync).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalled()
   })
 
   it('loads tokens from disk when not in memory', async () => {
@@ -433,7 +431,7 @@ describe('ensureValidToken', () => {
 
   it('initiates Device Code flow when no tokens exist', async () => {
     // No tokens on disk
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     // Mock device code request
     mockFetch.mockResolvedValueOnce({
@@ -456,7 +454,7 @@ describe('ensureValidToken', () => {
   })
 
   it('opens browser when initiating Device Code flow', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -480,7 +478,7 @@ describe('ensureValidToken', () => {
   })
 
   it('does not open browser on retry (reuses pending auth)', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -508,7 +506,7 @@ describe('ensureValidToken', () => {
   })
 
   it('reuses pending auth code on retry', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     // First call: device code request
     mockFetch.mockResolvedValueOnce({
@@ -623,7 +621,7 @@ describe('deviceCodeAuth', () => {
     expect(tokens.accessToken).toBe('at-success')
     expect(tokens.refreshToken).toBe('rt-success')
     expect(tokens.clientId).toBe('test-client-id')
-    expect(mockWriteFileSync).toHaveBeenCalled() // Tokens saved
+    expect(mockWriteFile).toHaveBeenCalled() // Tokens saved
   })
 
   it('polls until authorization is granted', async () => {
@@ -808,12 +806,12 @@ describe('saveTokens edge cases', () => {
     vi.clearAllMocks()
   })
 
-  it('starts fresh store if existing token file is corrupted JSON', () => {
+  it('starts fresh store if existing token file is corrupted JSON', async () => {
     mockExistsSync.mockImplementation((path) => {
       if (String(path).endsWith('tokens.json')) return true
       return true // config dir exists
     })
-    mockReadFileSync.mockImplementation(() => {
+    mockReadFile.mockImplementation(() => {
       throw new SyntaxError('Unexpected token')
     })
 
@@ -824,15 +822,15 @@ describe('saveTokens edge cases', () => {
       clientId: 'cid'
     }
 
-    saveTokens('user@outlook.com', tokens)
+    await saveTokens('user@outlook.com', tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual(tokens)
     // Should only have the new token, not corrupted data
     expect(Object.keys(written)).toEqual(['user@outlook.com'])
   })
 
-  it('uses cached token store on subsequent saves', () => {
+  it('uses cached token store on subsequent saves', async () => {
     mockExistsSync.mockReturnValue(false)
 
     const tokens1: OAuth2Tokens = {
@@ -849,12 +847,12 @@ describe('saveTokens edge cases', () => {
     }
 
     // First save populates cache
-    saveTokens('first@outlook.com', tokens1)
+    await saveTokens('first@outlook.com', tokens1)
     // Second save should use cache, not read from disk
-    saveTokens('second@outlook.com', tokens2)
+    await saveTokens('second@outlook.com', tokens2)
 
     // readFileSync should NOT be called for second save (cache is used)
-    const written = JSON.parse(mockWriteFileSync.mock.calls[1]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[1]![1] as string)
     expect(written['first@outlook.com']).toEqual(tokens1)
     expect(written['second@outlook.com']).toEqual(tokens2)
   })
@@ -891,7 +889,7 @@ describe('loadStoredTokens validation', () => {
     expect(retry).not.toBeNull()
   })
 
-  it('isValidTokens validates structure correctly', () => {
+  it('isValidTokens validates structure correctly', async () => {
     expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c-valid' })).toBe(true)
     expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', expiresAt: '1', clientId: 'c-valid' })).toBe(false)
     expect(isValidTokens({ accessToken: 'a', refreshToken: 'r', clientId: 'c-valid' })).toBe(false)
@@ -899,7 +897,7 @@ describe('loadStoredTokens validation', () => {
     expect(isValidTokens('not-an-object')).toBe(false)
   })
 
-  it('isValidTokenStore validates store correctly', () => {
+  it('isValidTokenStore validates store correctly', async () => {
     const valid = { 'a@b.com': { accessToken: 'a', refreshToken: 'r', expiresAt: 1, clientId: 'c-valid' } }
     expect(isValidTokenStore(valid)).toBe(true)
     expect(isValidTokenStore({ ...valid, 'x@y.com': { bad: true } })).toBe(false)
@@ -976,7 +974,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('forwards malicious URLs with shell metacharacters to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     const maliciousUri = 'https://microsoft.com/devicelogin?code=ABCD;echo"vulnerable"'
     mockFetch.mockResolvedValueOnce({
@@ -1002,7 +1000,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('intercepts non-http/https protocols before delegating to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -1026,7 +1024,7 @@ describe('openBrowser delegates to mcp-core', () => {
   })
 
   it('forwards URLs with leading hyphens to mcp-core', async () => {
-    mockReadFileSync.mockReturnValue('{}')
+    mockReadFile.mockResolvedValue('{}')
 
     const hyphenUri = 'https://-example.com'
     mockFetch.mockResolvedValueOnce({
@@ -1138,7 +1136,7 @@ describe('initiateOutlookDeviceCode', () => {
 
     expect(onComplete).toHaveBeenCalled()
     // Tokens persisted to disk.
-    expect(mockWriteFileSync).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalled()
   })
 
   it('does not throw if onComplete callback fails', async () => {
@@ -1243,8 +1241,8 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    expect(mockWriteFileSync).toHaveBeenCalled()
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    expect(mockWriteFile).toHaveBeenCalled()
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['user@outlook.com']).toEqual({
       accessToken: 'at-123',
       refreshToken: 'rt-123',
@@ -1262,7 +1260,7 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['env@outlook.com']).toBeDefined()
     expect(written['env@outlook.com'].accessToken).toBe('at-env')
   })
@@ -1275,7 +1273,7 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['outlook-device-code']).toBeDefined()
   })
 
@@ -1287,7 +1285,7 @@ describe('saveOutlookTokens', () => {
 
     await saveOutlookTokens(tokens)
 
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    const written = JSON.parse(mockWriteFile.mock.calls[0]![1] as string)
     expect(written['defaults@outlook.com']).toEqual({
       accessToken: '',
       refreshToken: '',
@@ -1324,7 +1322,7 @@ describe('Outlook token embed (per-sub config blob)', () => {
     expect((blob?.outlookTokens as Record<string, OAuth2Tokens>)['a@outlook.com']).toEqual(TOK('a'))
     expect(await loadStoredTokens('a@outlook.com', 'sub-1')).toEqual(TOK('a'))
     // Embed path must NOT touch the legacy tokens.json file.
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
   })
 
   it('isolates tokens per sub (sub-2 cannot read sub-1 tokens)', async () => {
@@ -1373,7 +1371,7 @@ describe('Outlook token embed (per-sub config blob)', () => {
 
     await saveTokens('a@outlook.com', TOK('a')) // no store, no scope
 
-    expect(mockWriteFileSync).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalled()
   })
 
   it('loadOutlookEmails returns the embedded token emails for a sub', async () => {

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -6,8 +6,8 @@
  * persistent token storage, and automatic token refresh.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { tryOpenBrowser } from '@n24q02m/mcp-core'
@@ -290,7 +290,7 @@ export async function saveTokens(email: string, tokens: OAuth2Tokens, sub?: stri
     return
   }
 
-  saveTokensToFile(key, tokens)
+  await saveTokensToFile(key, tokens)
 }
 
 /**
@@ -298,15 +298,15 @@ export async function saveTokens(email: string, tokens: OAuth2Tokens, sub?: stri
  * the file side-effect runs before ``saveTokens`` yields — preserving the
  * historical fire-and-forget contract. Creates the config dir if needed; 0600.
  */
-function saveTokensToFile(emailKey: string, tokens: OAuth2Tokens): void {
+async function saveTokensToFile(emailKey: string, tokens: OAuth2Tokens): Promise<void> {
   if (!existsSync(CONFIG_DIR)) {
-    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
+    await mkdir(CONFIG_DIR, { recursive: true, mode: 0o700 })
   }
 
   let store: TokenStore = cachedTokenStore || {}
   try {
     if (!cachedTokenStore && existsSync(TOKEN_FILE)) {
-      const data = readFileSync(TOKEN_FILE, 'utf-8')
+      const data = await readFile(TOKEN_FILE, 'utf-8')
       const parsedStore = parseTokenStore(data)
       if (parsedStore) {
         store = parsedStore
@@ -321,7 +321,7 @@ function saveTokensToFile(emailKey: string, tokens: OAuth2Tokens): void {
 
   store[emailKey] = tokens
   cachedTokenStore = store
-  writeFileSync(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 })
+  await writeFile(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 })
 }
 
 /**


### PR DESCRIPTION
This PR refactors the `saveTokensToFile` function in `src/tools/helpers/oauth2.ts` to use asynchronous file operations (`mkdir`, `readFile`, `writeFile` from `node:fs/promises`). 

Converting these synchronous operations to asynchronous ones prevents blocking the event loop during token persistence, which is crucial for maintaining high performance in asynchronous applications.

Key changes:
- `saveTokensToFile` is now an `async` function.
- All synchronous filesystem calls in `saveTokensToFile` have been replaced with their `node:fs/promises` counterparts.
- `saveTokens` now correctly `await`s the `saveTokensToFile` call.
- The unit test suite `src/tools/helpers/oauth2.test.ts` has been updated to mock the new asynchronous operations and all test cases now use `async/await` for token saving operations.
- Verified that all 75 tests pass and that linting/type-checking is clean.

---
*PR created automatically by Jules for task [3081436782448300508](https://jules.google.com/task/3081436782448300508) started by @n24q02m*