### PR TITLE
[FIX] Invoke markSetupCompleteFn after saving tokens

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -26,7 +26,13 @@ import { PerSubCredStore } from '../auth/cred-store.js'
 import { type CredStoreLike, InMemoryCredStore } from '../auth/in-memory-cred-store.js'
 import { subjectContext } from '../auth/subject-context.js'
 import { renderEmailCredentialForm } from '../credential-form.js'
-import { resolveCredentialState, setMarkSetupComplete, setSetupUrl, setState } from '../credential-state.js'
+import {
+  getMarkSetupComplete,
+  resolveCredentialState,
+  setMarkSetupComplete,
+  setSetupUrl,
+  setState
+} from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain, setOutlookTokenStore } from '../tools/helpers/oauth2.js'
@@ -125,6 +131,7 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[], sub?: stri
       first.email,
       () => {
         console.error(`[${SERVER_NAME}] Outlook OAuth2 completed for ${first.email}`)
+        getMarkSetupComplete()?.('outlook')
       },
       sub
     )


### PR DESCRIPTION
This PR implements the missing signal to the credential form setup-status polling after a successful Outlook OAuth2 device-code flow completion.

Specifically:
- Imported `getMarkSetupComplete` from `../credential-state.js` in `src/transports/http.ts`.
- Updated the `onComplete` callback passed to `initiateOutlookDeviceCode` in `initiateOutlookOAuth` to call `getMarkSetupComplete()?.('outlook')`.

This ensures that the `GET /setup-status` endpoint correctly flips the "outlook" key to "complete", allowing the frontend form spinner to stop and indicate success to the user.

Verified with existing regression tests in `src/transports/http.test.ts`.

---
*PR created automatically by Jules for task [1982942369970832735](https://jules.google.com/task/1982942369970832735) started by @n24q02m*