### PR TITLE
[FIX] Clear cached tokens on form submit to force device-code flow

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -4,7 +4,7 @@ import { ImapFlow } from 'imapflow'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { getMarkSetupComplete, resolveCredentialState, setState } from '../credential-state.js'
 import { loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
+import { _resetTokenCache, initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 // Mock dependencies
@@ -35,6 +35,7 @@ vi.mock('../tools/helpers/config.js', () => ({
 }))
 
 vi.mock('../tools/helpers/oauth2.js', () => ({
+  _resetTokenCache: vi.fn(),
   initiateOutlookDeviceCode: vi.fn(),
   isOutlookDomain: vi.fn(),
   saveOutlookTokens: vi.fn(),
@@ -372,6 +373,7 @@ describe('http transport', () => {
 
       await onCredentialsSaved({ EMAIL_CREDENTIALS: 'test@outlook.com:oauth2' })
 
+      expect(_resetTokenCache).toHaveBeenCalled()
       expect(mockAccounts[0]!.oauth2).toBeUndefined()
       expect(initiateOutlookDeviceCode).toHaveBeenCalledWith('test@outlook.com', expect.any(Function), undefined)
     })

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -29,7 +29,12 @@ import { renderEmailCredentialForm } from '../credential-form.js'
 import { resolveCredentialState, setMarkSetupComplete, setSetupUrl, setState } from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
-import { initiateOutlookDeviceCode, isOutlookDomain, setOutlookTokenStore } from '../tools/helpers/oauth2.js'
+import {
+  _resetTokenCache,
+  initiateOutlookDeviceCode,
+  isOutlookDomain,
+  setOutlookTokenStore
+} from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 
 const SERVER_NAME = 'better-email-mcp'
@@ -160,6 +165,11 @@ function buildOptions(args: {
     creds: Record<string, string>,
     context: SubjectContext
   ): Promise<NextStep | null> => {
+    // Force a fresh device-code flow by clearing the global token store cache
+    // so we don't accidentally reuse tokens from a previous user/session
+    // in the same container.
+    _resetTokenCache()
+
     const raw = creds?.EMAIL_CREDENTIALS?.trim()
     if (!raw) {
       return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }


### PR DESCRIPTION
The `onCredentialsSaved` callback in `src/transports/http.ts` now explicitly calls `_resetTokenCache()` at the beginning of its execution. This ensures that any cached OAuth2 tokens from previous sessions or users within the same container are cleared, forcing a fresh device-code flow when the credential form is submitted. This addresses a UX bug where stale tokens would bypass the Microsoft authorization step, leading to a "Setup complete" state without user interaction.

Additionally, `src/transports/http.test.ts` has been updated to include `_resetTokenCache` in its mocks and a specific assertion in the regression test to verify that the cache is indeed cleared on form submission.

---
*PR created automatically by Jules for task [3474827674672081550](https://jules.google.com/task/3474827674672081550) started by @n24q02m*