### PR TITLE
[FIX] Long Function: buildOptions

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -143,6 +143,110 @@ async function initiateOutlookOAuth(outlookAccounts: AccountConfig[], sub?: stri
   }
 }
 
+/** Partition accounts into Outlook (OAuth2) and standard IMAP. */
+function partitionAccounts(accounts: AccountConfig[]): {
+  outlookAccounts: AccountConfig[]
+  imapAccounts: AccountConfig[]
+} {
+  const outlookAccounts: AccountConfig[] = []
+  const imapAccounts: AccountConfig[] = []
+  for (const account of accounts) {
+    if (isOutlookDomain(account.email) || account.authType === 'oauth2') {
+      // Force fresh device-code flow for every form submit by clearing any
+      // cached tokens that ``parseCredentials`` may have populated via
+      // ``loadStoredTokens``. Without this, ``initiateOutlookOAuth`` filters
+      // out accounts with ``.oauth2`` set and silently returns ``null`` →
+      // the form shows "Setup complete" without ever displaying the Microsoft
+      // device-code step (UX bug reported 2026-04-24).
+      account.oauth2 = undefined
+      outlookAccounts.push(account)
+    } else {
+      imapAccounts.push(account)
+    }
+  }
+  return { outlookAccounts, imapAccounts }
+}
+
+/**
+ * Persist credentials based on the presence of a subject (JWT sub).
+ * Multi-user (sub present) -> per-user store.
+ * Single-user (no sub) -> global config + env.
+ */
+async function persistCredentials(args: {
+  sub: string | null | undefined
+  accounts: AccountConfig[]
+  raw: string
+  onAccountsLoaded: (accounts: AccountConfig[]) => void
+}): Promise<NextStep | null> {
+  const { sub, accounts, raw, onAccountsLoaded } = args
+  if (sub) {
+    try {
+      await credStore.save(sub, { accounts })
+    } catch (err) {
+      console.error(`[${SERVER_NAME}] Failed to save per-user credentials for sub=${sub}: ${(err as Error).message}`)
+      return { type: 'error', text: 'Failed to save credentials. Please retry.' }
+    }
+    console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured for sub=${sub} (per-user scope)`)
+  } else {
+    try {
+      await writeConfig(SERVER_NAME, { EMAIL_CREDENTIALS: raw })
+    } catch (err) {
+      console.error(`[${SERVER_NAME}] Failed to persist credentials: ${(err as Error).message}`)
+    }
+    process.env.EMAIL_CREDENTIALS = raw
+    onAccountsLoaded(accounts)
+    console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
+  }
+  return null
+}
+
+/**
+ * Core logic for saving credentials, extracted from buildOptions.
+ */
+async function handleCredentialsSaved(args: {
+  creds: Record<string, string>
+  context: SubjectContext
+  onAccountsLoaded: (accounts: AccountConfig[]) => void
+}): Promise<NextStep | null> {
+  const { creds, context, onAccountsLoaded } = args
+  const raw = creds?.EMAIL_CREDENTIALS?.trim()
+  if (!raw) {
+    return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }
+  }
+
+  let accounts: AccountConfig[]
+  try {
+    accounts = await parseCredentials(raw)
+  } catch (err) {
+    return {
+      type: 'error',
+      text: `Failed to parse credentials: ${(err as Error)?.message ?? 'invalid format'}`
+    }
+  }
+
+  if (accounts.length === 0) {
+    return {
+      type: 'error',
+      text: 'No valid accounts parsed. Expected email:app-password (multi-account: email1:pass1,email2:pass2)'
+    }
+  }
+
+  const { outlookAccounts, imapAccounts } = partitionAccounts(accounts)
+
+  const imapResult = await validateImapAccounts(imapAccounts)
+  if (imapResult) return imapResult
+
+  const sub = context?.sub
+  const persistenceResult = await persistCredentials({ sub, accounts, raw, onAccountsLoaded })
+  if (persistenceResult) return persistenceResult
+
+  const outlookResult = await initiateOutlookOAuth(outlookAccounts, sub)
+  if (outlookResult) return outlookResult
+
+  setState('configured')
+  return null
+}
+
 /**
  * Build `RunHttpServerOptions` for the email HTTP mode. Per-user credentials
  * are keyed by the JWT `sub` from `SubjectContext`; the shared `config.enc`
@@ -156,88 +260,8 @@ function buildOptions(args: {
 }): RunHttpServerOptions {
   const { port, host, onAccountsLoaded } = args
 
-  const onCredentialsSaved = async (
-    creds: Record<string, string>,
-    context: SubjectContext
-  ): Promise<NextStep | null> => {
-    const raw = creds?.EMAIL_CREDENTIALS?.trim()
-    if (!raw) {
-      return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }
-    }
-
-    let accounts: AccountConfig[]
-    try {
-      accounts = await parseCredentials(raw)
-    } catch (err) {
-      return {
-        type: 'error',
-        text: `Failed to parse credentials: ${(err as Error)?.message ?? 'invalid format'}`
-      }
-    }
-
-    if (accounts.length === 0) {
-      return {
-        type: 'error',
-        text: 'No valid accounts parsed. Expected email:app-password (multi-account: email1:pass1,email2:pass2)'
-      }
-    }
-
-    const outlookAccounts: AccountConfig[] = []
-    const imapAccounts: AccountConfig[] = []
-    for (const account of accounts) {
-      if (isOutlookDomain(account.email) || account.authType === 'oauth2') {
-        // Force fresh device-code flow for every form submit by clearing any
-        // cached tokens that ``parseCredentials`` may have populated via
-        // ``loadStoredTokens``. Without this, ``initiateOutlookOAuth`` filters
-        // out accounts with ``.oauth2`` set and silently returns ``null`` →
-        // the form shows "Setup complete" without ever displaying the Microsoft
-        // device-code step (UX bug reported 2026-04-24).
-        account.oauth2 = undefined
-        outlookAccounts.push(account)
-      } else {
-        imapAccounts.push(account)
-      }
-    }
-
-    const imapResult = await validateImapAccounts(imapAccounts)
-    if (imapResult) return imapResult
-
-    // Persistence is mode-dependent to avoid cross-user credential bleed.
-    //
-    // Multi-user (JWT `sub` present): write ONLY to the per-user store, keyed by
-    // `sub`. We must NOT touch the shared `config.enc`, `process.env`, or the
-    // single-user `currentAccounts` closure — those are process-global and would
-    // leak one subject's mailboxes into every other subject's tool calls.
-    //
-    // Single-user (no `sub`: stdio self-host / auth-disabled gateway): exactly
-    // one caller, so persist to the shared `config.enc` + env + closure so
-    // credentials survive restarts and are visible to non-HTTP-scoped calls.
-    const sub = context?.sub
-    if (sub) {
-      try {
-        await credStore.save(sub, { accounts })
-      } catch (err) {
-        console.error(`[${SERVER_NAME}] Failed to save per-user credentials for sub=${sub}: ${(err as Error).message}`)
-        return { type: 'error', text: 'Failed to save credentials. Please retry.' }
-      }
-      console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured for sub=${sub} (per-user scope)`)
-    } else {
-      try {
-        await writeConfig(SERVER_NAME, { EMAIL_CREDENTIALS: raw })
-      } catch (err) {
-        console.error(`[${SERVER_NAME}] Failed to persist credentials: ${(err as Error).message}`)
-      }
-      process.env.EMAIL_CREDENTIALS = raw
-      onAccountsLoaded(accounts)
-      console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
-    }
-
-    const outlookResult = await initiateOutlookOAuth(outlookAccounts, sub)
-    if (outlookResult) return outlookResult
-
-    setState('configured')
-    return null
-  }
+  const onCredentialsSaved = (creds: Record<string, string>, context: SubjectContext): Promise<NextStep | null> =>
+    handleCredentialsSaved({ creds, context, onAccountsLoaded })
 
   return {
     serverName: SERVER_NAME,


### PR DESCRIPTION
This PR refactors the `buildOptions` function in `src/transports/http.ts` to address a "Long Function" code smell. 

The complex logic within `buildOptions` (specifically inside the `onCredentialsSaved` callback) has been decomposed into three focused helper functions:
- `partitionAccounts`: Responsibly separates accounts into Outlook (OAuth2) and standard IMAP buckets, ensuring necessary state resets for fresh auth flows.
- `persistCredentials`: Handles the mode-dependent persistence logic (per-user KV vs. global config) with appropriate error handling.
- `handleCredentialsSaved`: Orchestrates the overall credential verification and saving workflow.

`buildOptions` now delegates to `handleCredentialsSaved`, significantly improving readability and maintainability of the transport layer.

Existing functionality is fully preserved, as verified by 100% pass rate in the test suite (`src/transports/http.test.ts`).

---
*PR created automatically by Jules for task [1384019227628807543](https://jules.google.com/task/1384019227628807543) started by @n24q02m*