### PR TITLE
[FIX] Potential flaky test using setTimeout in http.test.ts

### DIFF
--- a/scripts/start-server.test.ts
+++ b/scripts/start-server.test.ts
@@ -43,7 +43,7 @@ describe('start-server', () => {
     // Dynamically import to execute main() again
     await import('./start-server.js')
     // Await macro task queue to ensure main finishes
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await vi.waitFor(() => expect(runAuth).toHaveBeenCalled())
 
     expect(runAuth).toHaveBeenCalled()
     expect(initServer).not.toHaveBeenCalled()
@@ -53,7 +53,7 @@ describe('start-server', () => {
     vi.mocked(initServer).mockResolvedValue(undefined as any)
 
     await import('./start-server.js')
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
 
     expect(runAuth).not.toHaveBeenCalled()
     expect(initServer).toHaveBeenCalled()
@@ -73,7 +73,7 @@ describe('start-server', () => {
     })
 
     await import('./start-server.js')
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
 
     expect(sigintHandler).toBeDefined()
 
@@ -89,7 +89,7 @@ describe('start-server', () => {
     vi.mocked(initServer).mockRejectedValue(error)
 
     await import('./start-server.js')
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
 
     expect(initServer).toHaveBeenCalled()
     expect(console.error).toHaveBeenCalledWith('Failed to start server:', error)

--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -1134,7 +1134,7 @@ describe('initiateOutlookDeviceCode', () => {
     await initiateOutlookDeviceCode('cb@outlook.com', onComplete)
 
     // Allow background poll to run and fire the callback.
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await vi.waitFor(() => expect(onComplete).toHaveBeenCalled())
 
     expect(onComplete).toHaveBeenCalled()
     // Tokens persisted to disk.
@@ -1164,7 +1164,7 @@ describe('initiateOutlookDeviceCode', () => {
     })
     await initiateOutlookDeviceCode('fail-cb@outlook.com', onComplete)
 
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await vi.waitFor(() => expect(onComplete).toHaveBeenCalled())
 
     expect(onComplete).toHaveBeenCalled()
   })

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -103,8 +103,7 @@ describe('http transport', () => {
   async function runStartHttpAndTriggerShutdown(fn?: () => Promise<void>) {
     const startPromise = startHttp()
 
-    // Wait for the server to start
-    // Wait for the server to start AND the signal handler to be registered
+    // Wait for the server to start and the signal handler to be registered
     await vi.waitFor(() => {
       expect(runHttpServer).toHaveBeenCalled()
       expect(sigintHandler).toBeTruthy()


### PR DESCRIPTION
Refactored test files to replace arbitrary `setTimeout` calls with deterministic `vi.waitFor` assertions. This ensures that tests wait only as long as necessary for background processes or async side effects to complete, increasing reliability and reducing flakiness. Impacted files include `src/tools/helpers/oauth2.test.ts` and `scripts/start-server.test.ts`. Additionally, cleaned up redundant comments in `src/transports/http.test.ts`.

---
*PR created automatically by Jules for task [16608039076513521691](https://jules.google.com/task/16608039076513521691) started by @n24q02m*