### PR TITLE
[TEST] Missing edge case test in oauth2.ts

### DIFF
--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -183,6 +183,12 @@ describe('loadStoredTokens', () => {
 
     expect(await loadStoredTokens('user@outlook.com')).toBeNull()
   })
+  it('throws if email is missing', async () => {
+    await expect(loadStoredTokens(null as any)).rejects.toThrow('Email is required')
+    await expect(loadStoredTokens(undefined as any)).rejects.toThrow('Email is required')
+    await expect(loadStoredTokens('')).rejects.toThrow('Email is required')
+    await expect(loadStoredTokens('   ')).rejects.toThrow('Email is required')
+  })
 })
 
 // ============================================================================
@@ -192,6 +198,13 @@ describe('loadStoredTokens', () => {
 describe('saveTokens', () => {
   beforeEach(() => {
     _resetTokenCache()
+  })
+  it('throws if email is missing', async () => {
+    const tok = { accessToken: 'at', refreshToken: 'rt', expiresAt: 1, clientId: 'cid' }
+    await expect(saveTokens(null as any, tok)).rejects.toThrow('Email is required')
+    await expect(saveTokens(undefined as any, tok)).rejects.toThrow('Email is required')
+    await expect(saveTokens('', tok)).rejects.toThrow('Email is required')
+    await expect(saveTokens('   ', tok)).rejects.toThrow('Email is required')
   })
 
   const tokens: OAuth2Tokens = {

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -203,6 +203,7 @@ function resolveScope(sub: string | null | undefined): string | null {
  * ``sub``; absent => the current request scope). Returns null if none stored.
  */
 export async function loadStoredTokens(email: string, sub?: string | null): Promise<OAuth2Tokens | null> {
+  if (!email?.trim()) throw new Error('Email is required')
   const scope = resolveScope(sub)
   const key = email.toLowerCase()
 
@@ -272,6 +273,7 @@ export async function loadOutlookEmails(sub: string | null): Promise<string[]> {
  * the legacy 0600 ``tokens.json`` write.
  */
 export async function saveTokens(email: string, tokens: OAuth2Tokens, sub?: string | null): Promise<void> {
+  if (!email?.trim()) throw new Error('Email is required')
   const scope = resolveScope(sub)
   const key = email.toLowerCase()
 


### PR DESCRIPTION
Added `!email?.trim()` validation to `loadStoredTokens` and `saveTokens` in `src/tools/helpers/oauth2.ts` to ensure consistent behavior when handling empty email strings. Corresponding unit tests were added to `src/tools/helpers/oauth2.test.ts` to verify that these functions throw the expected 'Email is required' error for null, undefined, empty, and whitespace-only inputs.

---
*PR created automatically by Jules for task [13933659301258313488](https://jules.google.com/task/13933659301258313488) started by @n24q02m*