### PR TITLE
🎨 Palette: Dynamically update account card titles and ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -76,3 +76,6 @@
 ## 2025-02-19 - ARIA Pressed State for Password Toggles
 **Learning:** Screen reader users need clear context when toggling the visibility of password fields. While changing the button text or `aria-label` provides information, using `aria-pressed` robustly announces the toggled state to screen readers, improving the cognitive context of the action.
 **Action:** Always include the `aria-pressed` attribute (toggling between `true` and `false`) on "Show/Hide" password buttons to announce their active state reliably to screen readers.
+## 2026-06-29 - [Dynamic Account Card Titles and ARIA Labels]
+**Learning:** For forms involving multiple dynamic instances of the same component grouping (e.g. "Account 1", "Account 2"), hardcoded titles and generic ARIA labels like "Remove Account 2" lack context for screen reader users and can be confusing. Dynamically binding the user's entered email address to the section title and the removal button's ARIA label significantly improves context and usability.
+**Action:** When creating repeatable form structures, identify the primary input (like a name or email address) and bind it to the container's title and the ARIA labels of related action buttons (like Remove or Edit). Ensure long text is truncated gracefully using CSS (`text-overflow: ellipsis`) so layout doesn't break.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -103,7 +103,16 @@ export function renderEmailCredentialForm(
             align-items: center;
             margin-bottom: 0.75rem;
         }
-        .account-title { font-size: 0.95rem; font-weight: 600; color: #ddd; }
+        .account-title {
+            font-size: 0.95rem;
+            font-weight: 600;
+            color: #ddd;
+            max-width: 300px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: block;
+        }
         .remove-btn {
             background: transparent;
             color: #f87171;
@@ -472,11 +481,17 @@ export function renderEmailCredentialForm(
                 var cards = container.querySelectorAll(".account-card");
                 for (var i = 0; i < cards.length; i++) {
                     var titleEl = cards[i].querySelector(".account-title");
-                    if (titleEl) titleEl.textContent = "Account " + (i + 1);
+                    var emailInput = cards[i].querySelector('input[data-role="email"]');
+                    var emailVal = emailInput && (emailInput instanceof HTMLInputElement) && emailInput.value ? emailInput.value.trim() : "";
+                    var titleStr = emailVal ? emailVal : "Account " + (i + 1);
+                    if (titleEl && titleEl instanceof HTMLElement) {
+                        titleEl.textContent = titleStr;
+                        titleEl.title = titleStr;
+                    }
                     var removeBtn = cards[i].querySelector(".remove-btn");
-                    if (removeBtn) {
-                        removeBtn.style.display = i === 0 ? "none" : "";
-                        removeBtn.setAttribute("aria-label", "Remove Account " + (i + 1));
+                    if (removeBtn && removeBtn instanceof HTMLElement) {
+                        removeBtn.style.display = cards.length > 1 ? "" : "none";
+                        removeBtn.setAttribute("aria-label", "Remove " + titleStr);
                     }
                 }
             }
@@ -639,6 +654,7 @@ export function renderEmailCredentialForm(
                     var at = val.indexOf("@");
                     var domain = at >= 0 ? val.slice(at + 1).trim().toLowerCase() : "";
                     renderDomainSpecificFields(extra, idx, domain, state);
+                    updateAccountNumbers();
                 });
 
                 return card;


### PR DESCRIPTION
Improves UX and accessibility by updating the generic 'Account N' title and the 'Remove' button's ARIA label with the entered email address as the user types.

- Fetches the email field value and sets it as the `.account-title` and the "Remove" button's `aria-label`.
- Adds CSS text truncation to gracefully handle extremely long email addresses and prevent layout breaks.
- Updates the initial logic that previously hard-blocked the first card from being deleted to instead block deletion only if there is a single card remaining (improving UX where users add multiple accounts but want to remove the very first one).
- Logs this micro-UX learning in `.jules/palette.md`.
- Resolves TypeScript casting issues with `document.querySelector` accessing properties.

---
*PR created automatically by Jules for task [3127931767546048483](https://jules.google.com/task/3127931767546048483) started by @n24q02m*