### PR TITLE
Fix password field reset on email typo correction

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -79,3 +79,10 @@
 ## 2026-06-29 - [Dynamic Account Card Titles and ARIA Labels]
 **Learning:** For forms involving multiple dynamic instances of the same component grouping (e.g. "Account 1", "Account 2"), hardcoded titles and generic ARIA labels like "Remove Account 2" lack context for screen reader users and can be confusing. Dynamically binding the user's entered email address to the section title and the removal button's ARIA label significantly improves context and usability.
 **Action:** When creating repeatable form structures, identify the primary input (like a name or email address) and bind it to the container's title and the ARIA labels of related action buttons (like Remove or Edit). Ensure long text is truncated gracefully using CSS (`text-overflow: ellipsis`) so layout doesn't break.
+## 2026-06-30 - Preventing unnecessary DOM rebuilds
+**Learning:** When dynamic forms are updated on every keystroke, aggressively destroying and rebuilding DOM nodes based on a substring (like an email domain) causes unnecessary churn. This resets transient user interface states—such as the visibility toggle of a password field—when the user is simply correcting a typo in the prefix.
+**Action:** Implement category-based change detection (e.g., categorizing the input into 'oauth', 'app-password', or 'custom' domains). Only rebuild the related DOM nodes when the abstract category changes, preserving transient state for minor edits within the same category.
+
+## 2026-06-30 - Review Feedback: Avoid adding unused dependencies
+**Learning:** During UI testing in CI or agent environments, avoid adding heavy dependencies like `playwright` to the project's permanent `package.json` unless explicitly requested. Adding them can bloat the project and violate boundaries.
+**Action:** Always install temporary testing dependencies without saving them to `package.json` (e.g., using `--no-save` or rolling back changes with `git checkout -- package.json bun.lock`), or use standalone scripts that don't pollute the project's dependency tree.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -497,6 +497,9 @@ export function renderEmailCredentialForm(
             }
 
             function renderDomainSpecificFields(extraContainer, idx, domain, state) {
+                // If the user's email input isn't a valid domain yet, or if it matches an exact known provider
+                // (like gmail.com), the 'domain' string here is fine. If it's a custom domain, we technically
+                // don't use 'domain' within this function anyway (it just spawns the custom password+IMAP fields).
                 clearChildren(extraContainer);
                 if (!domain) return;
 
@@ -641,6 +644,7 @@ export function renderEmailCredentialForm(
                 card.appendChild(extra);
 
                 var state = { password: "", imap: "", imapPort: "" };
+                var lastCategory = null;
 
                 emailField.input.addEventListener("input", function () {
                     var pwNode = extra.querySelector('input[data-role="password"]');
@@ -653,7 +657,24 @@ export function renderEmailCredentialForm(
                     var val = emailField.input.value;
                     var at = val.indexOf("@");
                     var domain = at >= 0 ? val.slice(at + 1).trim().toLowerCase() : "";
-                    renderDomainSpecificFields(extra, idx, domain, state);
+
+                    var category = "none";
+                    if (domain) {
+                        if (OAUTH_DOMAINS.indexOf(domain) !== -1) {
+                            category = "oauth";
+                        } else if (Object.prototype.hasOwnProperty.call(APP_PASSWORD_DOMAINS, domain)) {
+                            category = "app_pw_" + domain;
+                        } else {
+                            category = "custom";
+                        }
+                    }
+
+                    // Only rebuild the DOM if the category (oauth vs app_password vs custom) has actually changed,
+                    // preserving transient UI state like password visibility when fixing typos in the prefix.
+                    if (category !== lastCategory) {
+                        lastCategory = category;
+                        renderDomainSpecificFields(extra, idx, domain, state);
+                    }
                     updateAccountNumbers();
                 });
 


### PR DESCRIPTION
Added logic to only rebuild domain-specific fields when the domain category changes, preventing the password visibility toggle from resetting unnecessarily when typing.

---
*PR created automatically by Jules for task [8955225272712090346](https://jules.google.com/task/8955225272712090346) started by @n24q02m*