### PR TITLE
fix: correct HTTP host to email.n24q02m.com and tool count in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - better-email-mcp
 
 MCP Server cho Email (IMAP/SMTP). TypeScript, Node.js >= 24, bun, ESM.
-7 composite tools, 20 actions (messages, folders, attachments, send, config, config__open_relay, help). Multi-account, App Passwords, auto-discovery.
+5 composite tools, 21 actions (messages, folders, attachments, send, config) plus config__open_relay + help. Multi-account, App Passwords, auto-discovery.
 
 ## Commands
 
@@ -98,7 +98,7 @@ PSR v10 (workflow_dispatch) -> npm + Docker (amd64+arm64) + GHCR + MCP Registry.
 Two transports, selected in `init-server.ts:52-53`. There is no `MCP_MODE` env var; the old `remote-relay` / `local-relay` distinction was removed (see `transports/http.ts:5`).
 
 - **stdio (default)**: MCP SDK `StdioServerTransport` directly. Reads credentials from `EMAIL_CREDENTIALS` OR `EMAIL_USER` + `EMAIL_APP_PASSWORD`. Outlook accounts use an App Password in this mode.
-- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Single multi-user relay: `/authorize` form for App-Password providers (paste `email:app-password`) plus bundled Outlook device-code OAuth. Per-user credentials keyed by JWT `sub`. Outlook token file: `~/.better-email-mcp/tokens.json`. Deploy at `https://better-email-mcp.n24q02m.com`.
+- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Single multi-user relay: `/authorize` form for App-Password providers (paste `email:app-password`) plus bundled Outlook device-code OAuth. Per-user credentials keyed by JWT `sub`. Outlook token file: `~/.better-email-mcp/tokens.json`. Deploy at `https://email.n24q02m.com`.
 
 ## Known bugs (phat hien 2026-04-18 E2E)
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Run as a multi-user HTTP server with OAuth 2.1 authentication:
   "mcpServers": {
     "better-email": {
       "type": "http",
-      "url": "https://better-email-mcp.n24q02m.com/mcp"
+      "url": "https://email.n24q02m.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## What

Fix two documentation drifts in the email MCP docs.

### 1. Dead HTTP host in Remote (HTTP Mode)
`README.md` §"Remote (HTTP Mode)" and `CLAUDE.md` §Modes pointed the client `url` / deploy target at `https://better-email-mcp.n24q02m.com`, a decommissioned host. The live Cloudflare custom domain is `email.n24q02m.com` (already used correctly in the README's Cloudflare serverless section). Both references now use `https://email.n24q02m.com`.

### 2. Tool count in CLAUDE.md
`CLAUDE.md` line 4 claimed "7 composite tools, 20 actions". Verified against `src/tools/composite/`: there are **5** composite domain tools (attachments, config, folders, messages, send) exposing **21** actions (2 + 6 + 1 + 9 + 3), plus the non-composite `config__open_relay` and `help` tools. Updated to "5 composite tools, 21 actions ... plus config__open_relay + help", matching the README ("5 composite tools with 21 actions").

Docs-only change.