### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace innerHTML with safe DOM manipulation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -43,3 +43,7 @@
 **Vulnerability:** The `window.location.replace()` function in the frontend credential form (`src/credential-form.ts`) used unvalidated `redirect_url` payloads obtained from backend JSON responses. While the backend provided this URL, an attacker could potentially manipulate the URL via the original POST request or another vector to inject a `javascript:` URI, leading to a DOM-based Cross-Site Scripting (XSS) execution.
 **Learning:** Even URLs originating from a seemingly trusted backend API must be explicitly validated on the client side before being used in sensitive DOM sinks like `window.location`.
 **Prevention:** Always parse and validate the protocol of user-influenced URLs using robust parsers (e.g., `new URL()`) and ensure the protocol is restricted to safe schemes (`http:` or `https:`) before using them for redirection or navigation.
+## 2025-05-22 - XSS via innerHTML in form submission
+**Vulnerability:** The credential form directly assigned dynamic UI string containing nested HTML markup using `.innerHTML` on a submit button.
+**Learning:** Any use of `.innerHTML` even with static-appearing data sets up a brittle pattern where future additions could inadvertently expose the application to Cross-Site Scripting (XSS).
+**Prevention:** Always use safe DOM traversal manipulation utilizing `document.createElement`, `setAttribute`, and `textContent` or `document.createTextNode` instead of string interpolation and `innerHTML`.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -901,7 +901,12 @@ export function renderEmailCredentialForm(
 
                 formFieldset.disabled = true;
                 submitBtn.setAttribute("aria-busy", "true");
-                submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Connecting...';
+                submitBtn.textContent = "";
+                var spinner = document.createElement("span");
+                spinner.className = "spinner";
+                spinner.setAttribute("aria-hidden", "true");
+                submitBtn.appendChild(spinner);
+                submitBtn.appendChild(document.createTextNode(" Connecting..."));
 
                 fetch(submitUrl, {
                     method: "POST",
@@ -926,8 +931,12 @@ export function renderEmailCredentialForm(
                             }
 
                             if (data.next_step && data.next_step.type === "oauth_device_code") {
-                                submitBtn.innerHTML =
-                                    '<span class="spinner" aria-hidden="true"></span> Awaiting Microsoft...';
+                                submitBtn.textContent = "";
+                                var spinner = document.createElement("span");
+                                spinner.className = "spinner";
+                                spinner.setAttribute("aria-hidden", "true");
+                                submitBtn.appendChild(spinner);
+                                submitBtn.appendChild(document.createTextNode(" Awaiting Microsoft..."));
                                 submitBtn.removeAttribute("aria-busy");
                                 renderOAuthDeviceCode(data.next_step);
                                 return;


### PR DESCRIPTION
Replaced `submitBtn.innerHTML` usages with standard DOM manipulation (`document.createElement`, `setAttribute`, `textContent`, `appendChild`) to mitigate potential Cross-Site Scripting (XSS) risks. Update included in `src/credential-form.ts` alongside Sentinel journal documentation.

---
*PR created automatically by Jules for task [14285491453590208650](https://jules.google.com/task/14285491453590208650) started by @n24q02m*