### PR TITLE
feat: deploy CF Worker+Container on release from cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -294,3 +294,49 @@ jobs:
             -f event_type=plugin-sync \
             -f 'client_payload[repo]=better-email-mcp' \
             -f 'client_payload[tag]=${{ needs.release.outputs.tag }}'
+
+  # ============================================================================
+  # Deploy Cloudflare Worker+Container (build http image on runner + push + deploy)
+  # ============================================================================
+  deploy-cf:
+    name: Deploy Cloudflare Worker+Container
+    # Builds the http-slim image on a GitHub Linux runner and deploys it to
+    # Cloudflare so any release == CF live on that version — a beta dispatch redeploys
+    # the beta, a stable dispatch is maintainer-gated (replaces the
+    # manual local deploy_cf.py step + its Windows Docker OOM). Only needs the
+    # `release` job (deploy_cf.py builds its OWN image, so merge-docker is not a
+    # dependency). Dispatch-only workflow (no fork PRs) => secrets are safe.
+    # NOTE: in CI the template renders the image at the NEW tag, so deploy_cf.py's
+    # auto-rollback (prev_ref != new) is inert here; a failed canary still fails
+    # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
+    # rollback is a tracked follow-up.
+    needs: [release]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout the released tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+      - name: Setup Bun (bunx wrangler)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install worker deps (wrangler bundles worker.ts, needs @cloudflare/containers)
+        run: bun install --frozen-lockfile
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - name: Deploy to Cloudflare (build http-slim + push + deploy + canary)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_DEPLOY_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_KV_ID: ${{ secrets.CF_KV_ID }}
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+          IMAGE_TAG: ${{ needs.release.outputs.version }}
+        run: python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}"

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -64,6 +65,28 @@ for _stream in (sys.stdout, sys.stderr):
         _stream.reconfigure(encoding="utf-8", errors="replace")
 
 DEPLOY_CONFIG = "wrangler.deploy.jsonc"
+TEMPLATE_CONFIG = "wrangler.deploy.template.jsonc"
+
+
+def render_template(path: str) -> str:
+    """Substitute ``${VAR}`` tokens in the committed deploy template from the
+    environment.
+
+    CI runs ``deploy_cf.py --from-template`` to reconstruct the gitignored
+    ``wrangler.deploy.jsonc`` from the committed placeholder template plus the
+    real IDs, which arrive as env vars (GitHub Actions secrets synced from
+    skret). Fails loudly if a referenced var is missing so a half-substituted
+    config never reaches ``wrangler deploy``.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+
+    def _sub(m: re.Match[str]) -> str:
+        val = os.environ.get(m.group(1))
+        if val is None:
+            raise SystemExit(f"template var ${{{m.group(1)}}} not set in environment")
+        return val
+
+    return re.sub(r"\$\{([A-Z0-9_]+)\}", _sub, text)
 
 
 def _strip_jsonc(text: str) -> str:
@@ -315,6 +338,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("--dry-run", action="store_true", help="print the plan, run nothing")
     p.add_argument(
+        "--from-template",
+        action="store_true",
+        help="reconstruct wrangler.deploy.jsonc from the committed template + env (CI)",
+    )
+    p.add_argument(
         "--no-canary",
         action="store_true",
         help="skip the post-deploy canary gate (and its auto-rollback)",
@@ -322,6 +350,11 @@ def main(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
 
     repo = Path(__file__).resolve().parent.parent
+    if args.from_template:
+        (repo / DEPLOY_CONFIG).write_text(
+            render_template(str(repo / TEMPLATE_CONFIG)), encoding="utf-8"
+        )
+        print(f"Rendered {DEPLOY_CONFIG} from {TEMPLATE_CONFIG} (CI mode).")
     cfg = _load_deploy_config(repo)
     worker = cfg["name"]
     base, _account, name = _image_parts(cfg)
@@ -334,7 +367,17 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_build:
         print("[1/4] docker build --target http")
         _run(
-            ["docker", "build", "--target", "http", "-t", local, "."],
+            [
+                "docker",
+                "build",
+                "--target",
+                "http",
+                "--build-arg",
+                "SLIM=1",
+                "-t",
+                local,
+                ".",
+            ],
             dry=args.dry_run,
             cwd=repo,
         )

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -1,0 +1,36 @@
+// wrangler.deploy.template.jsonc - COMMITTED placeholder template for CI CF deploy.
+// scripts/deploy_cf.py --from-template renders this into the gitignored
+// wrangler.deploy.jsonc by substituting the placeholder tokens below from the
+// environment (CI provides them from GitHub Actions secrets synced from skret).
+// Real account/KV IDs never live in git; they are placeholders here.
+// NO routes block (email.n24q02m.com already attached; the deploy token can't
+// reconcile routes). workers_dev:false keeps the worker off *.workers.dev.
+{
+  "name": "better-email-mcp-worker",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-14",
+  "workers_dev": false,
+  "containers": [
+    {
+      "name": "better-email-mcp-worker",
+      "class_name": "EmailContainer",
+      "image": "registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/better-email-mcp:${IMAGE_TAG}",
+      "instance_type": "basic",
+      "max_instances": 1
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "EMAIL", "class_name": "EmailContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["EmailContainer"] }],
+  "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
+  "vars": {
+    "PUBLIC_URL": "${PUBLIC_URL}",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal",
+    "MCP_TRANSPORT": "http",
+    "PORT": "8080",
+    "HOST": "0.0.0.0"
+  },
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
Mirrors the wet-mcp `deploy-cf-in-cd` pilot (TS variant, no Python test runner). Part of the 6-CF-server rollout.

## What this adds
- `deploy-cf` job in `cd.yml` — dispatch-only, `needs: [release]`, `if: needs.release.outputs.released == 'true'`. Builds the `http` image on a GitHub Linux runner, `bun install`, then `python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}"` (build + push to CF registry + deploy + credential-free canary + auto-rollback).
- `scripts/deploy_cf.py` upgraded to the wet-mcp version (adds `render_template()` + `--from-template`). Fetched verbatim from `n24q02m/wet-mcp@main`; fully generic (reads worker name / image ref / PUBLIC_URL from the deploy config, no wet-specific hardcode).
- `wrangler.deploy.template.jsonc` — committed placeholder template that `--from-template` renders into the gitignored `wrangler.deploy.jsonc` from CI env.

## Bindings (email = KV-only)
- `kv_namespaces`: `KV` -> `${CF_KV_ID}` — no D1, no Vectorize.
- container image: `registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/better-email-mcp:${IMAGE_TAG}`
- `PUBLIC_URL`: `${PUBLIC_URL}` (canary target `https://email.n24q02m.com`)
- deploy step env: `CF_DEPLOY_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CF_KV_ID`, `PUBLIC_URL`, `IMAGE_TAG` — `CF_D1_ID`/`CF_VECTORIZE_ID` intentionally dropped.

## Deviations from the wet-mcp source (deliberate, email-specific)
1. **No D1 / Vectorize** — email is KV-only; dropped those bindings + the two matching env lines.
2. **Template drops the `routes` block + adds `workers_dev: false`** — mirrors wet-mcp's PROVEN template. The scoped `CF_DEPLOY_TOKEN` cannot reconcile `custom_domain` routes; `email.n24q02m.com` is already attached to the live worker, so a config-only deploy keeps it. The base `wrangler.jsonc` (unchanged) still carries `routes` for the maintainer's full-access local `cf:deploy`.
3. **LF line endings** — repo `.gitattributes` enforces `* text=auto eol=lf` (`*.yml eol=lf`); appended the job as LF, not CRLF.
4. **`--build-arg SLIM=1` is a no-op here** — email's `Dockerfile` has no `ARG SLIM` and the `http` target is already an alpine-slim node image, so the flag is an unconsumed-arg warning only (harmless; kept for parity with the shared script).

## Verification
- `python scripts/deploy_cf.py` compiles (`py_compile`); `render_template` + `_strip_jsonc` + `json.loads` + `_image_parts` + `_public_url` round-trip on the template with dummy env (no leftover `${...}`, image regex matches, PUBLIC_URL resolves).
- `bun x biome check wrangler.deploy.template.jsonc` clean.
- `yaml.safe_load(cd.yml)` valid; `deploy-cf` well-formed, D1/Vectorize env absent.
- Full `pre-commit run --files` on all 3 files: all applicable hooks pass (gitleaks, check-yaml, trailing-whitespace, eof-fixer, preserve-diacritics; TS-only + json hooks skip).

## Not done (out of scope for this PR)
- GitHub Actions secrets NOT provisioned (`CF_DEPLOY_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CF_KV_ID`, `PUBLIC_URL`).
- Not merged, no workflow dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ3HhM3Uaxb3CUmk7HCL8g
