### PR TITLE
fix: bump mcp-core to 1.18.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": ">=1.18.0-beta.19,<2",
+        "@n24q02m/mcp-core": ">=1.18.1,<2",
         "html-to-text": "^10.0.0",
         "imapflow": "^1.4.3",
         "mailparser": "^3.9.12",
@@ -200,7 +200,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.22", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-NOEYOXiW95lBVZEu/BUfa2WFrorfjy88dLQYXWmSxMl/ek6hE16tVKYZNJLDx60lG9bDU8p5PJH8sSn/3EWhrw=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-QXHUO8w5DxDuvuVgcoAaSeusAz4csWYUTZ+VSa0JzgMkYdjwrER+UMwMMagq0gB2nkdCpviT92Mwbjb3jjhUnQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": ">=1.18.0-beta.19,<2",
+    "@n24q02m/mcp-core": ">=1.18.1,<2",
     "html-to-text": "^10.0.0",
     "imapflow": "^1.4.3",
     "mailparser": "^3.9.12",

--- a/src/mcp-core-pin.test.ts
+++ b/src/mcp-core-pin.test.ts
@@ -4,11 +4,12 @@ import { describe, expect, test } from 'vitest'
 describe('mcp-core dependency pin', () => {
   const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'))
 
-  test('depends on a 1.18.0-beta+ release that ships the storage backends + EdDSA', () => {
+  test('depends on a >=1.18.1 stable release that ships the storage backends + EdDSA', () => {
     const dep: string = pkg.dependencies['@n24q02m/mcp-core']
     // Storage backends (CfKvBackend/backendFromEnv) + EdDSA-from-CREDENTIAL_SECRET
-    // ship in the 1.18.0-beta line; the old exact 1.17.4 pin lacks them.
-    expect(dep).toContain('1.18.0-beta')
+    // shipped in the 1.18.0-beta line and are stable as of 1.18.1; the old exact
+    // 1.17.4 pin lacks them, and beta pins should not reach the stable build.
+    expect(dep).toContain('1.18.1')
     expect(dep).not.toBe('1.17.4')
   })
 


### PR DESCRIPTION
Closes #966. Bumps @n24q02m/mcp-core from a beta pin to the 1.18.1 stable so the stable build + CF image use stable mcp-core.

Changes:
- `package.json`: pin `>=1.18.0-beta.19,<2` -> `>=1.18.1,<2` (stable floor, keeps the repo's existing range convention for this dep).
- `bun.lock`: regenerated with `bun install`; now resolves `@n24q02m/mcp-core@1.18.1` (no -beta).
- `src/mcp-core-pin.test.ts`: guard test updated to assert the `1.18.1` stable floor instead of the `1.18.0-beta` literal (same intent: mcp-core must ship the storage backends + EdDSA and no beta reaches the stable build).

Verification (local, worktree):
- `bun run type-check`: pass
- `bun run test`: 690 passed, 1 skipped
- pre-commit (gitleaks/biome/tsc/test/common hooks): pass