### PR TITLE
fix: use placeholders for PUBLIC_URL and routes in wrangler.jsonc (BYO-generic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ mcp-name: io.github.n24q02m/better-email-mcp
 - [Configuration](#configuration)
 - [Security](#security)
 - [Build from Source](#build-from-source)
+- [Deploy to Cloudflare](#deploy-to-cloudflare)
 - [Trust Model](#trust-model)
 - [License](#license)
 
@@ -280,6 +281,50 @@ cd better-email-mcp
 bun install
 bun run dev
 ```
+
+## Deploy to Cloudflare
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/n24q02m/better-email-mcp)
+
+Run your own multi-user better-email instance serverless on Cloudflare (Containers + KV).
+Each JWT `sub` gets its own Container Durable Object, and every user's email credentials and
+Outlook OAuth tokens are AES-256-GCM encrypted into a single Workers KV blob per user, so they
+survive scale-to-zero / container recreate with no re-auth.
+
+**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+
+1. `git clone https://github.com/n24q02m/better-email-mcp && cd better-email-mcp`
+2. `wrangler login`
+3. Create the KV namespace (better-email is KV-only -- no D1 / Vectorize):
+   ```
+   wrangler kv namespace create better-email-kv
+   ```
+   Paste the returned id into `<better-email-kv-namespace-id>` in `wrangler.jsonc`.
+4. Push the container image to your Cloudflare managed registry (CF Containers cannot pull
+   from external registries directly), then set `<YOUR_ACCOUNT_ID>` in `wrangler.jsonc`:
+   ```
+   docker pull ghcr.io/n24q02m/better-email-mcp:beta
+   docker tag ghcr.io/n24q02m/better-email-mcp:beta better-email-mcp:beta
+   wrangler containers push better-email-mcp:beta   # prints registry.cloudflare.com/<ACCOUNT_ID>/better-email-mcp:beta
+   ```
+5. Point `wrangler.jsonc` at your own domain: set `<YOUR_PUBLIC_URL>` (e.g.
+   `https://email.example.com`) and `<YOUR_WORKER_DOMAIN>` (e.g. `email.example.com`).
+6. Set the deploy secrets:
+   ```
+   wrangler secret put CREDENTIAL_SECRET      # per-sub vault key + deterministic EdDSA signing (required)
+   wrangler secret put MCP_RELAY_PASSWORD     # gate for the /authorize setup form
+   wrangler secret put MCP_DCR_SERVER_SECRET  # proof of an intentional multi-user deploy
+   ```
+   Optional Outlook overrides -- only to replace the bundled public Azure device-code client
+   (default needs no user-side Azure app): `wrangler secret put OUTLOOK_CLIENT_ID` and
+   `wrangler secret put OUTLOOK_EMAIL`.
+7. `wrangler deploy`, then open `<YOUR_PUBLIC_URL>/authorize` and complete the browser relay form.
+
+End-users supply their own email credentials -- an App Password via the paste form, or the
+bundled Outlook device-code sign-in -- through that relay form; there is no server-side
+`EMAIL_CREDENTIALS`. Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (already set in
+`wrangler.jsonc`); see [Cloudflare serverless mode (KV-only)](#cloudflare-serverless-mode-kv-only)
+for the encryption and trust details.
 
 ## Trust Model
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Each JWT `sub` gets its own Container Durable Object, and every user's email cre
 Outlook OAuth tokens are AES-256-GCM encrypted into a single Workers KV blob per user, so they
 survive scale-to-zero / container recreate with no re-auth.
 
-**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+**Prerequisites:** a Cloudflare account on the **Workers Paid plan** — required for Containers (the Cloudflare free tier does not include Containers) — and the `wrangler` CLI.
 
 1. `git clone https://github.com/n24q02m/better-email-mcp && cd better-email-mcp`
 2. `wrangler login`

--- a/scripts/cf-deploy.js
+++ b/scripts/cf-deploy.js
@@ -4,11 +4,16 @@
 // committed (see the file header). This script fills them at deploy time into a
 // temp config (wrangler.deploy.jsonc, gitignored) and runs `wrangler deploy`:
 //   <YOUR_ACCOUNT_ID>              -> $CLOUDFLARE_ACCOUNT_ID (container image ref)
+//   <YOUR_PUBLIC_URL>              -> $PUBLIC_URL (vars.PUBLIC_URL for relay/OAuth URLs)
 //   <better-email-kv-namespace-id> -> $CLOUDFLARE_KV_NAMESPACE_ID (KV binding)
+// The base wrangler.jsonc `routes` block (a `<YOUR_WORKER_DOMAIN>` custom domain) is
+// dropped here, matching wrangler.deploy.template.jsonc: a scoped deploy token can't
+// reconcile routes, and the custom domain is attached out-of-band.
 //
 // Required env:
 //   CLOUDFLARE_ACCOUNT_ID       - target account id (also substituted into image ref).
 //   CLOUDFLARE_API_TOKEN        - full-access (or Workers+Containers) token for auth.
+//   PUBLIC_URL                  - public URL substituted into vars.PUBLIC_URL (relay / OAuth).
 //   CLOUDFLARE_KV_NAMESPACE_ID  - live KV namespace id for the KV binding.
 //                                 Look it up once with `wrangler kv namespace list`
 //                                 (or reuse the existing binding on the live worker).
@@ -18,7 +23,7 @@
 // and the container application config (instance_type / max_instances).
 //
 // Usage:
-//   CLOUDFLARE_ACCOUNT_ID=<id> CLOUDFLARE_KV_NAMESPACE_ID=<kv> \
+//   CLOUDFLARE_ACCOUNT_ID=<id> CLOUDFLARE_KV_NAMESPACE_ID=<kv> PUBLIC_URL=<url> \
 //     CLOUDFLARE_API_TOKEN=<token> bun run cf:deploy
 //   bun run cf:deploy -- --dry-run        # validate without deploying
 
@@ -39,10 +44,16 @@ if (!process.env.CLOUDFLARE_API_TOKEN) {
   console.error('cf:deploy: CLOUDFLARE_API_TOKEN is required for wrangler auth.')
   process.exit(1)
 }
+const publicUrl = process.env.PUBLIC_URL
+if (!publicUrl) {
+  console.error('cf:deploy: PUBLIC_URL is required (substituted into vars.PUBLIC_URL for relay/OAuth URLs).')
+  process.exit(1)
+}
 
 // Placeholder -> live value. KV id is optional only for --dry-run (upload-only).
 const substitutions = [
   { placeholder: '<YOUR_ACCOUNT_ID>', value: accountId, required: true },
+  { placeholder: '<YOUR_PUBLIC_URL>', value: publicUrl, required: true },
   { placeholder: '<better-email-kv-namespace-id>', value: process.env.CLOUDFLARE_KV_NAMESPACE_ID, required: false }
 ]
 
@@ -63,6 +74,13 @@ for (const { placeholder, value, required } of substitutions) {
   resolved = resolved.split(placeholder).join(value)
   console.log(`cf:deploy: substituted ${placeholder}`)
 }
+
+// Drop the routes block: the base wrangler.jsonc keeps a `<YOUR_WORKER_DOMAIN>`
+// custom-domain route for reference, but the deploy step must NOT ship it (matching
+// wrangler.deploy.template.jsonc) -- a scoped deploy token can't reconcile routes and
+// the custom domain is attached out-of-band. Strip the whole line so the placeholder
+// never reaches `wrangler deploy`.
+resolved = resolved.replace(/^[ \t]*"routes":\s*\[[^\n]*\],?\r?\n/m, '')
 
 // Write the temp config INSIDE projectRoot: wrangler resolves `main` and other
 // paths relative to the config file's directory, so it must sit next to src/.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,7 +34,7 @@
   //   OUTLOOK_CLIENT_ID     - optional: override the bundled Azure AD public client.
   //   OUTLOOK_EMAIL         - optional: fallback email key for device-code tokens.
   "vars": {
-    "PUBLIC_URL": "https://email.n24q02m.com",
+    "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "MCP_TRANSPORT": "http",
@@ -46,6 +46,6 @@
     // HOST MUST be 0.0.0.0 or the container is unreachable (worker returns 500).
     "HOST": "0.0.0.0"
   },
-  "routes": [{ "pattern": "email.n24q02m.com", "custom_domain": true }],
+  "routes": [{ "pattern": "<YOUR_WORKER_DOMAIN>", "custom_domain": true }],
   "observability": { "enabled": true }
 }


### PR DESCRIPTION
Base wrangler.jsonc now fully BYO: PUBLIC_URL + routes use placeholders. deploy path uses a gitignored/substituted config; maintainer CD unaffected.