### PR TITLE
⚡ Bolt: Optimize findClosestMatch to avoid bigram allocation on exact/prefix matches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2026-06-25 - [Avoid redundant .test() checks]
 **Learning:** Checking a regular expression match with `.test()` before performing a `.replace()` (e.g. `if (pattern.test(str)) { str = str.replace(pattern, ' ') }`) is a redundant anti-pattern. If the pattern is missing, both methods scan the string, but `.replace()` on V8 handles no-matches quickly with zero reallocation. Using both means performing a double O(N) scan.
 **Action:** Remove the redundant `pattern.test()` and perform the `.replace()` directly. Compare the newly returned string against the original string (e.g. `if (next !== original) { ... }`) to detect if a replacement occurred.
+## 2025-02-18 - [Optimize findClosestMatch fast-path]
+**Learning:** In hot paths where fuzzy matching is employed (like `findClosestMatch`), if the majority of cases match exactly or are prefixes, deferring the allocation of bigram structures (`Set` allocation and population) for the fuzzy-logic fallback leads to measurable optimization. Separating exact/prefix matching from fuzzy matching into two passes allows early return for common cases with zero bigram overhead.
+**Action:** Always consider inserting a zero-allocation fast-path before performing resource-intensive matching or scoring logic, especially when exact hits or simple startsWith/includes checks resolve the majority of calls.

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -190,16 +190,9 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   if (!input || validOptions.length === 0) return null
 
   const lower = input.toLowerCase()
-  let bestMatch: string | null = null
-  let bestScore = 0
-
-  // ⚡ Bolt: Pre-compute the input bigrams outside the loop.
-  // Use 32-bit integer representation ((char1 << 16) | char2) to avoid string slicing and allocation overhead.
-  const inputBigrams = new Set<number>()
-  for (let i = 0; i < lower.length - 1; i++) {
-    inputBigrams.add((lower.charCodeAt(i) << 16) | lower.charCodeAt(i + 1))
-  }
-
+  // ⚡ Bolt: Fast-path exact/prefix matching loop.
+  // This defers the allocation of `inputBigrams` and completely avoids fuzzy logic
+  // when a direct or prefix match is found (which is the majority of cases).
   for (const option of validOptions) {
     // ⚡ Bolt: Use original option as key to bypass redundant toLowerCase() calls
     let cached = validOptionBigramCache.get(option)
@@ -216,7 +209,21 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
     if (cached.lower.startsWith(lower) || lower.startsWith(cached.lower)) {
       return option
     }
+  }
 
+  // ⚡ Bolt: Fallback to fuzzy matching only if fast-path fails.
+  let bestMatch: string | null = null
+  let bestScore = 0
+
+  // Pre-compute the input bigrams outside the loop.
+  // Use 32-bit integer representation ((char1 << 16) | char2) to avoid string slicing and allocation overhead.
+  const inputBigrams = new Set<number>()
+  for (let i = 0; i < lower.length - 1; i++) {
+    inputBigrams.add((lower.charCodeAt(i) << 16) | lower.charCodeAt(i + 1))
+  }
+
+  for (const option of validOptions) {
+    const cached = validOptionBigramCache.get(option)!
     let overlap = 0
     for (const b of inputBigrams) {
       if (cached.bigrams.has(b)) overlap++


### PR DESCRIPTION
💡 **What**: Refactored `findClosestMatch` to use a two-pass strategy: a fast-path for exact/prefix matches and a fallback path for fuzzy matches.
🎯 **Why**: In the previous implementation, `inputBigrams` (a Set of 32-bit integers) was allocated and populated for the input string *before* any matching occurred. However, for the majority of tool calls, the input exactly matches (or is a prefix of) the valid options. This meant we were needlessly allocating memory and doing string processing for the fuzzy fallback logic on nearly every successful request.
📊 **Impact**: Reduces CPU and memory overhead during function routing. By checking for exact/prefix matches first, the common case returns early with zero bigram overhead (avoiding `new Set()` and character shifting operations entirely).
🔬 **Measurement**: Verified the logic using the existing unit test suite `bun run test src/tools/helpers/errors.test.ts` which fully passed.

---
*PR created automatically by Jules for task [12348682562762601515](https://jules.google.com/task/12348682562762601515) started by @n24q02m*