### PR TITLE
🎨 Palette: Add group roles to Account Cards for improved accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -86,3 +86,6 @@
 ## 2026-06-30 - Review Feedback: Avoid adding unused dependencies
 **Learning:** During UI testing in CI or agent environments, avoid adding heavy dependencies like `playwright` to the project's permanent `package.json` unless explicitly requested. Adding them can bloat the project and violate boundaries.
 **Action:** Always install temporary testing dependencies without saving them to `package.json` (e.g., using `--no-save` or rolling back changes with `git checkout -- package.json bun.lock`), or use standalone scripts that don't pollute the project's dependency tree.
+## 2025-07-03 - [Account Cards Group Accessibility]
+**Learning:** Screen reader users lose context when navigating deeply nested repeatable sections if those sections aren't logically grouped with accessible names. Form fields like 'Email' inside 'Account 2' might just be announced as 'Email' unless the container is properly structured as a group.
+**Action:** When creating repeatable form sections (like account cards), use `role="group"` on the container and `aria-labelledby` pointing to the section's dynamic title ID. This ensures the section title is announced along with its child form controls.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -577,13 +577,16 @@ export function renderEmailCredentialForm(
                 var card = document.createElement("div");
                 card.className = "account-card";
                 card.dataset.idx = String(idx);
+                card.setAttribute("role", "group");
 
                 var header = document.createElement("div");
                 header.className = "account-card-header";
                 var title = document.createElement("h3");
                 title.className = "account-title";
+                title.id = "account-title-" + idx;
                 title.textContent = "Account " + (idx + 1);
                 header.appendChild(title);
+                card.setAttribute("aria-labelledby", title.id);
 
                 var removeBtn = document.createElement("button");
                 removeBtn.type = "button";


### PR DESCRIPTION
💡 **What:** Added `role="group"` and `aria-labelledby` attributes to the dynamically generated account cards in the email setup form (`src/credential-form.ts`).
🎯 **Why:** To improve accessibility. When screen reader users navigate deeply nested, repeatable sections (like multi-account email forms), fields such as "Email" can lack context. By grouping the section and labeling it with its dynamic title ("Account 1", "test@example.com"), the screen reader will announce the group context along with the individual form fields, significantly enhancing spatial awareness and usability.
♿ **Accessibility:** Users using assistive technologies will now hear the full context when entering an account section, meeting WCAG grouping requirements.

---
*PR created automatically by Jules for task [14885795927744219496](https://jules.google.com/task/14885795927744219496) started by @n24q02m*