### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in client-side redirect

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,8 @@
  **Vulnerability:** Untested public function clearSentFolderCache.
  **Learning:** Testing internal caches requires explicit invalidation and verification that the system correctly falls back to re-fetching data. Mocking complex structures like email addresses and attachments requires precision to cover all logical branches (fallbacks for missing fields).
  **Prevention:** Use coverage tools (vitest --coverage) early to identify gaps in helper functions and edge case handlers.
+
+## 2024-05-30 - [DOM-based XSS Prevention in Client-Side Redirects]
+**Vulnerability:** The application was vulnerable to DOM-based XSS when assigning an untrusted, unvalidated `redirect_url` to `pendingRedirectUrl`, which was subsequently used in `window.location.replace()`.
+**Learning:** Even URLs provided by a supposedly trusted backend API response can be maliciously crafted or influenced, posing a risk when used in client-side navigation sinks. They must always be treated as untrusted and validated.
+**Prevention:** Explicitly parse the URL using `new URL(url, window.location.href)` and strictly validate that the `protocol` is safe (e.g., `http:` or `https:`) before utilizing it in `window.location.replace` or `window.location.assign`.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -904,7 +904,14 @@ export function renderEmailCredentialForm(
                             // (device code poll, future OTP) can navigate to it when
                             // they complete instead of orphaning the client callback.
                             if (typeof data.redirect_url === "string" && data.redirect_url.length > 0) {
-                                pendingRedirectUrl = data.redirect_url;
+                                try {
+                                    const parsedUrl = new URL(data.redirect_url, window.location.href);
+                                    if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+                                        pendingRedirectUrl = parsedUrl.href;
+                                    }
+                                } catch (e) {
+                                    // Ignore invalid URLs
+                                }
                             }
 
                             if (data.next_step && data.next_step.type === "oauth_device_code") {


### PR DESCRIPTION
**🛡️ Sentinel: [HIGH] Fix DOM-based XSS in client-side redirect**

🚨 **Severity:** HIGH
💡 **Vulnerability:** The client-side form (`src/credential-form.ts`) directly assigned a backend-provided `redirect_url` to a client-side variable (`pendingRedirectUrl`) and then used it in `window.location.replace()`. Without validation, this is a DOM-based XSS vulnerability, as an attacker controlling the backend response or manipulating the flow could inject a `javascript:` URL (e.g., `javascript:alert(1)`), which would execute in the context of the user's browser when the redirect happens.
🎯 **Impact:** Exploitation could lead to Cross-Site Scripting (XSS), allowing attackers to steal session tokens, manipulate the UI, or perform actions on behalf of the user within the context of the credential form page.
🔧 **Fix:** Added a `try/catch` block that parses the `data.redirect_url` using `new URL(...)` and enforces that its protocol is strictly `http:` or `https:` before updating `pendingRedirectUrl`.
✅ **Verification:** Verified by running `bun run check` and `bun run test` to ensure no functionality is broken and all tests pass.

*Sentinel Journal updated.*

---
*PR created automatically by Jules for task [2375853775970769974](https://jules.google.com/task/2375853775970769974) started by @n24q02m*