### PR TITLE
🎨 Palette: Add role="group" to account cards for screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -86,3 +86,7 @@
 ## 2026-06-30 - Review Feedback: Avoid adding unused dependencies
 **Learning:** During UI testing in CI or agent environments, avoid adding heavy dependencies like `playwright` to the project's permanent `package.json` unless explicitly requested. Adding them can bloat the project and violate boundaries.
 **Action:** Always install temporary testing dependencies without saving them to `package.json` (e.g., using `--no-save` or rolling back changes with `git checkout -- package.json bun.lock`), or use standalone scripts that don't pollute the project's dependency tree.
+
+## 2025-06-30 - Form Groups for Screen Readers
+**Learning:** Repeatable form structures (like "Account 1", "Account 2") need structural semantics for screen readers. If identical fields exist across instances (like multiple "Email Address" inputs), screen readers might present them as a flattened list, causing confusion.
+**Action:** Use `role="group"` on the container element for each repeatable form section and apply `aria-labelledby` pointing to the section's dynamic title ID. This groups the internal fields structurally and associates them with the dynamic title context for screen reader users.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -577,10 +577,13 @@ export function renderEmailCredentialForm(
                 var card = document.createElement("div");
                 card.className = "account-card";
                 card.dataset.idx = String(idx);
+                card.setAttribute("role", "group");
+                card.setAttribute("aria-labelledby", "account-title-" + idx);
 
                 var header = document.createElement("div");
                 header.className = "account-card-header";
                 var title = document.createElement("h3");
+                title.id = "account-title-" + idx;
                 title.className = "account-title";
                 title.textContent = "Account " + (idx + 1);
                 header.appendChild(title);


### PR DESCRIPTION
This PR improves accessibility by adding `role="group"` and `aria-labelledby` to the dynamic account cards in `src/credential-form.ts`. This structural semantic grouping provides essential context to screen reader users, preventing confusion when encountering multiple fields with identical names across repeatable instances. The PR also includes a related learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [9074769387368613515](https://jules.google.com/task/9074769387368613515) started by @n24q02m*