### PR TITLE
🎨 Palette: Form lockdown visual feedback and external link indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -93,3 +93,10 @@
 ## 2026-07-02 - Form Focus Management
 **Learning:** In complex interactive forms where asynchronous validation/submission toggles `disabled` states, focus can inadvertently drop to the `body` element. This completely disrupts keyboard and screen reader navigation. Furthermore, when injecting new interactive content dynamically (like an OAuth device code and copy button), keyboard users lose context if focus isn't moved into the newly generated UI.
 **Action:** When re-enabling a disabled form fieldset after an error, programmatically move focus back to the triggering element (e.g., `submitBtn.focus()`). When rendering new interactive flows that pause a multi-step process (like OAuth device code auth), dynamically transfer focus to the primary new interactive element (`copyBtn` or `link`) so users seamlessly enter the new flow without losing their place.
+## 2026-07-03 - Form Lockdown and Disabled CSS State
+**Learning:** When using `<fieldset disabled>` to programmatically lock down an entire form during an asynchronous operation (like submission), the default browser styling for `:disabled` descendant elements (inputs, secondary buttons like add/remove/toggle) is often subtle or missing in custom-themed designs. This leaves users frustrated because the UI appears active but is unresponsive.
+**Action:** Always provide explicit, custom `:disabled` CSS styles (e.g., `opacity: 0.6`, `cursor: not-allowed`, subdued backgrounds/borders) for all interactive form elements when implementing fieldset-based form lockdowns. This ensures the visual state accurately reflects the interaction state.
+
+## 2026-07-03 - External Link Indicators
+**Learning:** External links that open in a new tab without visual warning can disorient users. For screen reader users, opening a new tab without announcement creates a jarring context switch.
+**Action:** Always append a visual indicator (like `↗`) to text for external links and include an explicit `aria-label` (e.g., `"opens in a new tab"`) to pre-warn both sighted and assistive-technology users before they trigger a context switch.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -122,8 +122,9 @@ export function renderEmailCredentialForm(
             cursor: pointer;
             font-size: 0.75rem;
         }
-        .remove-btn:hover { background-color: rgba(248, 113, 113, 0.08); }
+        .remove-btn:hover:not(:disabled) { background-color: rgba(248, 113, 113, 0.08); }
         .remove-btn:focus-visible { outline: 2px solid #f87171; outline-offset: 2px; }
+        .remove-btn:disabled { opacity: 0.5; cursor: not-allowed; border-color: rgba(248, 113, 113, 0.1); }
         .copy-btn {
             background: transparent;
             color: #6c9bd2;
@@ -174,6 +175,12 @@ export function renderEmailCredentialForm(
             border-color: #4a6fa5;
             box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
         }
+        .field-input:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            background-color: rgba(13, 13, 13, 0.5);
+            border-color: #1a1a1a;
+        }
         .field-input[aria-invalid="true"] {
             border-color: #f87171;
         }
@@ -187,8 +194,9 @@ export function renderEmailCredentialForm(
             color: #9ca3af; font-size: 0.75rem; cursor: pointer; padding: 0.25rem 0.5rem;
             border-radius: 4px; font-weight: 600; text-transform: uppercase;
         }
-        .toggle-password-btn:hover { color: #e8e8e8; background-color: rgba(255,255,255,0.1); }
+        .toggle-password-btn:hover:not(:disabled) { color: #e8e8e8; background-color: rgba(255,255,255,0.1); }
         .toggle-password-btn:focus-visible { outline: 2px solid #6c9bd2; outline-offset: 2px; }
+        .toggle-password-btn:disabled { opacity: 0.5; cursor: not-allowed; }
         .field-input.has-toggle { padding-right: 4rem; }
         .help-text { font-size: 0.8125rem; color: #9ca3af; margin-top: 0.375rem; }
         .field-error {
@@ -221,8 +229,9 @@ export function renderEmailCredentialForm(
             margin-bottom: 1rem;
             transition: background-color 0.15s ease, border-color 0.15s ease;
         }
-        .add-btn:hover { background-color: rgba(108, 155, 210, 0.08); border-color: #4a6fa5; }
+        .add-btn:hover:not(:disabled) { background-color: rgba(108, 155, 210, 0.08); border-color: #4a6fa5; }
         .add-btn:focus-visible { outline: 2px solid #6c9bd2; outline-offset: 2px; }
+        .add-btn:disabled { opacity: 0.5; cursor: not-allowed; border-color: #2a3a4a; }
         .submit-btn {
             width: 100%;
             background-color: #4a6fa5;
@@ -440,7 +449,8 @@ export function renderEmailCredentialForm(
                         a.setAttribute("href", helpUrl);
                         a.setAttribute("target", "_blank");
                         a.setAttribute("rel", "noopener noreferrer");
-                        a.textContent = helpText;
+                        a.textContent = helpText + " ↗";
+                        a.setAttribute("aria-label", helpText + " (opens in a new tab)");
                         help.appendChild(a);
                     } else {
                         help.textContent = helpText;
@@ -761,7 +771,8 @@ export function renderEmailCredentialForm(
                 link.setAttribute("aria-label", "Opens Microsoft sign-in page in a new tab");
                 link.style.color = "#6c9bd2";
                 link.style.fontWeight = "bold";
-                link.textContent = nextStep.verification_url;
+                link.textContent = nextStep.verification_url + " ↗";
+                link.setAttribute("aria-label", "Opens Microsoft sign-in page in a new tab: " + nextStep.verification_url);
                 statusBox.appendChild(link);
                 statusBox.appendChild(document.createElement("br"));
                 statusBox.appendChild(document.createElement("br"));


### PR DESCRIPTION
💡 **What**: Added explicit custom `:disabled` CSS styles for form inputs and buttons (opacity, `cursor: not-allowed`). Added `↗` visual indicators and `aria-label` warnings for links that open in new tabs.

🎯 **Why**: When locking down a form using `<fieldset disabled>` during submission, default styling often leaves interactive elements looking active, causing user confusion. Explicit `:disabled` styles provide immediate visual feedback. External links without visual or screen-reader warnings create jarring context switches when they open in new tabs.

♿ **Accessibility**: 
- Added `:disabled` state styling directly maps functional lockdown to visual lockdown.
- External links now explicitly pre-warn screen-reader users they will be taken out of their current context.

📸 Verified frontend via Playwright screenshot. All 690 Vitest tests pass. Code formatted and linted via Biome.

---
*PR created automatically by Jules for task [1942577242674295192](https://jules.google.com/task/1942577242674295192) started by @n24q02m*