### PR TITLE
🎨 Palette: Add visual indicators and aria-labels to external links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -93,3 +93,6 @@
 ## 2026-07-02 - Form Focus Management
 **Learning:** In complex interactive forms where asynchronous validation/submission toggles `disabled` states, focus can inadvertently drop to the `body` element. This completely disrupts keyboard and screen reader navigation. Furthermore, when injecting new interactive content dynamically (like an OAuth device code and copy button), keyboard users lose context if focus isn't moved into the newly generated UI.
 **Action:** When re-enabling a disabled form fieldset after an error, programmatically move focus back to the triggering element (e.g., `submitBtn.focus()`). When rendering new interactive flows that pause a multi-step process (like OAuth device code auth), dynamically transfer focus to the primary new interactive element (`copyBtn` or `link`) so users seamlessly enter the new flow without losing their place.
+## 2025-07-08 - Visual Indicators for External Links
+**Learning:** Links that open in a new tab (`target="_blank"`) without visual cues can be disorienting, as users expect links to navigate within the same window. Screen reader users also need explicit warning before context shifts abruptly.
+**Action:** Always include a visual indicator (like an arrow '↗') next to the link text and add a descriptive `aria-label` (e.g., "opens in a new tab") to set clear expectations for all users before they click.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -440,7 +440,8 @@ export function renderEmailCredentialForm(
                         a.setAttribute("href", helpUrl);
                         a.setAttribute("target", "_blank");
                         a.setAttribute("rel", "noopener noreferrer");
-                        a.textContent = helpText;
+                        a.setAttribute("aria-label", helpText + " (opens in a new tab)");
+                        a.textContent = helpText + " ↗";
                         help.appendChild(a);
                     } else {
                         help.textContent = helpText;
@@ -761,7 +762,7 @@ export function renderEmailCredentialForm(
                 link.setAttribute("aria-label", "Opens Microsoft sign-in page in a new tab");
                 link.style.color = "#6c9bd2";
                 link.style.fontWeight = "bold";
-                link.textContent = nextStep.verification_url;
+                link.textContent = nextStep.verification_url + " ↗";
                 statusBox.appendChild(link);
                 statusBox.appendChild(document.createElement("br"));
                 statusBox.appendChild(document.createElement("br"));


### PR DESCRIPTION
**💡 What:** 
Added a visual arrow indicator (" ↗") and explicit `aria-label`s (e.g., "(opens in a new tab)") to all links in the credential form that open in a new tab (`target="_blank"`).

**🎯 Why:** 
Links that open in a new tab without visual cues can disorient users who expect navigation within the same window. Adding the indicator sets clear expectations. Similarly, screen reader users need an explicit warning before context shifts abruptly, which the `aria-label` provides.

**♿ Accessibility:**
- Added `aria-label="... (opens in a new tab)"` to helper URLs.
- Appended " ↗" visually to the Microsoft sign-in link (which already had a descriptive `aria-label`).

---
*PR created automatically by Jules for task [14302706481465321142](https://jules.google.com/task/14302706481465321142) started by @n24q02m*