### PR TITLE
fix: point EmailContainer pingEndpoint at /health

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -164,9 +164,10 @@ export class EmailContainer extends Container<Env> {
   sleepAfter = '5m'
   // CF container readiness-probe override. Default 'ping' (URL http://ping/) does
   // not resolve, so the health-check fetch throws and the container is marked
-  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. 'localhost/'
-  // resolves to the container itself; the default route returns 200.
-  pingEndpoint = 'localhost/'
+  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. core-ts's
+  // local-server.ts serves 200 at /health (liveness route); '/' 302-redirects to
+  // the OAuth/relay app, so the probe must target /health specifically.
+  pingEndpoint = 'localhost/health'
   // IMAP/SMTP + Microsoft OAuth reach the public internet; kv.internal stays
   // intercepted (see outboundByHost).
   enableInternet = true


### PR DESCRIPTION
## Summary
- `EmailContainer.pingEndpoint` was `'localhost/'`, which mcp-core's `local-server.ts` (core-ts) 302-redirects to the OAuth/relay app instead of returning 2xx.
- CF marks the container unhealthy on every probe, so it never sleeps (runs 24/7 instead of respecting `sleepAfter`).
- core-ts serves a dedicated liveness route at `/health` (200 JSON). Point the probe there instead.

## Change
- `src/worker.ts`: `pingEndpoint = 'localhost/'` -> `pingEndpoint = 'localhost/health'` + updated adjacent comment. No other lines touched.

## Test plan
- [x] `bun run check` (biome + tsc --noEmit) passes locally
- [ ] CI green