### PR TITLE
🎨 Palette: add visual feedback for disabled form elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -93,3 +93,8 @@
 ## 2026-07-02 - Form Focus Management
 **Learning:** In complex interactive forms where asynchronous validation/submission toggles `disabled` states, focus can inadvertently drop to the `body` element. This completely disrupts keyboard and screen reader navigation. Furthermore, when injecting new interactive content dynamically (like an OAuth device code and copy button), keyboard users lose context if focus isn't moved into the newly generated UI.
 **Action:** When re-enabling a disabled form fieldset after an error, programmatically move focus back to the triggering element (e.g., `submitBtn.focus()`). When rendering new interactive flows that pause a multi-step process (like OAuth device code auth), dynamically transfer focus to the primary new interactive element (`copyBtn` or `link`) so users seamlessly enter the new flow without losing their place.
+## 2024-05-22 - Visual State for Disabled Form Elements
+
+**Learning:** When locking down a form programmatically (e.g., using `<fieldset disabled>`), child interactive elements like text inputs and secondary buttons functionally become unclickable/untypeable, but visually they remain unchanged unless explicit `:disabled` CSS pseudo-classes are defined. This creates a confusing UX where users think they can interact with the elements but cannot.
+
+**Action:** Always explicitly define custom `:disabled` CSS styles (e.g., opacity reduction, `cursor: not-allowed`, or subdued background colors) for all interactive child elements (inputs, secondary buttons, etc.) within a form. This ensures their visual state correctly matches their functional state and prevents user confusion during async lock downs.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -237,7 +237,12 @@ export function renderEmailCredentialForm(
         }
         .submit-btn:hover { background-color: #5a7fb5; }
         .submit-btn:focus-visible { outline: 2px solid #4a6fa5; outline-offset: 2px; }
-        .submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .submit-btn:disabled,
+        .add-btn:disabled,
+        .remove-btn:disabled,
+        .toggle-password-btn:disabled,
+        .copy-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .field-input:disabled { opacity: 0.6; cursor: not-allowed; background-color: #1a1a1a; }
         .status-box {
             display: none;
             border-radius: 8px;


### PR DESCRIPTION
💡 What: Added explicit `:disabled` CSS pseudo-class styling for all interactive elements within the dynamic form (inputs, add/remove buttons, toggle password buttons, copy buttons, etc.), setting them to a lower opacity and `cursor: not-allowed`. Also recorded this learning in `.jules/palette.md`.

🎯 Why: During asynchronous operations (like waiting for Microsoft OAuth via Device Code), the entire form fieldset is programmatically disabled to prevent user interaction or corrupted state. However, without explicit CSS rules targeting the `:disabled` state for child elements, they appear completely active and clickable to users, causing confusion and frustration when clicks do not register. This makes the disabled state instantly and clearly legible.

♿ Accessibility: Ensures that users are visually informed of the disabled state of secondary controls, aligning the visual experience with the functional lockdown for better predictability and cognitive ease.

📸 Before/After: The inputs and secondary buttons now visually fade to 50% opacity and display a `not-allowed` cursor when locked down during connection processes, rather than looking clickable.

---
*PR created automatically by Jules for task [9741345953015586165](https://jules.google.com/task/9741345953015586165) started by @n24q02m*