### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,7 @@
 **Vulnerability:** The credential form directly assigned dynamic UI string containing nested HTML markup using `.innerHTML` on a submit button.
 **Learning:** Any use of `.innerHTML` even with static-appearing data sets up a brittle pattern where future additions could inadvertently expose the application to Cross-Site Scripting (XSS).
 **Prevention:** Always use safe DOM traversal manipulation utilizing `document.createElement`, `setAttribute`, and `textContent` or `document.createTextNode` instead of string interpolation and `innerHTML`.
+## 2026-07-09 - Missing Security Headers in Proxy Fetch
+**Vulnerability:** The `fetch` entrypoint in `src/worker.ts` proxied requests to the container process but forwarded the response directly to the client without setting critical security headers. This omission exposed the application to MIME-sniffing, clickjacking, and potential man-in-the-middle downgrade attacks.
+**Learning:** When acting as a reverse proxy or gateway (like in a Cloudflare Worker), you must explicitly attach security headers (e.g., `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`) to the cloned response before returning it to the client, as the backend container might not set them by default.
+**Prevention:** Always use a `new Response` wrapper around proxied fetches to inject standard security headers (e.g., `nosniff`, `DENY`, `max-age`) on the outbound `Headers` object.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -130,7 +130,16 @@ export default {
     if (env.EMAIL) {
       const userId = await extractUserId()
       const stub = env.EMAIL.get(env.EMAIL.idFromName(userId))
-      return stub.fetch(request)
+      const response = await stub.fetch(request)
+      const newHeaders = new Headers(response.headers)
+      newHeaders.set('X-Content-Type-Options', 'nosniff')
+      newHeaders.set('X-Frame-Options', 'DENY')
+      newHeaders.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: newHeaders
+      })
     }
     return new Response('not found', { status: 404 })
   }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing critical security headers (CSP, X-Frame-Options, HSTS, etc.) on proxied responses.
🎯 **Impact:** Exposes the application to MIME-type sniffing, clickjacking, and MITM downgrade attacks.
🔧 **Fix:** Cloned the `Response` object returned from the `fetch` proxy in `src/worker.ts` and injected standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, and `Strict-Transport-Security`).
✅ **Verification:** Ran `bun run test tests/worker.test.ts` and the full suite (`bun run test`). All tests pass.

---
*PR created automatically by Jules for task [4007803545864687520](https://jules.google.com/task/4007803545864687520) started by @n24q02m*