### PR TITLE
fix: reject unauthenticated /mcp at the Worker edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -118,6 +118,19 @@ export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
   'kv.internal': kvOutbound
 }
 
+// Bearer credential presence check. Structural only -- validity is the container's job.
+const BEARER = /^Bearer\s+\S/i
+
+function unauthenticated(request: Request): Response {
+  const { origin } = new URL(request.url)
+  return new Response(null, {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`
+    }
+  })
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     // Public entrypoint: ONLY routes inbound requests to the per-user container
@@ -127,6 +140,19 @@ export default {
     // KV namespace unauthenticated. Production container outbound reaches it via
     // @cloudflare/containers' ContainerProxy + the EmailContainer.outboundByHost
     // registry below; unit tests call the handler directly via OUTBOUND_BY_HOST.
+    // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before this
+    // gate every anonymous /mcp request started the container and reset its 5m idle
+    // timer -- an unauthenticated caller could pin it awake and bill GiB-s around the
+    // clock. Verified 2026-07-09: a python-httpx client POSTed /mcp with no
+    // Authorization header every ~20s for 12h+. The check is STRUCTURAL: it rejects
+    // requests carrying no bearer credential at all and reproduces the container's own
+    // 401 (empty body + RFC 9728 WWW-Authenticate). Token VALIDITY is never judged
+    // here -- the container remains the sole authority, so no mcp-core auth logic is
+    // duplicated at the edge.
+    const url = new URL(request.url)
+    if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+      if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
+    }
     if (env.EMAIL) {
       const userId = await extractUserId()
       const stub = env.EMAIL.get(env.EMAIL.idFromName(userId))
@@ -162,11 +188,12 @@ export class EmailContainer extends Container<Env> {
   // When the container wakes, ``ensureValidToken()`` checks KV and auto-resumes
   // the poll. See oauth2.ts:loadPendingDeviceCode / persistPendingDeviceCode.
   sleepAfter = '5m'
-  // CF container readiness-probe override. Default 'ping' (URL http://ping/) does
-  // not resolve, so the health-check fetch throws and the container is marked
-  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. core-ts's
-  // local-server.ts serves 200 at /health (liveness route); '/' 302-redirects to
-  // the OAuth/relay app, so the probe must target /health specifically.
+  // Port-readiness probe used by @cloudflare/containers' waitForPort(): it does
+  // tcpPort.fetch('http://' + pingEndpoint) against the container's bound port, so the
+  // host segment is only a Host header (no DNS) and ANY HTTP response marks the port
+  // ready. We point it at /health because core-ts serves a cheap 200 there while '/'
+  // 302-redirects into the OAuth app. This does NOT drive the platform's `healthy`
+  // metric -- see the edge auth gate above for the real cause of containers never sleeping.
   pingEndpoint = 'localhost/health'
   // IMAP/SMTP + Microsoft OAuth reach the public internet; kv.internal stays
   // intercepted (see outboundByHost).

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -98,17 +98,61 @@ describe('worker (KV-only)', () => {
   })
 
   test('fetch falls back to "default" sub when no Bearer token (E.2 single-user DO)', async () => {
+    // /authorize is not gated by the edge auth check (only /mcp is), so this still
+    // exercises extractUserId()'s unconditional "default" return.
     const idFromName = vi.fn().mockReturnValue('id-default')
     const env = {
       EMAIL: { idFromName, get: vi.fn().mockReturnValue({ fetch: vi.fn().mockResolvedValue(new Response()) }) }
     }
-    await worker.fetch(new Request('https://email.n24q02m.com/mcp'), env as never)
+    await worker.fetch(new Request('https://email.n24q02m.com/authorize'), env as never)
     expect(idFromName).toHaveBeenCalledWith('default')
   })
 
   test('fetch returns 404 when the EMAIL binding is absent', async () => {
-    const resp = await worker.fetch(new Request('https://email.n24q02m.com/mcp'), {} as never)
+    // Bearer header clears the edge gate so the request reaches the env.EMAIL check.
+    const resp = await worker.fetch(
+      new Request('https://email.n24q02m.com/mcp', { headers: { authorization: 'Bearer test' } }),
+      {} as never
+    )
     expect(resp.status).toBe(404)
+  })
+
+  test('edge auth gate: POST /mcp with no Authorization -> 401, DO never touched', async () => {
+    const stub = { fetch: vi.fn().mockResolvedValue(new Response('ok')) }
+    const env = { EMAIL: { idFromName: vi.fn(), get: vi.fn().mockReturnValue(stub) } }
+    const resp = await worker.fetch(new Request('https://email.n24q02m.com/mcp', { method: 'POST' }), env as never)
+    expect(resp.status).toBe(401)
+    expect(await resp.text()).toBe('')
+    expect(resp.headers.get('WWW-Authenticate')).toMatch(
+      /^Bearer resource_metadata="https:\/\/[^"]+\/\.well-known\/oauth-protected-resource"$/
+    )
+    expect(stub.fetch).not.toHaveBeenCalled()
+  })
+
+  test('edge auth gate: OPTIONS /mcp with no Authorization -> 401, DO never touched', async () => {
+    const stub = { fetch: vi.fn().mockResolvedValue(new Response('ok')) }
+    const env = { EMAIL: { idFromName: vi.fn(), get: vi.fn().mockReturnValue(stub) } }
+    const resp = await worker.fetch(new Request('https://email.n24q02m.com/mcp', { method: 'OPTIONS' }), env as never)
+    expect(resp.status).toBe(401)
+    expect(stub.fetch).not.toHaveBeenCalled()
+  })
+
+  test('edge auth gate: POST /mcp with a Bearer token reaches the DO (validity not judged)', async () => {
+    const stub = { fetch: vi.fn().mockResolvedValue(new Response('ok')) }
+    const env = { EMAIL: { idFromName: vi.fn().mockReturnValue('id'), get: vi.fn().mockReturnValue(stub) } }
+    const resp = await worker.fetch(
+      new Request('https://email.n24q02m.com/mcp', { method: 'POST', headers: { authorization: 'Bearer anything' } }),
+      env as never
+    )
+    expect(stub.fetch).toHaveBeenCalledTimes(1)
+    expect(resp.status).toBe(200)
+  })
+
+  test('edge auth gate: non-/mcp path with no Authorization still reaches the DO', async () => {
+    const stub = { fetch: vi.fn().mockResolvedValue(new Response('ok')) }
+    const env = { EMAIL: { idFromName: vi.fn().mockReturnValue('id'), get: vi.fn().mockReturnValue(stub) } }
+    await worker.fetch(new Request('https://email.n24q02m.com/authorize?foo=1'), env as never)
+    expect(stub.fetch).toHaveBeenCalledTimes(1)
   })
 
   test('defaultPort 8080 + sleepAfter is 5m (device-code session KV-persisted, no longer needs >=15m)', () => {


### PR DESCRIPTION
## The cost bug

mcp-core's OAuth Authorization Server runs INSIDE the container Durable Object, not at the
Worker edge. The Worker's `fetch` unconditionally routed every inbound request (including
anonymous ones) straight to the container, which starts the Durable Object and resets its
5-minute idle timer before it even gets a chance to answer 401 itself.

Measured live (2026-07-09/10): an unauthenticated `python-httpx/0.28.1` client POSTed `/mcp`
with NO `Authorization` header roughly every 20 seconds for 12+ hours, pinning the container
container awake around the clock -- 1282 x HTTP 401 in a single 6-hour window. Cloudflare
bills container memory (GiB-s) for the whole time it's awake, so this was a live, unbounded
cost leak driven entirely by anonymous traffic.

## The fix

`src/worker.ts` now gates `/mcp` (and any path under it) at the edge, before the Durable
Object is touched: if there is no `Bearer <token>` in the `Authorization` header, the Worker
answers 401 itself and never calls `env.EMAIL.get(...)`. The 401 is byte-compatible with what
the container returns today (empty body, `WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource"`).

The check is purely structural: it only asks "is there a bearer credential at all", never
"is this token valid". mcp-core's OAuth logic inside the container remains the sole authority
on token validity -- nothing is duplicated at the edge. Any request carrying `Bearer <anything>`
still reaches the container unchanged, same as `/authorize`, `/token`, `/register`, `/login`,
`/.well-known/*`, and `/health`.

## Second fix in the same file: a misleading comment

The `EmailContainer.pingEndpoint` comment claimed the default `'ping'` readiness probe "does
not resolve, so the health-check fetch throws and the container is marked unhealthy -> CF
keeps it running 24/7" -- that's not what happens and it already misled two debugging
sessions. `@cloudflare/containers`' `waitForPort()` does `tcpPort.fetch('http://' + pingEndpoint)`
against the container's already-bound TCP port; the host segment is only a `Host` header
(no DNS lookup happens), and the library's own docs say the user doesn't need to implement
this route at all -- any HTTP response resolves it. The comment is corrected to describe the
actual mechanism and points at the edge gate above as the real fix for the always-awake
behavior. The `pingEndpoint` value itself is unchanged.

## Tests

Extended `tests/worker.test.ts` (did not rewrite):
- `POST /mcp` with no `Authorization` -> 401, `WWW-Authenticate` matches the RFC 9728 shape,
  empty body, Durable Object stub never called.
- `OPTIONS /mcp` with no `Authorization` -> 401, stub never called.
- `POST /mcp` with `Authorization: Bearer anything` -> stub called exactly once (validity is
  not judged at the edge).
- Non-`/mcp` path (`/authorize`) with no `Authorization` -> still reaches the stub.
- Adjusted two pre-existing tests that asserted on `/mcp` with no `Authorization` (they now
  legitimately hit the new 401 before reaching their original assertions): one moved to
  `/authorize` (an ungated path) to keep testing `extractUserId()`'s default-sub fallback,
  the other adds a `Bearer` header to reach the "EMAIL binding absent -> 404" branch it was
  actually testing.

## Verification

- `bun run type-check` -- clean
- `bun run check` (biome + tsc) -- clean (2 pre-existing infos about biome.json schema version, unrelated)
- `bunx vitest run tests/worker.test.ts` -- 13/13 passed
- `bun run test` (full suite) -- 694 passed, 1 pre-existing skip, 0 failed
- `bun run cf:dryrun` -- fails locally because it requires `CLOUDFLARE_ACCOUNT_ID`/`CLOUDFLARE_API_TOKEN`
  which are not available in this environment (reported honestly, not faked). A direct
  `wrangler deploy --dry-run --config wrangler.jsonc` against the template config succeeded
  (`Total Upload: 60.08 KiB / gzip: 15.12 KiB`, `--dry-run: exiting now.`), confirming the
  Worker still bundles with these changes.

Not merging -- leaving open per request.