### PR TITLE
fix: decline standing GET /mcp SSE stream at the edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -153,6 +153,17 @@ export default {
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
+    // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
+    // scale-to-zero container this is pure idle cost: @cloudflare/containers
+    // counts an open stream as an in-flight request forever (inflight > 0 =>
+    // activity never expires), so a single idle client pins the container
+    // awake 24/7. None of this stack's servers send server-initiated
+    // messages; request-scoped notifications ride the POST's own SSE
+    // response. The spec allows declining the stream: both official SDKs
+    // treat 405 as the optional-feature path and continue POST-only.
+    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+      return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
+    }
     if (env.EMAIL) {
       const userId = await extractUserId()
       const stub = env.EMAIL.get(env.EMAIL.idFromName(userId))

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -89,7 +89,9 @@ describe('worker (KV-only)', () => {
     const env = { EMAIL: { idFromName, get: vi.fn().mockReturnValue(stub) } }
     // Bearer with base64url payload {"sub":"alice"} — single-DO collapse routes it to "default"
     const payload = Buffer.from(JSON.stringify({ sub: 'alice' })).toString('base64url')
+    // POST (not GET): GET /mcp is now declined with 405 at the edge (standing SSE stream).
     const req = new Request('https://email.n24q02m.com/mcp', {
+      method: 'POST',
       headers: { authorization: `Bearer h.${payload}.s` }
     })
     await worker.fetch(req, env as never)
@@ -110,8 +112,9 @@ describe('worker (KV-only)', () => {
 
   test('fetch returns 404 when the EMAIL binding is absent', async () => {
     // Bearer header clears the edge gate so the request reaches the env.EMAIL check.
+    // POST (not GET): GET /mcp is now declined with 405 at the edge (standing SSE stream).
     const resp = await worker.fetch(
-      new Request('https://email.n24q02m.com/mcp', { headers: { authorization: 'Bearer test' } }),
+      new Request('https://email.n24q02m.com/mcp', { method: 'POST', headers: { authorization: 'Bearer test' } }),
       {} as never
     )
     expect(resp.status).toBe(404)
@@ -153,6 +156,41 @@ describe('worker (KV-only)', () => {
     const env = { EMAIL: { idFromName: vi.fn().mockReturnValue('id'), get: vi.fn().mockReturnValue(stub) } }
     await worker.fetch(new Request('https://email.n24q02m.com/authorize?foo=1'), env as never)
     expect(stub.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('GET /mcp with a Bearer token -> 405, declining the standing SSE stream, DO never touched', async () => {
+    const stub = { fetch: vi.fn().mockResolvedValue(new Response('ok')) }
+    const env = { EMAIL: { idFromName: vi.fn(), get: vi.fn().mockReturnValue(stub) } }
+    const resp = await worker.fetch(
+      new Request('https://email.n24q02m.com/mcp', { method: 'GET', headers: { authorization: 'Bearer anything' } }),
+      env as never
+    )
+    expect(resp.status).toBe(405)
+    expect(resp.headers.get('allow')).toBe('POST, DELETE')
+    expect(stub.fetch).not.toHaveBeenCalled()
+  })
+
+  test('GET /mcp/sub-path with a Bearer token -> 405', async () => {
+    const stub = { fetch: vi.fn().mockResolvedValue(new Response('ok')) }
+    const env = { EMAIL: { idFromName: vi.fn(), get: vi.fn().mockReturnValue(stub) } }
+    const resp = await worker.fetch(
+      new Request('https://email.n24q02m.com/mcp/sub', {
+        method: 'GET',
+        headers: { authorization: 'Bearer anything' }
+      }),
+      env as never
+    )
+    expect(resp.status).toBe(405)
+    expect(resp.headers.get('allow')).toBe('POST, DELETE')
+    expect(stub.fetch).not.toHaveBeenCalled()
+  })
+
+  test('GET /mcp with no Authorization -> still 401 (edge auth gate runs before the 405 check)', async () => {
+    const stub = { fetch: vi.fn().mockResolvedValue(new Response('ok')) }
+    const env = { EMAIL: { idFromName: vi.fn(), get: vi.fn().mockReturnValue(stub) } }
+    const resp = await worker.fetch(new Request('https://email.n24q02m.com/mcp', { method: 'GET' }), env as never)
+    expect(resp.status).toBe(401)
+    expect(stub.fetch).not.toHaveBeenCalled()
   })
 
   test('defaultPort 8080 + sleepAfter is 5m (device-code session KV-persisted, no longer needs >=15m)', () => {


### PR DESCRIPTION
## Summary

A standing `GET /mcp` request (the streamable-HTTP server-push SSE stream) is counted by `@cloudflare/containers` as an in-flight request forever: `inflight > 0` means the container's idle-activity timer never expires, so a single idle MCP client pins the scale-to-zero container awake and billing 24/7. None of this stack's servers send server-initiated messages -- request-scoped notifications ride the POST's own SSE response -- so declining the standing stream loses nothing.

The streamable-HTTP spec allows a server to decline the GET stream with `405`, and both official SDKs already handle it as the optional-feature path:
- TS client: treats 405 as an "expected case" and continues POST-only (`client/streamableHttp.js:100-104`)
- Python client: retries the GET at most twice, then gives up quietly and continues POST-only

The edge worker (`src/worker.ts`) now returns `405` with `Allow: POST, DELETE` for any `GET /mcp` or `GET /mcp/*` request, placed after the existing Bearer auth gate (so an unauthenticated GET still gets `401`, unchanged) and before the request reaches the per-user Durable Object.

## Test evidence

Added to `tests/worker.test.ts`:
- `GET /mcp` with Bearer -> `405`, `Allow: POST, DELETE`, DO never touched
- `GET /mcp/sub-path` with Bearer -> `405`
- `GET /mcp` with no Authorization -> still `401` (auth gate runs first)

Two pre-existing tests implicitly relied on GET reaching the DO (default `Request` method) to exercise unrelated routing/fallback logic; updated those two to use `POST` so they keep testing what they were meant to test, now that GET is a declined method.

```
 Test Files  40 passed | 1 skipped (41)
      Tests  697 passed | 1 skipped (698)
```

`bun run check` (biome + `tsc --noEmit`) is clean.

## Test plan
- [x] `bun run test` -- full suite green (697 passed, 1 pre-existing skip)
- [x] `bun run check` -- lint + type-check clean
- [x] Manual grep confirms the auth gate (`BEARER`, `unauthenticated(request)`) is untouched; the new 405 branch is the only added control-flow change in `src/worker.ts`