### PR TITLE
fix: document public-by-design identifiers for secret scanners

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,12 @@
+# Public-by-design app identifiers -- reviewed and deliberately kept.
+# DEFAULT_CLIENT_ID in src/tools/helpers/oauth2.ts is a bundled Azure AD
+# PUBLIC client ID (no client secret involved -- same pattern Thunderbird
+# and other public OAuth clients use; see
+# https://learn.microsoft.com/en-us/entra/identity-platform/msal-client-applications
+# for the public-vs-confidential client distinction). Scanner alerts on this
+# exact value are a false positive. Do NOT rotate, do NOT placeholder-ize.
+version: 2
+secret:
+  ignored_matches:
+    - name: azure-ad-bundled-public-client-id
+      match: "d56f8c71-9f7c-43f4-9934-be29cb6e77b0"


### PR DESCRIPTION
## Summary
- Adds `.gitguardian.yaml` recording the bundled Azure AD `DEFAULT_CLIENT_ID` in `src/tools/helpers/oauth2.ts` as a reviewed, public-by-design identifier, using ggshield's `secret.ignored_matches` raw-string-equality format.
- This is an Azure AD **public client** ID (no client secret), the same pattern Thunderbird and other public OAuth clients use — the in-code comment above `DEFAULT_CLIENT_ID` already documents this. This is not a leak; do not rotate, do not placeholder-ize.

## Scope note
- This file is read by ggshield (the CLI/pre-commit scanner) and silences the local/CI re-raise. The GitGuardian **dashboard** app keeps its own separate ignore list, so if a dashboard incident exists for this value it still needs a one-time manual "ignore" resolution there — this file only records the decision in-repo for the scanner tooling that reads it.

## Test plan
- [x] `pre-commit run --files .gitguardian.yaml` (gitleaks + other hooks) passed, no allowlist changes needed
- [ ] CI green on this PR