### PR TITLE
fix: bump @n24q02m/mcp-core to 1.18.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.18.1",
+        "@n24q02m/mcp-core": "^1.18.2",
         "html-to-text": "^10.0.0",
         "imapflow": "^1.4.3",
         "mailparser": "^3.9.12",
@@ -200,7 +200,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-QXHUO8w5DxDuvuVgcoAaSeusAz4csWYUTZ+VSa0JzgMkYdjwrER+UMwMMagq0gB2nkdCpviT92Mwbjb3jjhUnQ=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-5sm/UNCIGHzSrxk/PAdmjV0pUHE5LXxbEWfnbvQcDMN13YkmFmvd/SV5TGD64nUql4sznnUtIyCmtRdxlhToSw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.18.1",
+    "@n24q02m/mcp-core": "^1.18.2",
     "html-to-text": "^10.0.0",
     "imapflow": "^1.4.3",
     "mailparser": "^3.9.12",

--- a/src/mcp-core-pin.test.ts
+++ b/src/mcp-core-pin.test.ts
@@ -9,8 +9,12 @@ describe('mcp-core dependency pin', () => {
     // Storage backends (CfKvBackend/backendFromEnv) + EdDSA-from-CREDENTIAL_SECRET
     // shipped in the 1.18.0-beta line and are stable as of 1.18.1; the old exact
     // 1.17.4 pin lacks them, and beta pins should not reach the stable build.
-    expect(dep).toContain('1.18.1')
-    expect(dep).not.toBe('1.17.4')
+    const [major, minor, patch] = dep
+      .replace(/^[^\d]*/, '')
+      .split('.')
+      .map(Number)
+    const meetsFloor = major > 1 || (major === 1 && minor > 18) || (major === 1 && minor === 18 && patch >= 1)
+    expect(meetsFloor).toBe(true)
   })
 
   test('does not use a path/workspace source for mcp-core (npm dependency only)', () => {


### PR DESCRIPTION
Bumps `@n24q02m/mcp-core` pin from `^1.18.1` to `^1.18.2` (package.json + bun.lock) to track the released core version and avoid pin drift.

Closes #979