### PR TITLE
feat: document CLI and smithery in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ mcp-name: io.github.n24q02m/better-email-mcp
 
 - [Features](#features)
 - [Install](#install)
+- [CLI](#cli)
+- [Smithery](#smithery)
 - [Documentation](#documentation)
 - [Tools](#tools)
 - [Comparison](#comparison)
@@ -95,6 +97,40 @@ The server runs in two modes: **stdio** (default, single-user, credentials from 
 Multiple accounts are comma-separated: `user1@gmail.com:pass1,user2@outlook.com:pass2`. See [Configuration](#configuration) for all env vars, and [Remote (HTTP Mode)](#remote-http-mode) to run a hosted multi-user server.
 
 Most providers use an **App Password** (no OAuth setup); Outlook/Hotmail/Live use a bundled OAuth device-code flow in HTTP mode. Settings (IMAP/SMTP host, port) are auto-discovered from the email domain.
+
+## CLI
+
+The package ships one binary, `better-email-mcp` (run via `npx @n24q02m/better-email-mcp`). With no arguments it starts the MCP server over stdio; it also accepts one flag and one subcommand:
+
+| Invocation | Description |
+|:-----------|:------------|
+| `better-email-mcp` | Start the MCP server over **stdio** (default). Reads credentials from `EMAIL_CREDENTIALS`, or from `EMAIL_USER` + `EMAIL_APP_PASSWORD` |
+| `better-email-mcp --http` | Start the server in **HTTP** (multi-user, OAuth 2.1) mode. Equivalent to `MCP_TRANSPORT=http` or `TRANSPORT_MODE=http` |
+| `better-email-mcp auth <email>` | Authenticate an Outlook/Hotmail/Live account via OAuth2 Device Code flow. Tokens are saved to `~/.better-email-mcp/tokens.json` |
+
+```bash
+# stdio server (normally launched by your MCP client, not by hand)
+EMAIL_CREDENTIALS="user@gmail.com:app-password" npx @n24q02m/better-email-mcp
+
+# HTTP multi-user server
+npx @n24q02m/better-email-mcp --http
+
+# One-off Outlook OAuth device-code sign-in
+npx @n24q02m/better-email-mcp auth user@outlook.com
+```
+
+`auth` is only for Outlook/Hotmail/Live addresses -- other providers use an App Password in `EMAIL_CREDENTIALS`. See [Remote (HTTP Mode)](#remote-http-mode) for the hosted endpoint and HTTP config.
+
+## Smithery
+
+Published with a [Smithery](https://smithery.ai) config ([`smithery.yaml`](smithery.yaml)). Smithery runs the server over **stdio** with no build config required; credentials are supplied at runtime through the server's own setup flow (see [Configuration](#configuration)). The start command is:
+
+```yaml
+startCommand:
+  type: stdio
+  commandFunction: |-
+    (config) => ({ command: 'npx', args: ['-y', '@n24q02m/better-email-mcp'] })
+```
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Refresh `README.md` to document the CLI surface and Smithery distribution.

- **`## CLI`** section: documents the real `better-email-mcp` binary — default stdio server, `--http` flag (HTTP multi-user mode), and the `auth <email>` subcommand (Outlook/Hotmail/Live OAuth2 device-code, tokens at `~/.better-email-mcp/tokens.json`). Subcommands verified against `scripts/start-server.ts`, `src/auth-cli.ts`, and `src/init-server.ts` — none invented.
- **`## Smithery`** section: notes the stdio `smithery.yaml` start command (`npx -y @n24q02m/better-email-mcp`, no config required).
- Table of contents updated with both new anchors.

The hosted endpoint `https://email.n24q02m.com/mcp` was already documented under [Remote (HTTP Mode)](https://github.com/n24q02m/better-email-mcp#remote-http-mode) and is left as-is (not duplicated); the CLI section links to it.

## Verification

- `pre-commit run --files README.md` — all applicable hooks pass (gitleaks, trailing-whitespace, end-of-file-fixer, preserve-diacritics).
- Docs-only change; no source or config touched.