### PR TITLE
🎨 Palette: Improve focus spatial orientation and add button tooltips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,8 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+
+## 2023-10-27 - Icon Button Tooltips and Spatial Orientation
+
+**Learning:** When navigating dynamic forms with repeated interactive elements, adding `:focus-within` to container cards helps maintain spatial orientation for keyboard users. Furthermore, relying only on `aria-label` for icon-like or sparse-text action buttons (like toggles, copies, or removals) leaves sighted pointer users guessing their exact function, especially if iconography is ambiguous.
+**Action:** Use `:focus-within` to apply prominent focus styling to repeating parent containers. Always complement existing `aria-label` attributes on icon-like or secondary action buttons with the native HTML `title` attribute to provide visible tooltip hints on hover for sighted users.

--- a/src/credential-form.ts
+++ b/src/credential-form.ts
@@ -96,6 +96,11 @@ export function renderEmailCredentialForm(
             padding: 1rem;
             margin-bottom: 0.875rem;
             background-color: #121212;
+            transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        }
+        .account-card:focus-within {
+            border-color: #4a6fa5;
+            box-shadow: 0 0 0 1px rgba(74, 111, 165, 0.2);
         }
         .account-card-header {
             display: flex;
@@ -417,12 +422,14 @@ export function renderEmailCredentialForm(
                     toggleBtn.className = "toggle-password-btn";
                     toggleBtn.textContent = "Show";
                     toggleBtn.setAttribute("aria-label", "Show password as plain text");
+                    toggleBtn.setAttribute("title", "Show password as plain text");
                     toggleBtn.setAttribute("aria-pressed", "false");
                     toggleBtn.addEventListener("click", function () {
                         const isPass = input.getAttribute("type") === "password";
                         input.setAttribute("type", isPass ? "text" : "password");
                         toggleBtn.textContent = isPass ? "Hide" : "Show";
                         toggleBtn.setAttribute("aria-label", isPass ? "Hide password" : "Show password as plain text");
+                        toggleBtn.setAttribute("title", isPass ? "Hide password" : "Show password as plain text");
                         toggleBtn.setAttribute("aria-pressed", isPass ? "true" : "false");
                     });
                     wrapper.appendChild(toggleBtn);
@@ -511,6 +518,7 @@ export function renderEmailCredentialForm(
                     if (removeBtn && removeBtn instanceof HTMLElement) {
                         removeBtn.style.display = cards.length > 1 ? "" : "none";
                         removeBtn.setAttribute("aria-label", "Remove " + titleStr);
+                        removeBtn.setAttribute("title", "Remove " + titleStr);
                     }
                 }
             }
@@ -612,6 +620,7 @@ export function renderEmailCredentialForm(
                 removeBtn.className = "remove-btn";
                 removeBtn.textContent = "Remove";
                 removeBtn.setAttribute("aria-label", "Remove Account " + (idx + 1));
+                removeBtn.setAttribute("title", "Remove Account " + (idx + 1));
                 removeBtn.addEventListener("click", function () {
                     var inputs = card.querySelectorAll("input");
                     var hasData = false;
@@ -799,14 +808,17 @@ export function renderEmailCredentialForm(
                     copyBtn.textContent = "Copy";
                     copyBtn.className = "copy-btn";
                     copyBtn.setAttribute("aria-label", "Copy code to clipboard");
+                    copyBtn.setAttribute("title", "Copy code to clipboard");
                     copyBtn.addEventListener("click", function () {
                         navigator.clipboard.writeText(nextStep.user_code).then(function () {
                             copyBtn.textContent = "Copied!";
                             copyBtn.setAttribute("aria-label", "Code copied to clipboard");
+                            copyBtn.setAttribute("title", "Code copied to clipboard");
                             copyBtn.setAttribute("aria-live", "polite");
                             setTimeout(function () {
                                 copyBtn.textContent = "Copy";
                                 copyBtn.setAttribute("aria-label", "Copy code to clipboard");
+                                copyBtn.setAttribute("title", "Copy code to clipboard");
                             }, 2000);
                         });
                     });


### PR DESCRIPTION
💡 What: Added `:focus-within` CSS styling to `.account-card` containers and mirrored `aria-label`s to native HTML `title` attributes on icon-like/action buttons (Copy, Remove, Show/Hide Password).
🎯 Why: Enhances spatial orientation for keyboard users navigating complex dynamic form sections by visibly highlighting the active card container. Improves usability for sighted pointer users by providing native browser tooltips for action buttons whose function might be ambiguous.
📸 Before/After: Verified visually via screenshot.
♿ Accessibility: Maintains all existing `aria-label` configurations while boosting visual feedback for both keyboard (focus rings/borders) and mouse (tooltips) users.

---
*PR created automatically by Jules for task [12000962114359159430](https://jules.google.com/task/12000962114359159430) started by @n24q02m*