### PR TITLE
fix: add orphan-tag integrity guard to release CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,6 +54,21 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
+      - name: Verify no orphaned release tags (main not regressed behind an existing tag)
+        run: |
+          set -uo pipefail
+          highest_tag="$(git tag -l 'v*' | sort -V | tail -1)"
+          if [ -z "$highest_tag" ]; then
+            echo "No existing tags -- nothing to verify."
+            exit 0
+          fi
+          if git merge-base --is-ancestor "$highest_tag" HEAD; then
+            echo "OK: highest known tag ${highest_tag} is reachable from HEAD."
+          else
+            echo "::error::Highest known tag ${highest_tag} is NOT an ancestor of HEAD (origin/main). Main history was rewritten (rebase/force-push) and dropped the chore(release) commit(s) carrying this tag -- PSR will recompute an already-published version and silently freeze. Do NOT proceed: re-tag ${highest_tag} onto a current main ancestor, or push the orphaned tip to an archive branch, per feedback_psr_release_gotchas. See mcp-dev/references/release-cascade.md."
+            exit 1
+          fi
+
       # Dry-run PSR (no_operation_mode => --noop: no commit/tag/push/release) purely to
       # learn the version it WOULD publish, so the npm-collision guard below can fire
       # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and


### PR DESCRIPTION
## Summary
- Add a CI step to the `release` job in `.github/workflows/cd.yml` that fails fast if the highest-known release tag is not reachable from HEAD (main history rewritten/rebased, dropping the release commit that carries the tag) before PSR runs.
- Closes the gap identified in the W2.3 orphan-tag audit — this exact failure mode caused a silent release freeze twice elsewhere in the stack (mnemo-mcp 2026-07-01, better-notion-mcp 2026-07-10).

## Test plan
- [x] `actionlint .github/workflows/cd.yml` passes
- [x] Step placed immediately after `actions/checkout` (which already has `fetch-depth: 0`), before the PSR dry-run step
- [x] Tag glob `v*` matches this repo's tag format (`v1.35.0-beta.4`)
- [x] CI runs on this PR to confirm workflow syntax is valid (guard step itself only executes in the `release` job triggered by `workflow_dispatch`, not on PR)