### PR TITLE
feat: wire core buildCli for doctor/config/relay/--version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "1.20.0-beta.1",
+        "@n24q02m/mcp-core": "1.20.0-beta.2",
         "html-to-text": "^10.0.0",
         "imapflow": "^1.4.6",
         "mailparser": "^3.9.14",
@@ -200,7 +200,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.20.0-beta.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-A6YHbwS/B3paJ7AZRddRgGH55TlIfLMF6tP60QCj7YsZwgbQFhrDKPTYNc/zlrrEhL2B+Bncc0hrJZiWJ0R49A=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.20.0-beta.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-i8dizV+LgAu+jFlEJbg0bd5ahPgmGbPw7mpWOb3M6ukxKsaT6dtxM48nvvdPIkKM4WUfjyr1NIa67BJl9e5qWQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "1.20.0-beta.1",
+    "@n24q02m/mcp-core": "1.20.0-beta.2",
     "html-to-text": "^10.0.0",
     "imapflow": "^1.4.6",
     "mailparser": "^3.9.14",

--- a/scripts/start-server.test.ts
+++ b/scripts/start-server.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setHomeDirForTesting } from '@n24q02m/mcp-core/storage'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runAuth } from '../src/auth-cli.js'
 import { initServer } from '../src/init-server.js'
@@ -7,49 +11,48 @@ vi.mock('../src/auth-cli.js', () => ({
 }))
 
 vi.mock('../src/init-server.js', () => ({
-  initServer: vi.fn()
+  initServer: vi.fn(),
+  getVersion: vi.fn(() => '0.0.0-test')
 }))
 
-describe('start-server', () => {
+describe('start-server (buildCli wiring)', () => {
   const originalArgv = process.argv
   const originalExit = process.exit
   const originalConsoleError = console.error
-  let processOnSpy: ReturnType<typeof vi.spyOn>
+  let onceSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    setHomeDirForTesting(mkdtempSync(join(tmpdir(), 'better-email-mcp-cli-test-')))
 
     process.argv = ['node', 'scripts/start-server.ts']
-    process.exit = vi.fn((_code) => {
-      // Don't throw for tests, just capture
-      return undefined as never
-    }) as any
+    process.exit = vi.fn((_code) => undefined as never) as any
     console.error = vi.fn()
-    processOnSpy = vi.spyOn(process, 'on').mockImplementation((_event, _listener) => process)
+    onceSpy = vi.spyOn(process, 'once').mockImplementation((_event, _listener) => process)
   })
 
   afterEach(() => {
     process.argv = originalArgv
     process.exit = originalExit
     console.error = originalConsoleError
+    setHomeDirForTesting(null)
     vi.restoreAllMocks()
   })
 
-  it('calls runAuth and exits if argv[2] is "auth"', async () => {
+  it('routes the "auth" subcommand to runAuth and does not start the server', async () => {
     process.argv.push('auth')
     vi.mocked(runAuth).mockResolvedValue(undefined)
 
-    // Dynamically import to execute main() again
     await import('./start-server.js')
-    // Await macro task queue to ensure main finishes
     await vi.waitFor(() => expect(runAuth).toHaveBeenCalled())
 
     expect(runAuth).toHaveBeenCalled()
     expect(initServer).not.toHaveBeenCalled()
+    expect(process.exit).toHaveBeenCalledWith(0)
   })
 
-  it('calls initServer and registers SIGINT handler if argv[2] is not "auth"', async () => {
+  it('starts the server and registers SIGINT/SIGTERM when no subcommand is given', async () => {
     vi.mocked(initServer).mockResolvedValue(undefined as any)
 
     await import('./start-server.js')
@@ -57,31 +60,43 @@ describe('start-server', () => {
 
     expect(runAuth).not.toHaveBeenCalled()
     expect(initServer).toHaveBeenCalled()
-    expect(processOnSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function))
+    expect(onceSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function))
+    expect(onceSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function))
   })
 
-  it('handles SIGINT correctly', async () => {
+  it('does not exit right after initServer resolves (stdio must stay alive until shutdown)', async () => {
+    // Regression guard: Server.connect() (inside initServer) resolves once
+    // the transport starts listening, not once the session ends. If
+    // `serve()` returned right there, buildCli's own
+    // `.then((code) => process.exit(code))` would kill the process
+    // immediately after startup instead of keeping the server running.
     vi.mocked(initServer).mockResolvedValue(undefined as any)
 
-    // We need to capture the SIGINT handler
+    await import('./start-server.js')
+    await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(process.exit).not.toHaveBeenCalled()
+  })
+
+  it('exits 0 once SIGINT fires after the server starts', async () => {
+    vi.mocked(initServer).mockResolvedValue(undefined as any)
+
     let sigintHandler: (() => void) | undefined
-    processOnSpy.mockImplementation((event: string, listener: (...args: any[]) => void) => {
-      if (event === 'SIGINT') {
-        sigintHandler = listener as () => void
-      }
+    onceSpy.mockImplementation((event: string, listener: (...args: any[]) => void) => {
+      if (event === 'SIGINT') sigintHandler = listener as () => void
       return process
     })
 
     await import('./start-server.js')
     await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
+    await vi.waitFor(() => expect(sigintHandler).toBeDefined())
 
-    expect(sigintHandler).toBeDefined()
+    sigintHandler?.()
+    await vi.waitFor(() => expect(process.exit).toHaveBeenCalled())
 
-    if (sigintHandler) {
-      sigintHandler!()
-      expect(console.error).toHaveBeenCalledWith('\nShutting down Better Email MCP Server')
-      expect(process.exit).toHaveBeenCalledWith(0)
-    }
+    expect(console.error).toHaveBeenCalledWith('\nShutting down Better Email MCP Server')
+    expect(process.exit).toHaveBeenCalledWith(0)
   })
 
   it('exits with 1 if initServer throws', async () => {
@@ -90,9 +105,51 @@ describe('start-server', () => {
 
     await import('./start-server.js')
     await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
+    await vi.waitFor(() => expect(process.exit).toHaveBeenCalled())
 
-    expect(initServer).toHaveBeenCalled()
     expect(console.error).toHaveBeenCalledWith('Failed to start server:', error)
     expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('does not start the server for --http (isHttp resolves immediately, no SIGINT wait)', async () => {
+    process.argv.push('--http')
+    vi.mocked(initServer).mockResolvedValue(undefined as any)
+
+    await import('./start-server.js')
+    await vi.waitFor(() => expect(initServer).toHaveBeenCalled())
+    await vi.waitFor(() => expect(process.exit).toHaveBeenCalledWith(0))
+
+    // http mode's initServer() already blocks until its own shutdown
+    // completes (transports/http.ts), so serve() must not add a redundant
+    // SIGINT wait -- that would hang the process after a graceful http
+    // shutdown, since the http path's own `process.once('SIGINT', ...)`
+    // handler already consumed the signal.
+    expect(onceSpy).not.toHaveBeenCalled()
+  })
+
+  it('prints version and exits 0 without starting the server', async () => {
+    process.argv.push('--version')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await import('./start-server.js')
+    await vi.waitFor(() => expect(process.exit).toHaveBeenCalled())
+
+    expect(logSpy).toHaveBeenCalledWith('better-email-mcp 0.0.0-test')
+    expect(process.exit).toHaveBeenCalledWith(0)
+    expect(initServer).not.toHaveBeenCalled()
+    logSpy.mockRestore()
+  })
+
+  it('routes config status to the built-in handler (isolated store dir: not configured)', async () => {
+    process.argv.push('config', 'status')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await import('./start-server.js')
+    await vi.waitFor(() => expect(process.exit).toHaveBeenCalled())
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('better-email-mcp: not configured'))
+    expect(process.exit).toHaveBeenCalledWith(0)
+    expect(initServer).not.toHaveBeenCalled()
+    logSpy.mockRestore()
   })
 })

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -1,30 +1,59 @@
 /**
  * Better Email MCP Server Starter
- * Routes: `auth` subcommand → OAuth2 flow, default → MCP server
+ *
+ * Wired via mcp-core's buildCli: `auth` subcommand routes to the OAuth2
+ * device-code CLI (extra handler); bare/flag argv starts the MCP server
+ * (config/relay/doctor/--version/-h built in).
  */
 
+import { buildCli } from '@n24q02m/mcp-core'
 import { runAuth } from '../src/auth-cli.js'
-import { initServer } from '../src/init-server.js'
+import { getVersion, initServer } from '../src/init-server.js'
 
-async function main() {
-  // Route `auth` subcommand to OAuth2 CLI
-  if (process.argv[2] === 'auth') {
-    await runAuth()
-    return
-  }
+const SERVER_NAME = 'better-email-mcp'
 
+/**
+ * `serve` entry point for `buildCli` (bare/flag argv routes here).
+ *
+ * `initServer()` already blocks until shutdown for http mode
+ * (`transports/http.ts` waits on its own SIGINT/SIGTERM handler before
+ * resolving), but for stdio mode `server.connect(transport)` resolves the
+ * instant the stdin listener attaches, not once the session ends. If this
+ * function returned right there, buildCli's
+ * `.then((code) => process.exit(code))` would kill the process immediately
+ * after startup. So stdio keeps this promise pending until SIGINT/SIGTERM,
+ * mirroring the shutdown-wait pattern http already uses.
+ */
+async function serve(): Promise<number | undefined> {
   try {
     await initServer()
-
-    // Keep process running
-    process.on('SIGINT', () => {
-      console.error('\nShutting down Better Email MCP Server')
-      process.exit(0)
-    })
   } catch (error) {
     console.error('Failed to start server:', error)
-    process.exit(1)
+    return 1
   }
+
+  const isHttp =
+    process.argv.includes('--http') || process.env.MCP_TRANSPORT === 'http' || process.env.TRANSPORT_MODE === 'http'
+  if (isHttp) return 0
+
+  await new Promise<void>((resolve) => {
+    const shutdown = () => {
+      console.error('\nShutting down Better Email MCP Server')
+      resolve()
+    }
+    process.once('SIGINT', shutdown)
+    process.once('SIGTERM', shutdown)
+  })
+  return undefined
 }
 
-main()
+buildCli(SERVER_NAME, {
+  serve,
+  version: getVersion(),
+  extra: {
+    auth: async () => {
+      await runAuth()
+      return 0
+    }
+  }
+})(process.argv.slice(2)).then((code) => process.exit(code))

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -24,7 +24,7 @@ const SERVER_NAME = 'better-email-mcp'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
-function getVersion(): string {
+export function getVersion(): string {
   // Walk up from __dirname to find package.json.
   // Needed because __dirname differs between contexts:
   //   - src/          (dev via tsx)


### PR DESCRIPTION
## Summary
- Wire mcp-core's `buildCli` into `scripts/start-server.ts`, giving `better-email-mcp` the same `doctor`/`config status|delete`/`relay status|open|reset`/`--version`/`-h` CLI built-ins the Python servers (wet/mnemo/telegram/crg) already have (Task W5.1). `pluginName` uses the default `serverName.replace(/-mcp$/, '')` = `better-email`, matching the existing `PerPluginStore("better-email")` slug the HTTP multi-user cred store already uses. The existing `auth <email>` device-code subcommand moves into buildCli's `extra`, behavior unchanged.
- Bump `@n24q02m/mcp-core` to the exact `1.20.0-beta.2` prerelease (a `^` range never resolves to a prerelease build; verified `bun install` resolves `1.20.0-beta.2`).
- Export `init-server.ts`'s existing `getVersion()` instead of a static `../package.json` import: this repo's `tsconfig.json` has `composite: true`, which requires `resolveJsonModule` imports to be covered by an `include` glob — a static package.json import from `scripts/` fails `tsc --noEmit` with `TS6307`. Reusing the pre-existing directory-walking `getVersion()` (already handles dev/build/bin path differences) avoids touching `tsconfig.json`.
- Fix the same premature-exit hazard found in the sibling notion PR: `Server.connect()` for stdio resolves as soon as the transport starts listening, not once the session ends. buildCli's documented usage is `buildCli(...)(argv).then((code) => process.exit(code))`, so without a fix the process would exit right after startup. `serve()` now waits on `SIGINT`/`SIGTERM` before resolving for stdio; `http` mode already blocks inside `transports/http.ts` until its own shutdown handler resolves, so `serve()` skips the extra wait there (adding it unconditionally would hang the process after a graceful http shutdown, since http's own signal handler already consumed the SIGINT).

## Test plan
- [x] `bun run test` — 727/727 pass + 1 pre-existing skip (rewrote `scripts/start-server.test.ts`: auth routing, SIGINT/SIGTERM registration, stdio does-not-exit-early regression guard, SIGINT-triggers-exit(0), initServer-throw exits 1, `--http` skips the extra wait, `--version`, `config status`).
- [x] `bun run check` (biome + tsc) — clean.
- [x] `bun run build` + real binary: `node bin/cli.mjs --version` → `better-email-mcp 1.35.0`; `-h` → usage + `subcommands: auth, config, doctor, relay`; `config status` / `doctor` against an isolated HOME → correct "not configured" / `[warn]` output, store dir `.better-email-mcp`; `auth` (no email arg) → unchanged usage message, exit 1.
- [x] Spawned the built binary with an open stdin pipe (real client-connection shape) and `EMAIL_CREDENTIALS` set: process stays alive past 2s (regression guard), then a simulated `SIGINT` resolves the wait and exits 0.

Note: real OS-level `SIGINT` delivery via `child_process.kill('SIGINT')` isn't reliably testable on Windows (Node/Windows terminates the child directly rather than routing through the JS handler); the shutdown-handler logic itself is covered by a unit test that captures and manually invokes the registered handler. CI runs on `ubuntu-latest` where real signal delivery works as documented.

https://claude.ai/code/session_014BDQppEphd9i2hfu1x35Ns