### PR TITLE
feat: setup_status config action, logout CLI, and BYO client-id flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ src/
   - Local IMAP proxy: `user@custom.com:password:localhost:1993` (`localhost` accepted as host; per-account port)
 - **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `PUBLIC_URL` (for relay/OAuth redirect URLs). Per-user credentials are held in an in-memory store (`auth/in-memory-cred-store.ts`, keyed by JWT `sub`, cleared on restart). `MCP_AUTH_DISABLE=1` skips Bearer JWT verification (for deploys behind an external auth gateway).
 - `PORT` (default `0` = OS-assigned random port), `HOST` (optional bind address)
-- `OUTLOOK_CLIENT_ID` -- tu chon, cho self-hosted OAuth2 client
+- `OUTLOOK_CLIENT_ID` -- tu chon, cho self-hosted OAuth2 client. CLI `auth --client-id=<id>` override env var (flag thang env, xem `auth-cli.ts:parseArgs`)
 
 ## Code conventions
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ The package ships one binary, `better-email-mcp` (run via `npx @n24q02m/better-e
 |:-----------|:------------|
 | `better-email-mcp` | Start the MCP server over **stdio** (default). Reads credentials from `EMAIL_CREDENTIALS`, or from `EMAIL_USER` + `EMAIL_APP_PASSWORD` |
 | `better-email-mcp --http` | Start the server in **HTTP** (multi-user, OAuth 2.1) mode. Equivalent to `MCP_TRANSPORT=http` or `TRANSPORT_MODE=http` |
-| `better-email-mcp auth <email>` | Authenticate an Outlook/Hotmail/Live account via OAuth2 Device Code flow. Tokens are saved to `~/.better-email-mcp/tokens.json` |
+| `better-email-mcp auth [outlook] <email> [--client-id=<id>]` | Authenticate an Outlook/Hotmail/Live account via OAuth2 Device Code flow. Tokens are saved to `~/.better-email-mcp/tokens.json`. The `outlook` provider positional is optional (email has a single OAuth2 provider); `--client-id` overrides `OUTLOOK_CLIENT_ID` for a self-hosted Azure AD app |
+| `better-email-mcp logout [<email>]` | Clear the locally stored Outlook token(s). Omit `<email>` to clear every stored token |
 
 ```bash
 # stdio server (normally launched by your MCP client, not by hand)
@@ -117,9 +118,12 @@ npx @n24q02m/better-email-mcp --http
 
 # One-off Outlook OAuth device-code sign-in
 npx @n24q02m/better-email-mcp auth user@outlook.com
+
+# Sign out of a single account (or omit the email to clear all)
+npx @n24q02m/better-email-mcp logout user@outlook.com
 ```
 
-`auth` is only for Outlook/Hotmail/Live addresses -- other providers use an App Password in `EMAIL_CREDENTIALS`. See [Remote (HTTP Mode)](#remote-http-mode) for the hosted endpoint and HTTP config.
+`auth`/`logout` are only for Outlook/Hotmail/Live addresses -- other providers use an App Password in `EMAIL_CREDENTIALS`. See [Remote (HTTP Mode)](#remote-http-mode) for the hosted endpoint and HTTP config.
 
 ## Smithery
 
@@ -153,7 +157,7 @@ Full docs at **[mcp.n24q02m.com/servers/better-email-mcp/setup/](https://mcp.n24
 | `folders` | `list` | List mailbox folders |
 | `attachments` | `list`, `download` | List and download email attachments |
 | `send` | `new`, `reply`, `forward` | Compose, reply, and forward emails |
-| `config` | `status`, `setup_start`, `setup_reset`, `setup_complete`, `set`, `cache_clear` | Credential setup via browser relay, status check, reset, re-resolve, cache clear |
+| `config` | `status`, `setup_status`, `setup_start`, `setup_reset`, `setup_complete`, `set`, `cache_clear` | Credential setup via browser relay, status check, reset, re-resolve, cache clear |
 | `config__open_relay` | - | Open the relay configuration form in the browser and return the relay URL |
 | `help` | - | Get full documentation for any tool |
 
@@ -253,7 +257,7 @@ In **stdio mode**, Outlook accounts use an **App Password** instead (Outlook Acc
 | `PORT` | No | `0` (OS-assigned) | Server port (http mode); set explicitly (e.g. `8080`) to bind a fixed port |
 | `HOST` | No | - | Bind address (http mode) |
 | `MCP_AUTH_DISABLE` | No (http) | - | Set to `1` to skip Bearer JWT verification when behind an external auth gateway |
-| `OUTLOOK_CLIENT_ID` | No | `d56f8c71-9f7c-43f4-9934-be29cb6e77b0` (bundled public client) | Override the bundled Azure AD public client for self-hosted Outlook OAuth2 |
+| `OUTLOOK_CLIENT_ID` | No | `d56f8c71-9f7c-43f4-9934-be29cb6e77b0` (bundled public client) | Override the bundled Azure AD public client for self-hosted Outlook OAuth2 (or `--client-id=<id>` on `auth`, which overrides this env var) |
 | `OUTLOOK_EMAIL` | No | - | Workaround when Microsoft device-code response omits the email field |
 
 ### Multiple Accounts

--- a/scripts/start-server.test.ts
+++ b/scripts/start-server.test.ts
@@ -3,11 +3,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { setHomeDirForTesting } from '@n24q02m/mcp-core/storage'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { runAuth } from '../src/auth-cli.js'
+import { runAuth, runLogout } from '../src/auth-cli.js'
 import { initServer } from '../src/init-server.js'
 
 vi.mock('../src/auth-cli.js', () => ({
-  runAuth: vi.fn()
+  runAuth: vi.fn(),
+  runLogout: vi.fn()
 }))
 
 vi.mock('../src/init-server.js', () => ({
@@ -48,6 +49,18 @@ describe('start-server (buildCli wiring)', () => {
     await vi.waitFor(() => expect(runAuth).toHaveBeenCalled())
 
     expect(runAuth).toHaveBeenCalled()
+    expect(initServer).not.toHaveBeenCalled()
+    expect(process.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('routes the "logout" subcommand to runLogout and does not start the server', async () => {
+    process.argv.push('logout')
+    vi.mocked(runLogout).mockResolvedValue(undefined)
+
+    await import('./start-server.js')
+    await vi.waitFor(() => expect(runLogout).toHaveBeenCalled())
+
+    expect(runLogout).toHaveBeenCalled()
     expect(initServer).not.toHaveBeenCalled()
     expect(process.exit).toHaveBeenCalledWith(0)
   })

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -1,13 +1,13 @@
 /**
  * Better Email MCP Server Starter
  *
- * Wired via mcp-core's buildCli: `auth` subcommand routes to the OAuth2
- * device-code CLI (extra handler); bare/flag argv starts the MCP server
- * (config/relay/doctor/--version/-h built in).
+ * Wired via mcp-core's buildCli: `auth`/`logout` subcommands route to the
+ * OAuth2 device-code CLI (extra handlers); bare/flag argv starts the MCP
+ * server (config/relay/doctor/--version/-h built in).
  */
 
 import { buildCli } from '@n24q02m/mcp-core'
-import { runAuth } from '../src/auth-cli.js'
+import { runAuth, runLogout } from '../src/auth-cli.js'
 import { getVersion, initServer } from '../src/init-server.js'
 
 const SERVER_NAME = 'better-email-mcp'
@@ -53,6 +53,10 @@ buildCli(SERVER_NAME, {
   extra: {
     auth: async () => {
       await runAuth()
+      return 0
+    },
+    logout: async () => {
+      await runLogout()
       return 0
     }
   }

--- a/src/auth-cli.test.ts
+++ b/src/auth-cli.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { runAuth } from './auth-cli.js'
-import { deviceCodeAuth, isOutlookDomain } from './tools/helpers/oauth2.js'
+import { runAuth, runLogout } from './auth-cli.js'
+import { deleteStoredTokens, deviceCodeAuth, isOutlookDomain } from './tools/helpers/oauth2.js'
 
 vi.mock('./tools/helpers/oauth2.js', () => ({
   deviceCodeAuth: vi.fn(),
-  isOutlookDomain: vi.fn()
+  isOutlookDomain: vi.fn(),
+  deleteStoredTokens: vi.fn()
 }))
 
 describe('runAuth', () => {
@@ -34,7 +35,7 @@ describe('runAuth', () => {
   it('should exit with 1 and print usage if no email is provided', async () => {
     await expect(runAuth()).rejects.toThrow('process.exit called with 1')
 
-    expect(console.error).toHaveBeenCalledWith('Usage: better-email-mcp auth <email>')
+    expect(console.error).toHaveBeenCalledWith('Usage: better-email-mcp auth [outlook] <email> [--client-id=<id>]')
     expect(console.error).toHaveBeenCalledWith('Example: better-email-mcp auth user@outlook.com')
     expect(console.error).toHaveBeenCalledWith('')
     expect(console.error).toHaveBeenCalledWith(
@@ -107,5 +108,97 @@ describe('runAuth', () => {
 
     expect(console.error).toHaveBeenCalledWith('\nError: String error')
     expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('should accept an optional leading "outlook" provider positional', async () => {
+    process.argv.push('outlook', 'user@outlook.com')
+    vi.mocked(isOutlookDomain).mockReturnValue(true)
+    vi.mocked(deviceCodeAuth).mockResolvedValue({} as any)
+
+    await runAuth()
+
+    expect(isOutlookDomain).toHaveBeenCalledWith('user@outlook.com')
+    expect(deviceCodeAuth).toHaveBeenCalledWith('user@outlook.com')
+  })
+
+  it('should thread a --client-id=<id> flag through to deviceCodeAuth', async () => {
+    process.argv.push('user@outlook.com', '--client-id=my-azure-app')
+    vi.mocked(isOutlookDomain).mockReturnValue(true)
+    vi.mocked(deviceCodeAuth).mockResolvedValue({} as any)
+
+    await runAuth()
+
+    expect(deviceCodeAuth).toHaveBeenCalledWith('user@outlook.com', 'my-azure-app')
+  })
+
+  it('should thread a separate --client-id <id> flag through to deviceCodeAuth', async () => {
+    process.argv.push('user@outlook.com', '--client-id', 'my-azure-app')
+    vi.mocked(isOutlookDomain).mockReturnValue(true)
+    vi.mocked(deviceCodeAuth).mockResolvedValue({} as any)
+
+    await runAuth()
+
+    expect(deviceCodeAuth).toHaveBeenCalledWith('user@outlook.com', 'my-azure-app')
+  })
+})
+
+describe('runLogout', () => {
+  const originalArgv = process.argv
+  const originalConsoleError = console.error
+
+  beforeEach(() => {
+    process.argv = ['node', 'script.js', 'logout']
+    console.error = vi.fn()
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    console.error = originalConsoleError
+    vi.clearAllMocks()
+  })
+
+  it('deletes the token for the given email and reports it', async () => {
+    process.argv.push('user@outlook.com')
+    vi.mocked(deleteStoredTokens).mockResolvedValue(['user@outlook.com'])
+
+    await runLogout()
+
+    expect(deleteStoredTokens).toHaveBeenCalledWith('user@outlook.com')
+    expect(console.error).toHaveBeenCalledWith('Logged out. Cleared token(s) for: user@outlook.com')
+  })
+
+  it('accepts an optional leading "outlook" provider positional', async () => {
+    process.argv.push('outlook', 'user@outlook.com')
+    vi.mocked(deleteStoredTokens).mockResolvedValue(['user@outlook.com'])
+
+    await runLogout()
+
+    expect(deleteStoredTokens).toHaveBeenCalledWith('user@outlook.com')
+  })
+
+  it('clears every stored token when no email is given', async () => {
+    vi.mocked(deleteStoredTokens).mockResolvedValue(['a@outlook.com', 'b@outlook.com'])
+
+    await runLogout()
+
+    expect(deleteStoredTokens).toHaveBeenCalledWith(undefined)
+    expect(console.error).toHaveBeenCalledWith('Logged out. Cleared token(s) for: a@outlook.com, b@outlook.com')
+  })
+
+  it('reports nothing to log out when there is no saved token for the email', async () => {
+    process.argv.push('user@outlook.com')
+    vi.mocked(deleteStoredTokens).mockResolvedValue([])
+
+    await runLogout()
+
+    expect(console.error).toHaveBeenCalledWith('Nothing to log out (no saved token for user@outlook.com).')
+  })
+
+  it('reports nothing to log out when there are no saved tokens at all', async () => {
+    vi.mocked(deleteStoredTokens).mockResolvedValue([])
+
+    await runLogout()
+
+    expect(console.error).toHaveBeenCalledWith('Nothing to log out (no saved Outlook tokens).')
   })
 })

--- a/src/auth-cli.ts
+++ b/src/auth-cli.ts
@@ -1,16 +1,56 @@
 /**
- * CLI for OAuth2 authentication (Device Code flow)
+ * CLI for OAuth2 authentication (Device Code flow) + local session logout.
  *
- * Usage: npx @n24q02m/better-email-mcp auth user@outlook.com
+ * Usage:
+ *   npx @n24q02m/better-email-mcp auth [outlook] user@outlook.com [--client-id=<id>]
+ *   npx @n24q02m/better-email-mcp logout [user@outlook.com]
+ *
+ * The leading `outlook` provider positional is optional (email has a single
+ * OAuth2 provider today) -- kept for CLI naming parity with wet/mnemo's
+ * `auth <provider>` and telegram's `auth [<provider>]`, per the WS5 CLI/auth
+ * naming standard. `--client-id` is single-user / local-machine only, same
+ * scope as the rest of this CLI (per tool-layout.md CLI Surface invariants).
  */
 
-import { deviceCodeAuth, isOutlookDomain } from './tools/helpers/oauth2.js'
+import { deleteStoredTokens, deviceCodeAuth, isOutlookDomain } from './tools/helpers/oauth2.js'
+
+const KNOWN_PROVIDERS = new Set(['outlook'])
+
+interface ParsedArgs {
+  positionals: string[]
+  clientId: string | null
+}
+
+/** Split CLI args into positionals and the `--client-id[=value]` flag. */
+function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = []
+  let clientId: string | null = null
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] as string
+    if (arg.startsWith('--client-id=')) {
+      clientId = arg.slice('--client-id='.length)
+    } else if (arg === '--client-id') {
+      i += 1
+      clientId = argv[i] ?? null
+    } else {
+      positionals.push(arg)
+    }
+  }
+  return { positionals, clientId }
+}
+
+/** Drop a leading known-provider positional (e.g. `outlook`), if present. */
+function stripProvider(positionals: string[]): string[] {
+  const [first, ...rest] = positionals
+  return first && KNOWN_PROVIDERS.has(first.toLowerCase()) ? rest : positionals
+}
 
 export async function runAuth(): Promise<void> {
-  const email = process.argv[3]?.trim()
+  const { positionals, clientId } = parseArgs(process.argv.slice(3))
+  const email = stripProvider(positionals)[0]?.trim()
 
   if (!email) {
-    console.error('Usage: better-email-mcp auth <email>')
+    console.error('Usage: better-email-mcp auth [outlook] <email> [--client-id=<id>]')
     console.error('Example: better-email-mcp auth user@outlook.com')
     console.error('')
     console.error('Authenticates an Outlook/Hotmail/Live account via OAuth2 Device Code flow.')
@@ -25,10 +65,28 @@ export async function runAuth(): Promise<void> {
   }
 
   try {
-    await deviceCodeAuth(email)
+    if (clientId) {
+      await deviceCodeAuth(email, clientId)
+    } else {
+      await deviceCodeAuth(email)
+    }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
     console.error(`\nError: ${message}`)
     process.exit(1)
   }
+}
+
+export async function runLogout(): Promise<void> {
+  const { positionals } = parseArgs(process.argv.slice(3))
+  const email = stripProvider(positionals)[0]?.trim()
+
+  const deleted = await deleteStoredTokens(email || undefined)
+  if (deleted.length === 0) {
+    console.error(
+      email ? `Nothing to log out (no saved token for ${email}).` : 'Nothing to log out (no saved Outlook tokens).'
+    )
+    return
+  }
+  console.error(`Logged out. Cleared token(s) for: ${deleted.join(', ')}`)
 }

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -15,7 +15,15 @@ Check current credential state.
 }
 ```
 
-#### 2. setup_start
+#### 2. setup_status
+Credential/setup state only -- `state` and `setup_url`, without the `accounts` list `status` also returns. Cross-server parity action (matches wet/mnemo/telegram's `config(action="setup_status")`).
+```json
+{
+  "action": "setup_status"
+}
+```
+
+#### 3. setup_start
 Return the current setup URL (the credential form on `/authorize` in HTTP mode). Does not spawn a separate relay session; in stdio mode the URL is `null` (credentials come from env vars).
 ```json
 {
@@ -25,7 +33,7 @@ Return the current setup URL (the credential form on `/authorize` in HTTP mode).
 ```
 *   `force`: (Optional) boolean. Accepted for compatibility; the current implementation does not restart a relay session.
 
-#### 3. setup_reset
+#### 4. setup_reset
 Clear all saved credentials and reset to awaiting_setup state.
 ```json
 {
@@ -33,7 +41,7 @@ Clear all saved credentials and reset to awaiting_setup state.
 }
 ```
 
-#### 4. setup_complete
+#### 5. setup_complete
 Re-check credential state after external config changes (e.g. relay submission).
 ```json
 {
@@ -41,7 +49,7 @@ Re-check credential state after external config changes (e.g. relay submission).
 }
 ```
 
-#### 5. set
+#### 6. set
 Update a runtime setting. Email MCP has no runtime settings; always returns `ok: false`.
 ```json
 {
@@ -49,7 +57,7 @@ Update a runtime setting. Email MCP has no runtime settings; always returns `ok:
 }
 ```
 
-#### 6. cache_clear
+#### 7. cache_clear
 Clear all in-memory caches (sent folder paths, archive folder paths, OAuth token cache).
 Returns the number of cache entries cleared.
 ```json

--- a/src/tools/composite/config.test.ts
+++ b/src/tools/composite/config.test.ts
@@ -139,6 +139,50 @@ describe('config - status', () => {
   })
 })
 
+describe('config - setup_status', () => {
+  it('returns credential state without the accounts list', async () => {
+    mockGetState.mockReturnValue('configured')
+    mockGetSetupUrl.mockReturnValue(null)
+
+    const result = await handleConfig(accounts, { action: 'setup_status' })
+
+    expect(result).toEqual({
+      action: 'setup_status',
+      state: 'configured',
+      setup_url: null
+    })
+    expect(result).not.toHaveProperty('accounts')
+  })
+
+  it('returns setup URL when in setup_in_progress state', async () => {
+    mockGetState.mockReturnValue('setup_in_progress')
+    mockGetSetupUrl.mockReturnValue('https://relay.example.com/setup/abc123')
+
+    const result = await handleConfig(accounts, { action: 'setup_status' })
+
+    expect(result).toEqual({
+      action: 'setup_status',
+      state: 'setup_in_progress',
+      setup_url: 'https://relay.example.com/setup/abc123'
+    })
+  })
+
+  it('derives configured state from per-sub accounts in multi-user mode (same as status)', async () => {
+    mockGetState.mockReturnValue('awaiting_setup')
+    mockGetSetupUrl.mockReturnValue(null)
+
+    const result = await subjectContext.run({ sub: 'sub-123', accounts }, () =>
+      handleConfig(accounts, { action: 'setup_status' })
+    )
+
+    expect(result).toEqual({
+      action: 'setup_status',
+      state: 'configured',
+      setup_url: null
+    })
+  })
+})
+
 describe('config - setup_start', () => {
   it('returns current state and setup URL without triggering relay spawn', async () => {
     mockGetState.mockReturnValue('awaiting_setup')

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -4,7 +4,7 @@
  * Replaces the former `setup` tool with canonical name `config`.
  *
  * Setup actions (credential lifecycle):
- *   status, setup_start, setup_reset, setup_complete
+ *   status, setup_status, setup_start, setup_reset, setup_complete
  *
  * Runtime config actions:
  *   set, cache_clear
@@ -20,7 +20,7 @@ import { _resetTokenCache } from '../helpers/oauth2.js'
 import { clearArchiveFolderCache } from './messages.js'
 
 export interface ConfigInput {
-  action: 'status' | 'setup_start' | 'setup_reset' | 'setup_complete' | 'set' | 'cache_clear'
+  action: 'status' | 'setup_status' | 'setup_start' | 'setup_reset' | 'setup_complete' | 'set' | 'cache_clear'
   force?: boolean
   key?: string
   value?: string
@@ -31,6 +31,12 @@ interface ConfigStatusResult {
   state: CredentialState
   setup_url: string | null
   accounts: string[]
+}
+
+interface ConfigSetupStatusResult {
+  action: 'setup_status'
+  state: CredentialState
+  setup_url: string | null
 }
 
 interface ConfigSetupStartResult {
@@ -66,6 +72,7 @@ interface ConfigCacheClearResult {
 
 type ConfigResult =
   | ConfigStatusResult
+  | ConfigSetupStatusResult
   | ConfigSetupStartResult
   | ConfigSetupResetResult
   | ConfigSetupCompleteResult
@@ -80,6 +87,9 @@ export async function handleConfig(accounts: AccountConfig[], input: ConfigInput
     switch (input.action) {
       case 'status':
         return handleStatus(accounts)
+
+      case 'setup_status':
+        return handleSetupStatus(accounts)
 
       case 'setup_start':
         return await handleSetupStart(input)
@@ -99,29 +109,45 @@ export async function handleConfig(accounts: AccountConfig[], input: ConfigInput
       default:
         throw createUnknownActionError(
           input.action,
-          'status, setup_start, setup_reset, setup_complete, set, cache_clear'
+          'status, setup_status, setup_start, setup_reset, setup_complete, set, cache_clear'
         )
     }
   })()
 }
 
-function handleStatus(accounts: AccountConfig[]): ConfigStatusResult {
-  // Per-subject status (multi-user / Cloudflare). When the request carries a JWT
-  // `sub` scope, the process-wide single-user `getState()` lifecycle is
-  // meaningless: a per-sub container may only ever READ blobs from KV and never
-  // run the single-user save that flips getState() to 'configured', so it would
-  // forever report 'awaiting_setup' even though the caller's accounts resolved
-  // (the `folders`/`messages` tools work). Derive the state from whether THIS
-  // subject's accounts resolved instead. Single-user (no sub: stdio /
-  // auth-disabled gateway) keeps the global credential-state machine, which also
-  // distinguishes 'setup_in_progress' (Outlook device-code pending).
+// Per-subject credential state (multi-user / Cloudflare). When the request
+// carries a JWT `sub` scope, the process-wide single-user `getState()`
+// lifecycle is meaningless: a per-sub container may only ever READ blobs from
+// KV and never run the single-user save that flips getState() to
+// 'configured', so it would forever report 'awaiting_setup' even though the
+// caller's accounts resolved (the `folders`/`messages` tools work). Derive the
+// state from whether THIS subject's accounts resolved instead. Single-user
+// (no sub: stdio / auth-disabled gateway) keeps the global credential-state
+// machine, which also distinguishes 'setup_in_progress' (Outlook device-code
+// pending). Shared by `status` and `setup_status` so both stay consistent.
+function resolveConfigState(accounts: AccountConfig[]): CredentialState {
   const sub = currentSub()
-  const state: CredentialState = sub ? (accounts.length > 0 ? 'configured' : 'awaiting_setup') : getState()
+  return sub ? (accounts.length > 0 ? 'configured' : 'awaiting_setup') : getState()
+}
+
+function handleStatus(accounts: AccountConfig[]): ConfigStatusResult {
   return {
     action: 'status',
-    state,
+    state: resolveConfigState(accounts),
     setup_url: getSetupUrl(),
     accounts: accounts.map((a) => a.email)
+  }
+}
+
+// Credential/setup-only view of `status` (no `accounts` list), for
+// cross-server tool-surface parity with wet/mnemo/telegram's
+// `config(action="setup_status")`. `status` keeps returning `accounts` too
+// (backward compatible; unchanged behavior).
+function handleSetupStatus(accounts: AccountConfig[]): ConfigSetupStatusResult {
+  return {
+    action: 'setup_status',
+    state: resolveConfigState(accounts),
+    setup_url: getSetupUrl()
   }
 }
 

--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -48,6 +48,7 @@ import {
   _resetBrowserOpenDedupe,
   _resetTokenCache,
   decodeIdTokenSubject,
+  deleteStoredTokens,
   deviceCodeAuth,
   ensureValidToken,
   getClientId,
@@ -871,6 +872,82 @@ describe('saveTokens edge cases', () => {
     const written = JSON.parse(mockWriteFileSync.mock.calls[1]![1] as string)
     expect(written['first@outlook.com']).toEqual(tokens1)
     expect(written['second@outlook.com']).toEqual(tokens2)
+  })
+})
+
+// ============================================================================
+// deleteStoredTokens (CLI `logout`)
+// ============================================================================
+
+describe('deleteStoredTokens', () => {
+  beforeEach(() => {
+    _resetTokenCache()
+    vi.clearAllMocks()
+  })
+
+  it('returns an empty array and does not write when no token file exists', async () => {
+    mockExistsSync.mockReturnValue(false)
+
+    const deleted = await deleteStoredTokens('user@outlook.com')
+
+    expect(deleted).toEqual([])
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('deletes a single stored token by email and preserves the rest', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        'a@outlook.com': { accessToken: 'a', refreshToken: 'a', expiresAt: 1, clientId: 'c' },
+        'b@outlook.com': { accessToken: 'b', refreshToken: 'b', expiresAt: 2, clientId: 'c' }
+      })
+    )
+
+    const deleted = await deleteStoredTokens('A@outlook.com')
+
+    expect(deleted).toEqual(['a@outlook.com'])
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    expect(Object.keys(written)).toEqual(['b@outlook.com'])
+  })
+
+  it('returns an empty array and does not write when the email has no stored token', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ 'a@outlook.com': { accessToken: 'a', refreshToken: 'a', expiresAt: 1, clientId: 'c' } })
+    )
+
+    const deleted = await deleteStoredTokens('missing@outlook.com')
+
+    expect(deleted).toEqual([])
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('clears every stored token when email is omitted', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        'a@outlook.com': { accessToken: 'a', refreshToken: 'a', expiresAt: 1, clientId: 'c' },
+        'b@outlook.com': { accessToken: 'b', refreshToken: 'b', expiresAt: 2, clientId: 'c' }
+      })
+    )
+
+    const deleted = await deleteStoredTokens()
+
+    expect(deleted.sort()).toEqual(['a@outlook.com', 'b@outlook.com'])
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string)
+    expect(written).toEqual({})
+  })
+
+  it('treats a corrupted token file as empty (nothing to delete)', async () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockImplementation(() => {
+      throw new SyntaxError('Unexpected token')
+    })
+
+    const deleted = await deleteStoredTokens('user@outlook.com')
+
+    expect(deleted).toEqual([])
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
   })
 })
 

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -312,6 +312,48 @@ export async function saveTokens(email: string, tokens: OAuth2Tokens, sub?: stri
 }
 
 /**
+ * Delete stored OAuth2 token(s) from the local file store (single-user /
+ * stdio CLI scope only -- HTTP multi-user tokens live in the per-sub KV blob
+ * and are cleared via account-level ``config`` actions, not this CLI path).
+ * Omitting ``email`` clears every stored token. Returns the email keys that
+ * were actually removed (empty array if there was nothing to delete).
+ */
+export async function deleteStoredTokens(email?: string): Promise<string[]> {
+  if (!existsSync(TOKEN_FILE)) {
+    cachedTokenStore = null
+    return []
+  }
+
+  let store: TokenStore
+  try {
+    const data = readFileSync(TOKEN_FILE, 'utf-8')
+    store = parseTokenStore(data) ?? {}
+  } catch {
+    store = {}
+  }
+
+  const deleted: string[] = []
+  if (email) {
+    const key = email.toLowerCase()
+    if (store[key]) {
+      delete store[key]
+      deleted.push(key)
+    }
+  } else {
+    deleted.push(...Object.keys(store))
+    store = {}
+  }
+
+  if (deleted.length === 0) {
+    return deleted
+  }
+
+  cachedTokenStore = store
+  writeFileSync(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 })
+  return deleted
+}
+
+/**
  * Legacy email-keyed ``tokens.json`` write (single-user / stdio). Synchronous so
  * the file side-effect runs before ``saveTokens`` yields — preserving the
  * historical fire-and-forget contract. Creates the config dir if needed; 0600.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -202,7 +202,7 @@ const TOOLS = [
   {
     name: 'config',
     description:
-      'Manage email credential setup and runtime configuration.\n\nSetup actions (credential lifecycle):\n- status: Show current credential state, setup URL, and configured accounts\n- setup_start (-> force): Trigger relay setup session and return the setup URL. Set force=true to restart even if already in progress\n- setup_reset: Clear all saved credentials and reset to awaiting_setup state\n- setup_complete: Re-check credential state after external config changes (e.g. relay submission)\n\nRuntime actions:\n- set: Update runtime settings (email has no runtime settings; returns ok=false)\n- cache_clear: Clear in-memory account and OAuth token caches',
+      'Manage email credential setup and runtime configuration.\n\nSetup actions (credential lifecycle):\n- status: Show current credential state, setup URL, and configured accounts\n- setup_status: Show credential state and setup URL only (no accounts list; cross-server parity action)\n- setup_start (-> force): Trigger relay setup session and return the setup URL. Set force=true to restart even if already in progress\n- setup_reset: Clear all saved credentials and reset to awaiting_setup state\n- setup_complete: Re-check credential state after external config changes (e.g. relay submission)\n\nRuntime actions:\n- set: Update runtime settings (email has no runtime settings; returns ok=false)\n- cache_clear: Clear in-memory account and OAuth token caches',
     annotations: {
       title: 'Config',
       readOnlyHint: false,
@@ -215,7 +215,7 @@ const TOOLS = [
       properties: {
         action: {
           type: 'string',
-          enum: ['status', 'setup_start', 'setup_reset', 'setup_complete', 'set', 'cache_clear'],
+          enum: ['status', 'setup_status', 'setup_start', 'setup_reset', 'setup_complete', 'set', 'cache_clear'],
           description: 'Action to perform'
         },
         force: {


### PR DESCRIPTION
## Summary

Part of S16 UX/asymmetry hardening (WS6 Task W6.3 + WS5 Tasks W5.2 + W5.3), verified against `origin/main` in an isolated worktree.

- **W6.3 (setup_status)**: `config(action="status")` returned `state` + `setup_url` (credential/setup) bundled with `accounts` (domain content). Added a dedicated `setup_status` action returning just the credential/setup fields, for cross-server tool-surface parity with wet/mnemo/telegram's `config(action="setup_status")`. `status` is unchanged (backward-compatible, still includes `accounts`) -- both now share one `resolveConfigState()` helper.
- **W5.2 (auth naming)**: email's CLI was bare `auth <email>` -- no `logout`, no optional provider positional. Standardized to `auth [outlook] <email> [--client-id=<id>]` + a new `logout [<email>]` subcommand (was missing entirely). The `outlook` provider positional is optional (email has a single OAuth2 provider today) but matches the cross-server `auth [<provider>]` contract (wet/mnemo `auth google`, telegram `auth [<provider>]` + deprecated `login` alias). `logout` clears the local Outlook token store via a new `deleteStoredTokens()` helper in `oauth2.ts` -- omit the email to clear every stored token.
- **W5.3 (BYOK)**: `OUTLOOK_CLIENT_ID` was env-var-only. `auth` now also accepts `--client-id=<id>` (or `--client-id <id>`), which overrides the env var, matching the "env AND CLI flag" contract already shipped for wet/mnemo's `auth --client-id`. No client-secret flag needed -- Microsoft's device-code flow for a public client never sends one (confirmed in `oauth2.ts`'s token requests).

Registry tool schema (`config` action enum + description), `src/docs/config.md`, `README.md`, and `CLAUDE.md` updated to match.

## Test plan

- [x] `bun run type-check` -- clean
- [x] `bun run lint` -- clean (biome; 2 pre-existing `biome.json` schema-version infos, unrelated)
- [x] `bun run test` -- 744/745 passing, 1 pre-existing skip (41/42 files), including:
  - new `setup_status` action tests (`config.test.ts`)
  - new `deleteStoredTokens` tests (`oauth2.test.ts`)
  - new `runAuth` provider-positional + `--client-id` flag tests, and new `runLogout` tests (`auth-cli.test.ts`)
  - new `logout` subcommand routing test (`start-server.test.ts`)
- [x] Existing `status`/`auth <email>` behavior unchanged/passing (backward compat verified)