### PR TITLE
fix: honor PUBLIC_URL when building setup URL and startup banner

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -2,7 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { runHttpServer, writeConfig } from '@n24q02m/mcp-core'
 import { ImapFlow } from 'imapflow'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
-import { getMarkSetupComplete, resolveCredentialState, setState } from '../credential-state.js'
+import { getMarkSetupComplete, resolveCredentialState, setSetupUrl, setState } from '../credential-state.js'
 import { loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
@@ -57,7 +57,29 @@ vi.mock('../auth/outlook-device-code.js', () => ({
 }))
 
 // We need to import startHttp AFTER mocks are set up
-import { startHttp } from './http.js'
+import { resolveSetupBaseUrl, startHttp } from './http.js'
+
+describe('resolveSetupBaseUrl', () => {
+  it('prefers PUBLIC_URL over the bind address', () => {
+    expect(resolveSetupBaseUrl('https://mail.example.com', '0.0.0.0', 8080)).toBe('https://mail.example.com')
+  })
+
+  it('strips a trailing slash so the /authorize path is not doubled', () => {
+    expect(resolveSetupBaseUrl('https://mail.example.com/', '0.0.0.0', 8080)).toBe('https://mail.example.com')
+  })
+
+  it('rewrites the 0.0.0.0 wildcard bind to localhost when PUBLIC_URL is unset', () => {
+    expect(resolveSetupBaseUrl(undefined, '0.0.0.0', 8080)).toBe('http://localhost:8080')
+  })
+
+  it('keeps a concrete bind host', () => {
+    expect(resolveSetupBaseUrl(undefined, '127.0.0.1', 3000)).toBe('http://127.0.0.1:3000')
+  })
+
+  it('treats an empty PUBLIC_URL as unset', () => {
+    expect(resolveSetupBaseUrl('', '0.0.0.0', 8080)).toBe('http://localhost:8080')
+  })
+})
 
 describe('http transport', () => {
   let consoleSpy: any
@@ -151,6 +173,24 @@ describe('http transport', () => {
         )
       })
       delete process.env.MCP_PORT
+    })
+
+    it('publishes a setup URL built from PUBLIC_URL, not from the bind address', async () => {
+      // Regression for #1042: the setup URL reported by `config` (status /
+      // setup_status / setup_start) came from the listening socket, so a
+      // container bound to 0.0.0.0 advertised an unreachable
+      // http://0.0.0.0:8080/authorize behind the public hostname.
+      process.env.PUBLIC_URL = 'https://mail.example.com'
+      vi.mocked(runHttpServer).mockResolvedValue({
+        host: '0.0.0.0',
+        port: 8080,
+        close: vi.fn().mockResolvedValue(undefined)
+      } as any)
+
+      await runStartHttpAndTriggerShutdown(async () => {
+        expect(setSetupUrl).toHaveBeenCalledWith('https://mail.example.com/authorize')
+      })
+      delete process.env.PUBLIC_URL
     })
   })
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -268,6 +268,26 @@ function buildOptions(args: {
   }
 }
 
+/** Bind-any wildcards: valid to listen on, never routable from a client. */
+const UNROUTABLE_BIND_HOSTS = new Set(['0.0.0.0', '::', '[::]'])
+
+/**
+ * Resolve the origin used for the `/authorize` setup link and the startup banner.
+ *
+ * `PUBLIC_URL` wins whenever it is set: it is the externally reachable origin that
+ * mcp-core advertises in the OAuth discovery documents and in `config__open_relay`,
+ * so the setup URL must match it or the user is sent to a host that cannot serve
+ * the form. Falling back to the listening address is only correct for a direct
+ * local bind, and `0.0.0.0` / `::` must be rewritten to `localhost` there because
+ * a wildcard bind address is not a destination a client can dial.
+ */
+export function resolveSetupBaseUrl(publicUrl: string | undefined, host: string, port: number): string {
+  const configured = publicUrl?.trim()
+  if (configured) return configured.replace(/\/$/, '')
+  const reachableHost = UNROUTABLE_BIND_HOSTS.has(host) ? 'localhost' : host
+  return `http://${reachableHost}:${port}`
+}
+
 export async function startHttp(): Promise<void> {
   // Share the per-sub credential store with the Outlook token layer so OAuth
   // refresh tokens embed in the SAME per-sub config blob as the account list
@@ -362,9 +382,10 @@ export async function startHttp(): Promise<void> {
 
   const handle = await runHttpServer(serverFactory, options)
 
-  const setupUrl = `http://${handle.host}:${handle.port}/authorize`
+  const baseUrl = resolveSetupBaseUrl(process.env.PUBLIC_URL, handle.host, handle.port)
+  const setupUrl = `${baseUrl}/authorize`
   setSetupUrl(setupUrl)
-  console.error(`[${SERVER_NAME}] HTTP mode on http://${handle.host}:${handle.port}/mcp`)
+  console.error(`[${SERVER_NAME}] HTTP mode on ${baseUrl}/mcp`)
   if (currentAccounts.length === 0) {
     console.error(`[${SERVER_NAME}] Open ${setupUrl} to configure your email accounts`)
   }


### PR DESCRIPTION
## Problem

`config` action `status` (and `setup_status` / `setup_start` / the tools-registry setup prompt) returned `http://0.0.0.0:8080/authorize` on the deployed server, an address no client can reach. Reproduced live against https://email.n24q02m.com.

`config__open_relay` returned the correct `https://email.n24q02m.com/authorize` because mcp-core's `buildOpenRelayHandler` takes `publicUrl` — proving `PUBLIC_URL` was present in the container and only this code path ignored it.

## Root cause

`src/transports/http.ts` built the setup URL from the listening socket:

```ts
const setupUrl = `http://${handle.host}:${handle.port}/authorize`
setSetupUrl(setupUrl)
```

`0.0.0.0` is a bind-any wildcard, not a destination. `setSetupUrl` writes a module-global read by `tools/composite/config.ts` (status, setup_status, setup_start) and `tools/registry.ts`, so one bad value corrupted four surfaces plus both startup banner lines.

## Fix

Resolve the origin through one exported pure function:

- `PUBLIC_URL` wins when set, with a trailing slash stripped (same normalization as mcp-core's `buildOpenRelayHandler`) so `/authorize` is never doubled.
- Otherwise fall back to the bind address, rewriting the `0.0.0.0` / `::` / `[::]` wildcards to `localhost`.

The resolved base URL now feeds the setup URL and both banner lines.

## Tests

Six new cases in `src/transports/http.test.ts`: five unit cases on `resolveSetupBaseUrl` (PUBLIC_URL wins / trailing slash / wildcard fallback / concrete host preserved / empty string treated as unset) and one wiring regression asserting `setSetupUrl` receives the `PUBLIC_URL`-derived value while the server is bound to `0.0.0.0`. The wiring test was confirmed to fail against the pre-fix call site.

`bun run check` exit 0. `bun run test`: 750 passed, 1 skipped, 41 files.

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1EQo9LQEYzqWUSUjGzeSE
