### PR TITLE
feat: derive a stable subject from the workspace username

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "1.20.0",
+        "@n24q02m/mcp-core": "1.21.0-beta.1",
         "html-to-text": "^10.0.0",
         "imapflow": "^1.4.6",
         "mailparser": "^3.9.14",
@@ -200,7 +200,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.20.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-l7oeOucnWU50LVvmfQkMNF5RApDIW9FZPuKp1i+gzKnsTR/iPDrhDFBrNZXN9hZAZ+tO1K13eS6IFS/uAogfDQ=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.21.0-beta.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-9z909iu36x8J00xBapC3lfFA3QcgIhJ3xxHkCBEtEDXpsdfoYSO53l0e4U1JpZiK5kbNRXEASdgit65qWJjXig=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "1.20.0",
+    "@n24q02m/mcp-core": "1.21.0-beta.1",
     "html-to-text": "^10.0.0",
     "imapflow": "^1.4.6",
     "mailparser": "^3.9.14",

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -22,7 +22,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { NextStep, RunHttpServerOptions, SubjectContext } from '@n24q02m/mcp-core'
-import { renderCredentialForm, runHttpServer, writeConfig } from '@n24q02m/mcp-core'
+import { runHttpServer, writeConfig } from '@n24q02m/mcp-core'
 import { ImapFlow } from 'imapflow'
 
 import { PerSubCredStore } from '../auth/cred-store.js'
@@ -261,7 +261,14 @@ function buildOptions(args: {
     port,
     host,
     onCredentialsSaved,
-    customCredentialFormHtml: renderCredentialForm,
+    // Opt in to the username-derived stable subject, so a returning user reaches
+    // the same per-`sub` bucket instead of the one-off subject minted for each
+    // /authorize round-trip. No `customCredentialFormHtml` here on purpose: it
+    // used to pass mcp-core's own `renderCredentialForm` straight back to
+    // mcp-core, and a custom renderer suppresses the workspace-username field
+    // because the OAuth app only forwards `includeUsernameField` to its default
+    // renderer. Letting core render its own form is what makes the field appear.
+    stableSubEnabled: true,
     setupCompleteHook: (markComplete: (key?: string) => void) => {
       setMarkSetupComplete(markComplete)
     }


### PR DESCRIPTION
Part of n24q02m/mcp-core#676, and the half of #1042 that the URL fix could not solve on its own.

Entering the same workspace username in the setup form now lands you in the same per-`sub` bucket, instead of the one-off subject minted for each `/authorize` round-trip. That is what makes credentials entered through a setup link reachable by a client that authorized earlier — previously the only workaround was to remove and re-add the connector.

**Why the diff removes a line rather than adding one:** this server passed `customCredentialFormHtml: renderCredentialForm` — mcp-core's *own* renderer handed straight back to mcp-core, a leftover from the de-fork. It changed nothing about the output, but a custom renderer suppresses the workspace-username field, because the local OAuth app only forwards `includeUsernameField` to its default renderer. Dropping the passthrough lets core render its own form, field included.

Also bumps `@n24q02m/mcp-core` to `1.21.0-beta.1`, which is where `stableSubEnabled` lands. `tsc --noEmit` passing is itself the check that the option exists in the published types.

**One-time migration:** existing users must re-enter credentials once. Nothing is deleted; credentials stored under the old random subject are simply no longer addressed.

Gate: `bun run check` clean, 750 passed / 1 skipped.