### PR TITLE
feat: make the Outlook tenant, scopes and OAuth domains configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ src/
 - **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `PUBLIC_URL` (for relay/OAuth redirect URLs). Per-user credentials are held in an in-memory store (`auth/in-memory-cred-store.ts`, keyed by JWT `sub`, cleared on restart). `MCP_AUTH_DISABLE=1` skips Bearer JWT verification (for deploys behind an external auth gateway).
 - `PORT` (default `0` = OS-assigned random port), `HOST` (optional bind address)
 - `OUTLOOK_CLIENT_ID` -- tu chon, cho self-hosted OAuth2 client. CLI `auth --client-id=<id>` override env var (flag thang env, xem `auth-cli.ts:parseArgs`)
+- `OUTLOOK_TENANT` -- tu chon, tenant cho CA device-code LAN token refresh (`oauth2.ts:getOutlookTenant`). Default `consumers` (stdio/CLI) va `common` (http delegated, `auth/outlook-device-code.ts`). Work/school (Entra ID) can `common` hoac tenant GUID -- refresh token cua work/school danh vao `/consumers` se loi `AADSTS7000012`
+- `OUTLOOK_SCOPES` -- tu chon, danh sach scope cach nhau bang space (`oauth2.ts:getOutlookScopes`). Dung khi grant duoc consent hep hon default (vd IMAP-only, khong SMTP)
+- `OUTLOOK_EXTRA_DOMAINS` -- tu chon, domain cach nhau bang dau phay, gop them vao `OUTLOOK_DOMAINS` de mailbox M365 tren custom domain di duong OAuth thay vi doi password
+- CF deploy: 3 bien tren PHAI nam trong `worker.ts:CONTAINER_ENV_KEYS`, khong forward = set o Worker nhung container khong nhan
 
 ## Code conventions
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ In **stdio mode**, Outlook accounts use an **App Password** instead (Outlook Acc
 | `MCP_AUTH_DISABLE` | No (http) | - | Set to `1` to skip Bearer JWT verification when behind an external auth gateway |
 | `OUTLOOK_CLIENT_ID` | No | `d56f8c71-9f7c-43f4-9934-be29cb6e77b0` (bundled public client) | Override the bundled Azure AD public client for self-hosted Outlook OAuth2 (or `--client-id=<id>` on `auth`, which overrides this env var) |
 | `OUTLOOK_EMAIL` | No | - | Workaround when Microsoft device-code response omits the email field |
+| `OUTLOOK_TENANT` | No | `consumers` (stdio/CLI), `common` (http device-code) | Microsoft directory to sign in against, used for **both** the device-code and the token-refresh endpoint. Set `common` for a work/school (Entra ID) mailbox, or a tenant GUID / verified domain to pin one directory |
+| `OUTLOOK_SCOPES` | No | `https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send offline_access` | Space-separated scope list. Narrow it (e.g. drop `SMTP.Send`) for a read-only deployment — a grant consented with fewer scopes cannot be refreshed against the full list |
+| `OUTLOOK_EXTRA_DOMAINS` | No | - | Comma-separated domains routed to OAuth in addition to `outlook.com`/`hotmail.com`/`live.com`. Needed for a Microsoft 365 mailbox on your own domain, which otherwise looks like a password account |
 
 ### Multiple Accounts
 
@@ -282,6 +285,28 @@ EMAIL_CREDENTIALS=user@custom.com:password:localhost:1993
 Each account can use its own host and port. A non-993 port is treated as
 plaintext/STARTTLS -- the usual shape for a local IMAP proxy (for example
 [email-oauth2-proxy](https://github.com/simonrob/email-oauth2-proxy)).
+
+### Microsoft 365 work/school accounts
+
+A mailbox in a Microsoft 365 organisation -- including one on your own domain --
+signs in through Entra ID rather than the consumer directory, and Microsoft
+disabled basic auth for Exchange Online in 2024, so an App Password is not an
+option. Two settings make it work:
+
+```bash
+# Sign in against the directory that owns the mailbox
+OUTLOOK_TENANT=common                      # or a tenant GUID / verified domain
+
+# Route your own domain to OAuth instead of asking for a password
+OUTLOOK_EXTRA_DOMAINS=company.com
+```
+
+`OUTLOOK_TENANT` applies to the token refresh as well as the initial sign-in --
+refreshing a work/school token against the consumer directory fails with
+`AADSTS7000012: The grant was obtained for a different tenant`.
+
+If the mailbox was consented with a narrower grant (say IMAP but no SMTP), match
+it with `OUTLOOK_SCOPES` so the refresh does not ask for more than was granted.
 
 ### Search Query Language
 
@@ -357,7 +382,8 @@ survive scale-to-zero / container recreate with no re-auth.
    ```
    Optional Outlook overrides -- only to replace the bundled public Azure device-code client
    (default needs no user-side Azure app): `wrangler secret put OUTLOOK_CLIENT_ID` and
-   `wrangler secret put OUTLOOK_EMAIL`.
+   `wrangler secret put OUTLOOK_EMAIL`. For a Microsoft 365 organisation, also set
+   `OUTLOOK_TENANT` (and `OUTLOOK_EXTRA_DOMAINS` for mailboxes on your own domain).
 7. `wrangler deploy`, then open `<YOUR_PUBLIC_URL>/authorize` and complete the browser relay form.
 
 End-users supply their own email credentials -- an App Password via the paste form, or the

--- a/src/auth/outlook-device-code.test.ts
+++ b/src/auth/outlook-device-code.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { buildOutlookUpstream } from './outlook-device-code.js'
 
 describe('buildOutlookUpstream', () => {
+  afterEach(() => {
+    delete process.env.OUTLOOK_TENANT
+    delete process.env.OUTLOOK_SCOPES
+  })
+
   it('constructs correct upstream config for Outlook device code', () => {
     const upstream = buildOutlookUpstream({ clientId: 'test-app' })
     expect(upstream.deviceAuthUrl).toBe('https://login.microsoftonline.com/common/oauth2/v2.0/devicecode')
@@ -13,5 +18,22 @@ describe('buildOutlookUpstream', () => {
       'https://outlook.office.com/SMTP.Send'
     ])
     expect(upstream.pollIntervalMs).toBe(5000)
+  })
+
+  it('honors OUTLOOK_TENANT on both endpoints', () => {
+    process.env.OUTLOOK_TENANT = '72f988bf-86f1-41af-91ab-2d7cd011db47'
+    const upstream = buildOutlookUpstream({ clientId: 'test-app' })
+    expect(upstream.deviceAuthUrl).toBe(
+      'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/devicecode'
+    )
+    expect(upstream.tokenUrl).toBe(
+      'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token'
+    )
+  })
+
+  it('honors OUTLOOK_SCOPES', () => {
+    process.env.OUTLOOK_SCOPES = 'offline_access https://outlook.office.com/IMAP.AccessAsUser.All'
+    const upstream = buildOutlookUpstream({ clientId: 'test-app' })
+    expect(upstream.scopes).toEqual(['offline_access', 'https://outlook.office.com/IMAP.AccessAsUser.All'])
   })
 })

--- a/src/auth/outlook-device-code.ts
+++ b/src/auth/outlook-device-code.ts
@@ -6,19 +6,28 @@
  *   - offline_access                                   -> refresh_token
  *   - https://outlook.office.com/IMAP.AccessAsUser.All -> IMAP mailbox
  *   - https://outlook.office.com/SMTP.Send             -> SMTP send
+ *
+ * Tenant and scopes are overridable (`OUTLOOK_TENANT`, `OUTLOOK_SCOPES`) so an
+ * M365 work/school directory can be targeted; the defaults here are unchanged
+ * (`common`, full IMAP+SMTP grant).
  */
 import type { UpstreamOAuthConfig } from '@n24q02m/mcp-core'
+import { getOutlookScopes, getOutlookTenant } from '../tools/helpers/oauth2.js'
+
+const UPSTREAM_DEFAULT_TENANT = 'common'
+const UPSTREAM_DEFAULT_SCOPES = [
+  'offline_access',
+  'https://outlook.office.com/IMAP.AccessAsUser.All',
+  'https://outlook.office.com/SMTP.Send'
+]
 
 export function buildOutlookUpstream(opts: { clientId: string }): UpstreamOAuthConfig {
+  const authBase = `https://login.microsoftonline.com/${getOutlookTenant(UPSTREAM_DEFAULT_TENANT)}/oauth2/v2.0`
   return {
-    deviceAuthUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode',
-    tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+    deviceAuthUrl: `${authBase}/devicecode`,
+    tokenUrl: `${authBase}/token`,
     clientId: opts.clientId,
-    scopes: [
-      'offline_access',
-      'https://outlook.office.com/IMAP.AccessAsUser.All',
-      'https://outlook.office.com/SMTP.Send'
-    ],
+    scopes: getOutlookScopes(UPSTREAM_DEFAULT_SCOPES),
     pollIntervalMs: 5000
   }
 }

--- a/src/relay-setup.test.ts
+++ b/src/relay-setup.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { assembleEmailCredentials, formatCredentials } from './relay-setup.js'
+import { afterEach, describe, expect, it } from 'vitest'
+import { assembleEmailCredentials, findUnusableAccountCards, formatCredentials } from './relay-setup.js'
 
 describe('formatCredentials', () => {
   it('formats a single email:password pair (legacy format)', () => {
@@ -106,5 +106,58 @@ describe('assembleEmailCredentials', () => {
   it('returns an empty string for an empty or missing array', () => {
     expect(assembleEmailCredentials([])).toBe('')
     expect(assembleEmailCredentials(undefined)).toBe('')
+  })
+})
+
+describe('findUnusableAccountCards', () => {
+  afterEach(() => {
+    delete process.env.OUTLOOK_EXTRA_DOMAINS
+  })
+
+  it('flags a card that carries an email but no password', () => {
+    expect(findUnusableAccountCards([{ email: 'a@gmail.com' }])).toEqual(['a@gmail.com'])
+  })
+
+  it('does not flag Outlook cards — device code needs no password', () => {
+    expect(findUnusableAccountCards([{ email: 'a@outlook.com' }])).toEqual([])
+  })
+
+  it('does not flag a card that has a password', () => {
+    expect(findUnusableAccountCards([{ email: 'a@gmail.com', password: 'p' }])).toEqual([])
+  })
+
+  it('does not flag a custom domain routed to OAuth via OUTLOOK_EXTRA_DOMAINS', () => {
+    process.env.OUTLOOK_EXTRA_DOMAINS = 'company.com'
+    expect(findUnusableAccountCards([{ email: 'user@company.com' }])).toEqual([])
+  })
+
+  it('reports every unusable card, not just the first', () => {
+    expect(
+      findUnusableAccountCards([
+        { email: 'a@gmail.com' },
+        { email: 'b@gmail.com', password: 'p' },
+        { email: 'c@yahoo.com', password: '  ' }
+      ])
+    ).toEqual(['a@gmail.com', 'c@yahoo.com'])
+  })
+
+  it('ignores cards without an email — the form already requires one', () => {
+    expect(findUnusableAccountCards([{ password: 'p' }])).toEqual([])
+  })
+
+  it('returns an empty array for an empty or missing array', () => {
+    expect(findUnusableAccountCards([])).toEqual([])
+    expect(findUnusableAccountCards(undefined)).toEqual([])
+  })
+})
+
+describe('assembleEmailCredentials with OUTLOOK_EXTRA_DOMAINS', () => {
+  afterEach(() => {
+    delete process.env.OUTLOOK_EXTRA_DOMAINS
+  })
+
+  it('emits email-only for a custom domain listed as an OAuth domain', () => {
+    process.env.OUTLOOK_EXTRA_DOMAINS = 'company.com'
+    expect(assembleEmailCredentials([{ email: 'user@company.com' }])).toBe('user@company.com')
   })
 })

--- a/src/relay-setup.ts
+++ b/src/relay-setup.ts
@@ -84,3 +84,27 @@ export function assembleEmailCredentials(accounts: EmailAccountCard[] | undefine
   }
   return parts.join(',')
 }
+
+/**
+ * Emails of the cards `assembleEmailCredentials` would drop: an address was
+ * typed but no password, and the domain is not on the OAuth path. The encoder
+ * skips those silently — correct for an encoder, wrong as the end of the story,
+ * because the submitter sees no error and nothing happens (reported in #1049
+ * for an M365 custom domain). The transport calls this first and names them.
+ */
+export function findUnusableAccountCards(accounts: EmailAccountCard[] | undefined): string[] {
+  if (!Array.isArray(accounts)) {
+    return []
+  }
+  const unusable: string[] = []
+  for (const account of accounts) {
+    const email = (account?.email ?? '').trim()
+    if (!email || isOutlookDomain(email)) {
+      continue
+    }
+    if (!(account?.password ?? '').trim()) {
+      unusable.push(email)
+    }
+  }
+  return unusable
+}

--- a/src/tools/helpers/oauth2.test.ts
+++ b/src/tools/helpers/oauth2.test.ts
@@ -52,6 +52,8 @@ import {
   deviceCodeAuth,
   ensureValidToken,
   getClientId,
+  getOutlookScopes,
+  getOutlookTenant,
   initiateOutlookDeviceCode,
   isOutlookDomain,
   isValidTokenStore,
@@ -1561,5 +1563,191 @@ describe('decodeIdTokenSubject', () => {
     const payload = Buffer.from(JSON.stringify({ other: 'claim' })).toString('base64url')
     const idToken = `header.${payload}.signature`
     expect(decodeIdTokenSubject(idToken)).toBeNull()
+  })
+})
+
+// ============================================================================
+// Configurable tenant / scopes / extra OAuth domains (#1049)
+// ============================================================================
+
+describe('getOutlookTenant', () => {
+  afterEach(() => {
+    delete process.env.OUTLOOK_TENANT
+  })
+
+  it('falls back to the caller default when OUTLOOK_TENANT is unset', () => {
+    expect(getOutlookTenant('consumers')).toBe('consumers')
+  })
+
+  it('returns OUTLOOK_TENANT when set', () => {
+    process.env.OUTLOOK_TENANT = 'common'
+    expect(getOutlookTenant('consumers')).toBe('common')
+  })
+
+  it('accepts a tenant GUID', () => {
+    process.env.OUTLOOK_TENANT = '72f988bf-86f1-41af-91ab-2d7cd011db47'
+    expect(getOutlookTenant('consumers')).toBe('72f988bf-86f1-41af-91ab-2d7cd011db47')
+  })
+
+  it('accepts a verified tenant domain', () => {
+    process.env.OUTLOOK_TENANT = 'contoso.onmicrosoft.com'
+    expect(getOutlookTenant('consumers')).toBe('contoso.onmicrosoft.com')
+  })
+
+  it('ignores a blank value', () => {
+    process.env.OUTLOOK_TENANT = '   '
+    expect(getOutlookTenant('consumers')).toBe('consumers')
+  })
+
+  it('rejects a value carrying path separators so it cannot reshape the endpoint URL', () => {
+    process.env.OUTLOOK_TENANT = '../../evil'
+    expect(getOutlookTenant('consumers')).toBe('consumers')
+  })
+})
+
+describe('getOutlookScopes', () => {
+  afterEach(() => {
+    delete process.env.OUTLOOK_SCOPES
+  })
+
+  it('defaults to IMAP + SMTP + offline_access', () => {
+    expect(getOutlookScopes()).toEqual([
+      'https://outlook.office.com/IMAP.AccessAsUser.All',
+      'https://outlook.office.com/SMTP.Send',
+      'offline_access'
+    ])
+  })
+
+  it('parses a space-separated OUTLOOK_SCOPES', () => {
+    process.env.OUTLOOK_SCOPES = 'https://outlook.office.com/IMAP.AccessAsUser.All offline_access'
+    expect(getOutlookScopes()).toEqual(['https://outlook.office.com/IMAP.AccessAsUser.All', 'offline_access'])
+  })
+
+  it('collapses extra whitespace between scopes', () => {
+    process.env.OUTLOOK_SCOPES = '  offline_access   https://outlook.office.com/IMAP.AccessAsUser.All  '
+    expect(getOutlookScopes()).toEqual(['offline_access', 'https://outlook.office.com/IMAP.AccessAsUser.All'])
+  })
+
+  it('ignores a blank value', () => {
+    process.env.OUTLOOK_SCOPES = '   '
+    expect(getOutlookScopes()).toEqual([
+      'https://outlook.office.com/IMAP.AccessAsUser.All',
+      'https://outlook.office.com/SMTP.Send',
+      'offline_access'
+    ])
+  })
+})
+
+describe('isOutlookDomain with OUTLOOK_EXTRA_DOMAINS', () => {
+  afterEach(() => {
+    delete process.env.OUTLOOK_EXTRA_DOMAINS
+  })
+
+  it('routes a listed custom domain to the OAuth path', () => {
+    process.env.OUTLOOK_EXTRA_DOMAINS = 'company.com'
+    expect(isOutlookDomain('user@company.com')).toBe(true)
+  })
+
+  it('accepts a comma-separated list with whitespace and mixed case', () => {
+    process.env.OUTLOOK_EXTRA_DOMAINS = ' Company.com , other.co.uk '
+    expect(isOutlookDomain('user@company.com')).toBe(true)
+    expect(isOutlookDomain('user@OTHER.CO.UK')).toBe(true)
+  })
+
+  it('leaves unlisted domains on the password path', () => {
+    process.env.OUTLOOK_EXTRA_DOMAINS = 'company.com'
+    expect(isOutlookDomain('user@gmail.com')).toBe(false)
+  })
+
+  it('keeps the built-in domains when the list is empty', () => {
+    process.env.OUTLOOK_EXTRA_DOMAINS = '   '
+    expect(isOutlookDomain('user@outlook.com')).toBe(true)
+    expect(isOutlookDomain('user@company.com')).toBe(false)
+  })
+})
+
+describe('tenant and scopes reach the Microsoft endpoints (#1049)', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+    _getPendingAuths().clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    _getPendingAuths().clear()
+    delete process.env.OUTLOOK_TENANT
+    delete process.env.OUTLOOK_SCOPES
+  })
+
+  it('refreshes against the configured tenant instead of /consumers', async () => {
+    process.env.OUTLOOK_TENANT = 'common'
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'at', refresh_token: 'rt', expires_in: 3600, token_type: 'Bearer' })
+    })
+
+    await refreshAccessToken('client-id', 'refresh-token')
+
+    expect(mockFetch.mock.calls[0]![0]).toBe('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+  })
+
+  it('defaults the refresh endpoint to /consumers when no tenant is configured', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'at', refresh_token: 'rt', expires_in: 3600, token_type: 'Bearer' })
+    })
+
+    await refreshAccessToken('client-id', 'refresh-token')
+
+    expect(mockFetch.mock.calls[0]![0]).toBe('https://login.microsoftonline.com/consumers/oauth2/v2.0/token')
+  })
+
+  it('sends the configured scopes when refreshing', async () => {
+    process.env.OUTLOOK_SCOPES = 'https://outlook.office.com/IMAP.AccessAsUser.All offline_access'
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'at', refresh_token: 'rt', expires_in: 3600, token_type: 'Bearer' })
+    })
+
+    await refreshAccessToken('client-id', 'refresh-token')
+
+    const body = mockFetch.mock.calls[0]![1].body as URLSearchParams
+    expect(body.get('scope')).toBe('https://outlook.office.com/IMAP.AccessAsUser.All offline_access')
+  })
+
+  it('requests the device code from the configured tenant', async () => {
+    process.env.OUTLOOK_TENANT = 'common'
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        device_code: 'dc',
+        user_code: 'UC-123',
+        verification_uri: 'https://microsoft.com/link',
+        expires_in: 900,
+        interval: 5,
+        message: ''
+      })
+    })
+
+    await initiateOutlookDeviceCode('user@company.com')
+
+    expect(mockFetch.mock.calls[0]![0]).toBe('https://login.microsoftonline.com/common/oauth2/v2.0/devicecode')
+  })
+
+  it('sends the configured scopes in the device-code request', async () => {
+    process.env.OUTLOOK_SCOPES = 'offline_access https://outlook.office.com/IMAP.AccessAsUser.All'
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        device_code: 'dc',
+        user_code: 'UC-456',
+        verification_uri: 'https://microsoft.com/link',
+        expires_in: 900,
+        interval: 5,
+        message: ''
+      })
+    })
+
+    await initiateOutlookDeviceCode('scoped@company.com')
+
+    const body = mockFetch.mock.calls[0]![1].body as URLSearchParams
+    expect(body.get('scope')).toBe('offline_access https://outlook.office.com/IMAP.AccessAsUser.All')
   })
 })

--- a/src/tools/helpers/oauth2.ts
+++ b/src/tools/helpers/oauth2.ts
@@ -16,21 +16,74 @@ import { currentSub } from '../../auth/subject-context.js'
 import { getMarkSetupComplete, setState } from '../../credential-state.js'
 import { isSafeUrl } from './security.js'
 
-// Microsoft OAuth2 endpoints — "consumers" tenant for personal Microsoft accounts
-const TENANT = 'consumers'
-const AUTH_BASE = `https://login.microsoftonline.com/${TENANT}/oauth2/v2.0`
-const DEVICE_CODE_URL = `${AUTH_BASE}/devicecode`
-const TOKEN_URL = `${AUTH_BASE}/token`
+// Microsoft OAuth2 endpoints. The tenant segment decides which directory signs
+// the user in: "consumers" = personal Microsoft accounts, "common" = personal
+// plus work/school (Entra ID), or a specific tenant GUID / verified domain.
+// It is configurable because a work/school mailbox can neither complete the
+// device-code flow nor refresh a token minted elsewhere against /consumers —
+// the refresh fails with AADSTS7000012 (grant obtained for a different tenant).
+const DEFAULT_TENANT = 'consumers'
+
+// The tenant is interpolated into the endpoint path, so keep it to the shapes
+// Microsoft actually accepts (GUID, "common"/"consumers"/"organizations", or a
+// verified domain). Anything carrying a separator is refused rather than
+// reshaping the URL.
+const TENANT_PATTERN = /^[A-Za-z0-9._-]+$/
+
+let warnedInvalidTenant: string | null = null
+
+/**
+ * Tenant used for the device-code and token endpoints. ``OUTLOOK_TENANT`` wins
+ * when it is set and well-formed; otherwise the caller's default applies (the
+ * two call sites differ: this module historically signs in personal accounts,
+ * the HTTP delegated flow uses "common").
+ */
+export function getOutlookTenant(fallback: string = DEFAULT_TENANT): string {
+  const configured = process.env.OUTLOOK_TENANT?.trim()
+  if (!configured) return fallback
+  if (!TENANT_PATTERN.test(configured)) {
+    if (warnedInvalidTenant !== configured) {
+      warnedInvalidTenant = configured
+      console.error(`[better-email-mcp] Ignoring malformed OUTLOOK_TENANT; falling back to "${fallback}".`)
+    }
+    return fallback
+  }
+  return configured
+}
+
+function authBase(): string {
+  return `https://login.microsoftonline.com/${getOutlookTenant()}/oauth2/v2.0`
+}
+
+function deviceCodeUrl(): string {
+  return `${authBase()}/devicecode`
+}
+
+function tokenUrl(): string {
+  return `${authBase()}/token`
+}
 
 // IMAP + SMTP + offline_access (for refresh tokens)
 // Full resource URL with outlook.office.com — required for personal Microsoft accounts.
 // outlook.office.com (personal/MSA) vs outlook.office365.com (work/school/Entra ID).
 // Short scopes (no URL) produce Microsoft Graph tokens that Exchange Online IMAP rejects.
-const SCOPES = [
+const DEFAULT_SCOPES = [
   'https://outlook.office.com/IMAP.AccessAsUser.All',
   'https://outlook.office.com/SMTP.Send',
   'offline_access'
 ]
+
+/**
+ * Scopes requested at sign-in and re-sent on refresh. ``OUTLOOK_SCOPES``
+ * (space-separated) overrides the default set — a grant consented with a
+ * narrower scope (IMAP-only, no SMTP) is legitimate for read-only deployments,
+ * and refreshing such a grant against the full list is rejected.
+ */
+export function getOutlookScopes(fallback: string[] = DEFAULT_SCOPES): string[] {
+  const configured = process.env.OUTLOOK_SCOPES?.trim()
+  if (!configured) return [...fallback]
+  return configured.split(/\s+/).filter(Boolean)
+}
 
 // Time constants
 const MS_PER_SECOND = 1000
@@ -148,13 +201,29 @@ export function decodeIdTokenSubject(idToken: unknown): string | null {
 const OUTLOOK_DOMAINS = new Set(['outlook.com', 'hotmail.com', 'live.com'])
 
 /**
- * Check if an email address belongs to an Outlook/Hotmail/Live domain
+ * Additional domains routed to OAuth via ``OUTLOOK_EXTRA_DOMAINS``
+ * (comma-separated). An M365 mailbox on a custom domain looks like any other
+ * address, so without this it is treated as a password account — and Microsoft
+ * disabled basic auth for Exchange Online in 2024, leaving no working path.
+ */
+function extraOutlookDomains(): string[] {
+  const configured = process.env.OUTLOOK_EXTRA_DOMAINS?.trim()
+  if (!configured) return []
+  return configured
+    .split(',')
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+/**
+ * Check if an email address belongs to an Outlook/Hotmail/Live domain, or to a
+ * domain the deployment declared as OAuth-backed via ``OUTLOOK_EXTRA_DOMAINS``.
  */
 export function isOutlookDomain(email: string): boolean {
   const atIndex = email.indexOf('@')
   if (atIndex === -1) return false
   const domain = email.substring(atIndex + 1).toLowerCase()
-  return OUTLOOK_DOMAINS.has(domain)
+  return OUTLOOK_DOMAINS.has(domain) || extraOutlookDomains().includes(domain)
 }
 
 // Bundled Azure AD public client ID for better-email-mcp.
@@ -389,14 +458,14 @@ function saveTokensToFile(emailKey: string, tokens: OAuth2Tokens): void {
  * Microsoft may rotate the refresh token on each use.
  */
 export async function refreshAccessToken(clientId: string, refreshToken: string): Promise<TokenResponse> {
-  const response = await fetch(TOKEN_URL, {
+  const response = await fetch(tokenUrl(), {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       client_id: clientId,
       grant_type: 'refresh_token',
       refresh_token: refreshToken,
-      scope: SCOPES.join(' ')
+      scope: getOutlookScopes().join(' ')
     })
   })
 
@@ -510,12 +579,12 @@ function openBrowser(url: string): void {
  * Request a device code from Microsoft's OAuth2 endpoint.
  */
 async function requestDeviceCode(clientId: string): Promise<DeviceCodeResponse> {
-  const response = await fetch(DEVICE_CODE_URL, {
+  const response = await fetch(deviceCodeUrl(), {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       client_id: clientId,
-      scope: SCOPES.join(' ')
+      scope: getOutlookScopes().join(' ')
     })
   })
 
@@ -553,7 +622,7 @@ function startBackgroundPoll(
     while (Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, pollInterval))
 
-      const response = await fetch(TOKEN_URL, {
+      const response = await fetch(tokenUrl(), {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
@@ -884,7 +953,7 @@ export async function deviceCodeAuth(email: string, clientId?: string): Promise<
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, pollInterval))
 
-    const tokenResponse = await fetch(TOKEN_URL, {
+    const tokenResponse = await fetch(tokenUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -495,6 +495,28 @@ describe('http transport', () => {
           text: 'Email credentials are required. Format: email:app-password'
         })
       })
+
+      it('names the card it cannot use instead of dropping it silently (#1049)', async () => {
+        vi.mocked(isOutlookDomain).mockReturnValue(false)
+
+        const result = await onCredentialsSaved({ accounts: [{ email: 'user@company.com' }] })
+
+        expect(result.type).toBe('error')
+        expect(result.text).toContain('user@company.com')
+        expect(result.text).toContain('OUTLOOK_EXTRA_DOMAINS')
+      })
+
+      it('still reports the unusable card when another card is valid', async () => {
+        vi.mocked(isOutlookDomain).mockReturnValue(false)
+
+        const result = await onCredentialsSaved({
+          accounts: [{ email: 'ok@gmail.com', password: 'p' }, { email: 'user@company.com' }]
+        })
+
+        expect(result.type).toBe('error')
+        expect(result.text).toContain('user@company.com')
+        expect(result.text).not.toContain('ok@gmail.com')
+      })
     })
   })
 })

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -36,7 +36,7 @@ import {
   setState
 } from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
-import { assembleEmailCredentials, type EmailAccountCard } from '../relay-setup.js'
+import { assembleEmailCredentials, type EmailAccountCard, findUnusableAccountCards } from '../relay-setup.js'
 import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain, setOutlookTokenStore } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
@@ -176,6 +176,20 @@ function buildOptions(args: {
     // A direct `EMAIL_CREDENTIALS` string (legacy / non-form POST) is still
     // accepted so the credential contract stays backward-compatible.
     const submitted = creds as { EMAIL_CREDENTIALS?: string; accounts?: EmailAccountCard[] }
+    if (!submitted?.EMAIL_CREDENTIALS?.trim()) {
+      // Tell the submitter which card cannot be used instead of encoding around
+      // it — a password-less card on a non-OAuth domain used to vanish silently.
+      const unusable = findUnusableAccountCards(submitted?.accounts)
+      if (unusable.length > 0) {
+        return {
+          type: 'error',
+          text:
+            `No password given for ${unusable.join(', ')}. ` +
+            'Enter an App Password, or — for a Microsoft 365 mailbox on your own domain — ' +
+            'add the domain to OUTLOOK_EXTRA_DOMAINS so the server signs in with OAuth instead.'
+        }
+      }
+    }
     const raw = submitted?.EMAIL_CREDENTIALS?.trim() || assembleEmailCredentials(submitted?.accounts)
     if (!raw) {
       return { type: 'error', text: 'Email credentials are required. Format: email:app-password' }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -45,6 +45,9 @@ export interface Env {
   MCP_DCR_SERVER_SECRET: string
   OUTLOOK_CLIENT_ID?: string
   OUTLOOK_EMAIL?: string
+  OUTLOOK_TENANT?: string
+  OUTLOOK_SCOPES?: string
+  OUTLOOK_EXTRA_DOMAINS?: string
 }
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the
@@ -61,7 +64,10 @@ const CONTAINER_ENV_KEYS = [
   'MCP_RELAY_PASSWORD',
   'MCP_DCR_SERVER_SECRET',
   'OUTLOOK_CLIENT_ID',
-  'OUTLOOK_EMAIL'
+  'OUTLOOK_EMAIL',
+  'OUTLOOK_TENANT',
+  'OUTLOOK_SCOPES',
+  'OUTLOOK_EXTRA_DOMAINS'
 ] as const
 
 function pickContainerEnv(env: Env): Record<string, string> {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -217,4 +217,22 @@ describe('worker (KV-only)', () => {
     })
     expect(c.envVars).not.toHaveProperty('OUTLOOK_CLIENT_ID')
   })
+
+  test('envVars forwards the Outlook tenant/scope/domain overrides (#1049)', () => {
+    // Without forwarding, these are settable on the Worker but never reach the
+    // container, so an M365 deployment stays broken while looking configured.
+    const c = new EmailContainer(
+      undefined as never,
+      {
+        OUTLOOK_TENANT: 'common',
+        OUTLOOK_SCOPES: 'https://outlook.office.com/IMAP.AccessAsUser.All offline_access',
+        OUTLOOK_EXTRA_DOMAINS: 'company.com'
+      } as never
+    )
+    expect(c.envVars).toEqual({
+      OUTLOOK_TENANT: 'common',
+      OUTLOOK_SCOPES: 'https://outlook.office.com/IMAP.AccessAsUser.All offline_access',
+      OUTLOOK_EXTRA_DOMAINS: 'company.com'
+    })
+  })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,6 +33,10 @@
   //   MCP_DCR_SERVER_SECRET - proof of intentional multi-user deploy.
   //   OUTLOOK_CLIENT_ID     - optional: override the bundled Azure AD public client.
   //   OUTLOOK_EMAIL         - optional: fallback email key for device-code tokens.
+  //   OUTLOOK_TENANT        - optional: directory for device-code AND token refresh
+  //                           ("common" or a tenant GUID for M365 work/school).
+  //   OUTLOOK_SCOPES        - optional: space-separated scope override.
+  //   OUTLOOK_EXTRA_DOMAINS - optional: comma-separated domains routed to OAuth.
   "vars": {
     "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",


### PR DESCRIPTION
Closes #1049. Closes #1052.

Reported by @5rancz, who traced it to the exact constants, confirmed the fix against a live Microsoft 365 tenant, and offered a PR — thank you.

## Why this is a bug, not a missing feature

Microsoft disabled basic auth for Exchange Online in 2024. Combined with a tenant hardcoded to `consumers`, an M365 business mailbox has no working path at all today:

- device-code sign-in never completes for a work/school (Entra ID) account;
- a refresh token obtained elsewhere dies against `/consumers` with `AADSTS7000012: The grant was obtained for a different tenant`;
- a mailbox on a custom domain is not recognised as OAuth-backed, so the form asks for a password that cannot exist — and then discards the card without a word.

One constant caused two of those: `TENANT` fed `AUTH_BASE`, which fed both the device-code URL and the token URL.

## What changed

| Variable | Default | Effect |
|---|---|---|
| `OUTLOOK_TENANT` | `consumers` (stdio/CLI), `common` (HTTP delegated) | Directory used for **both** device-code and token refresh |
| `OUTLOOK_SCOPES` | current IMAP + SMTP + `offline_access` | Space-separated override, for grants consented narrower than the built-in list |
| `OUTLOOK_EXTRA_DOMAINS` | — | Comma-separated domains joined to the built-in Outlook domains |

All three are additive and backward-compatible: **no default behaviour changes.** The two sign-in paths kept the defaults they already had — `consumers` in `oauth2.ts` (personal accounts), `common` in `auth/outlook-device-code.ts` (HTTP delegated flow) — so existing deployments are untouched whether or not they set anything.

Two things beyond the reported shape, both required for the fix to actually work:

- **Worker forwarding.** The three keys are added to `worker.ts` `CONTAINER_ENV_KEYS`. Without it they would be settable on the Worker and never reach the container — the deployment would look configured and behave as before.
- **No more silent drop (#1052).** A card with an email but no password, on a non-OAuth domain, is now rejected by name with both ways out (App Password, or `OUTLOOK_EXTRA_DOMAINS`). Previously it vanished with no error, which is how the custom-domain case failed.

`OUTLOOK_TENANT` is validated against `^[A-Za-z0-9._-]+$` — it is interpolated into the endpoint path, so a value carrying separators is refused (with a one-time warning) instead of reshaping the URL.

On the note about patching a running container: correct, and it is why an env-var solution belongs upstream — the Docker entrypoint runs the esbuild bundle `bin/cli.mjs`, so edits under `build/**` have no runtime effect.

## Tests

Written first, each watched failing before the code existed (28 failing → passing). Full suite: **782 passed, 1 skipped**; `biome check` and `tsc --noEmit` clean.

- tenant reaches the device-code *and* refresh endpoints; defaults to `consumers` when unset; malformed values fall back
- configured scopes reach both requests
- `OUTLOOK_EXTRA_DOMAINS` routes a custom domain to OAuth (comma list, whitespace, mixed case)
- `buildOutlookUpstream` honours both overrides, defaults unchanged
- a password-less card is reported by name, alone and alongside a valid card
- the Worker forwards all three keys into the container

## Still open, deliberately

Refresh re-sends the configured scopes rather than scopes stored with the token. `OUTLOOK_SCOPES` covers the reported case; storing per-token scopes would change the token store shape, so it is left for a separate change if a real setup needs it.

@5rancz — could you verify against your M365 tenant once this is on `main`? The one thing this cannot cover locally is a real work/school directory.