### PR TITLE
fix: record the declined kv.internal security-header proposal in the sentinel ledger

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -55,3 +55,30 @@
 **Vulnerability:** The Cloudflare worker `fetch` handler added security headers (HSTS, X-Content-Type-Options, X-Frame-Options) only to the responses successfully proxied from the Durable Object. All other responses, such as 401 Unauthenticated, 404 Not Found, and 405 Method Not Allowed, were returned without any security headers, exposing these endpoints to MIME-sniffing or clickjacking risks.
 **Learning:** In edge routing patterns like Cloudflare Workers where the edge performs initial authentication or method checking before delegating to another service (like a Durable Object), it is a common blind spot to only secure the "happy path" proxy response. The edge router's own generated responses must also be secured.
 **Prevention:** Implement a global response wrapper function (e.g., `withSecurityHeaders(response: Response)`) that clones and sets standard security headers on *every* outbound response originating from the worker, regardless of the response's status code or source.
+
+## Rejected
+
+Proposals that were reviewed and turned down. They live here, not only in a
+closed PR comment, so the reasoning travels with the file the bot reads.
+
+### Security headers on the `kv.internal` outbound handler (PRs #1041, #1045, #1051 — 2026-07-25)
+
+**Proposed:** wrap every response from `kvOutbound` in `src/worker.ts` with
+`withSecurityHeaders` (`X-Content-Type-Options`, `X-Frame-Options`, HSTS).
+
+**Why not:** those headers are instructions to a *browser*. `kvOutbound` is not
+reachable by one. It is deliberately NOT dispatched from the public `fetch`
+entrypoint — a comment there explains that exposing it would let a caller
+spoofing the `kv.internal` hostname read, write and delete the credential KV
+namespace unauthenticated. It is reached only by the container through
+`@cloudflare/containers`' ContainerProxy, and its response is consumed by an HTTP
+client inside that container. Adding clickjacking/MIME-sniffing directives to
+that channel protects nothing.
+
+The browser-facing surface is already covered: every response returned from the
+`fetch` entrypoint — proxied, 401, 404 and 405 alike — goes through
+`withSecurityHeaders` (the 2026-07-09 and 2026-07-10 entries above).
+
+Note the recurrence pattern: #1041 and #1045 carried an identical diff, and #1051
+repeated it with the helper exported. Three PRs, one idea, because nothing in
+this file recorded that it had been considered and declined.


### PR DESCRIPTION
Closes the root cause behind #1041, #1045 and #1051 — three PRs proposing the same change because nothing in `.jules/sentinel.md` recorded that it had been considered and declined. A closed-PR comment does not travel; the ledger is what the bot reads.

## The proposal, and why it is declined

All three wrap `kvOutbound` responses in `withSecurityHeaders`. Those headers are directives to a browser, and `kvOutbound` cannot be reached by one:

- it is deliberately not dispatched from the public `fetch` entrypoint — the comment there spells out that exposing it would let a caller spoofing the `kv.internal` hostname read, write and delete the credential KV namespace unauthenticated;
- it is reached only by the container via `@cloudflare/containers`' ContainerProxy, and its response is consumed by an HTTP client inside that container.

Clickjacking and MIME-sniffing directives on that channel protect nothing.

The browser-facing surface is already covered — every response out of `fetch`, proxied or self-generated (401 / 404 / 405), goes through `withSecurityHeaders`. That is exactly what the 2026-07-09 and 2026-07-10 ledger entries above describe as landed.

## Recurrence evidence

#1041 and #1045 carry an **identical** diff (same blob hash `fbc84580..666fe15b`); #1051 repeats it with the helper exported for testing. Adding a `## Rejected` section is the fix that stops the fourth one.