### PR TITLE
fix: repair the live protocol harness so it can catch regressions again

### DIFF
--- a/tests/live/mcp-protocol.live.test.ts
+++ b/tests/live/mcp-protocol.live.test.ts
@@ -2,19 +2,28 @@
  * Live MCP Protocol Tests
  *
  * Spawns the actual MCP server via stdio and communicates using JSON-RPC
- * through the official MCP SDK client. Tests work WITHOUT EMAIL_CREDENTIALS
- * to verify plug-and-play UX.
+ * through the official MCP SDK client.
+ *
+ * stdio mode REQUIRES credentials (`init-server.ts` exits with guidance when
+ * they are absent — spec `2026-05-01-stdio-pure-http-multiuser.md` §5.2.1), so
+ * the protocol suite runs with `EMAIL_CREDENTIALS` and is skipped without it.
+ * The unconfigured path is covered separately below, against the real exit.
  */
 
+import { spawn } from 'node:child_process'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-const EXPECTED_TOOLS = ['messages', 'folders', 'attachments', 'send', 'setup', 'help']
+/** Every tool the registry exposes (`src/tools/registry.ts` TOOLS). */
+const EXPECTED_TOOLS = ['messages', 'folders', 'attachments', 'send', 'config', 'config__open_relay', 'help']
 
-const EMAIL_DEPENDENT_TOOLS = ['messages', 'folders', 'attachments', 'send']
+/** Tools carrying their own documentation resource (`email://docs/<name>`). */
+const DOCUMENTED_TOOLS = ['messages', 'folders', 'attachments', 'send', 'config', 'help']
 
-describe('MCP Protocol - Live Server (no EMAIL_CREDENTIALS)', () => {
+const EMAIL_CREDS = process.env.EMAIL_CREDENTIALS ?? ''
+
+describe.skipIf(!EMAIL_CREDS)('MCP Protocol - Live Server (stdio)', () => {
   let client: Client
   let transport: StdioClientTransport
 
@@ -23,10 +32,9 @@ describe('MCP Protocol - Live Server (no EMAIL_CREDENTIALS)', () => {
       command: 'node',
       args: ['bin/cli.mjs'],
       env: {
-        PATH: process.env.PATH ?? '',
-        HOME: process.env.HOME ?? '',
+        ...(process.env as Record<string, string>),
+        EMAIL_CREDENTIALS: EMAIL_CREDS,
         NODE_ENV: 'test'
-        // Intentionally NO EMAIL_CREDENTIALS
       },
       stderr: 'pipe'
     })
@@ -42,7 +50,7 @@ describe('MCP Protocol - Live Server (no EMAIL_CREDENTIALS)', () => {
     it('should connect and report server info', () => {
       const serverVersion = client.getServerVersion()
       expect(serverVersion).toBeDefined()
-      expect(serverVersion?.name).toBe('@n24q02m/better-email-mcp')
+      expect(serverVersion?.name).toBe('better-email-mcp')
       expect(serverVersion?.version).toMatch(/^\d+\.\d+\.\d+/)
     })
 
@@ -59,10 +67,10 @@ describe('MCP Protocol - Live Server (no EMAIL_CREDENTIALS)', () => {
   })
 
   describe('tools/list', () => {
-    it('should return all 5 tools', async () => {
+    it('should return every registered tool', async () => {
       const result = await client.listTools()
       const toolNames = result.tools.map((t) => t.name)
-      expect(toolNames).toHaveLength(6)
+      expect(toolNames).toHaveLength(EXPECTED_TOOLS.length)
       for (const name of EXPECTED_TOOLS) {
         expect(toolNames).toContain(name)
       }
@@ -98,8 +106,8 @@ describe('MCP Protocol - Live Server (no EMAIL_CREDENTIALS)', () => {
   })
 
   describe('help tool', () => {
-    it('should return documentation for each tool', async () => {
-      for (const toolName of EXPECTED_TOOLS) {
+    it('should return documentation for each documented tool', async () => {
+      for (const toolName of DOCUMENTED_TOOLS) {
         const result = await client.callTool({ name: 'help', arguments: { tool_name: toolName } })
         expect(result.isError).toBeFalsy()
         const text = (result.content as Array<{ type: string; text: string }>)[0]?.text
@@ -114,29 +122,6 @@ describe('MCP Protocol - Live Server (no EMAIL_CREDENTIALS)', () => {
       const text = (result.content as Array<{ type: string; text: string }>)[0]?.text
       expect(text).toContain('Invalid tool name')
     })
-  })
-
-  describe('Email-dependent tools return setup hints without credentials', () => {
-    for (const toolName of EMAIL_DEPENDENT_TOOLS) {
-      it(`${toolName} should return no-accounts error with setup instructions`, async () => {
-        const actionMap: Record<string, Record<string, unknown>> = {
-          messages: { action: 'search' },
-          folders: { action: 'list' },
-          attachments: { action: 'list', account: 'test@test.com', uid: 1 },
-          send: { action: 'new', account: 'test@test.com', to: 'a@b.com', subject: 'test', body: 'test' }
-        }
-
-        const result = await client.callTool({
-          name: toolName,
-          arguments: actionMap[toolName]
-        })
-        expect(result.isError).toBe(true)
-        const text = (result.content as Array<{ type: string; text: string }>)[0]?.text
-        expect(text).toBeTruthy()
-        expect(text).toContain('No email accounts configured')
-        expect(text).toContain('EMAIL_CREDENTIALS')
-      })
-    }
   })
 
   describe('unknown tool handling', () => {
@@ -169,4 +154,31 @@ describe('MCP Protocol - Live Server (no EMAIL_CREDENTIALS)', () => {
       expect(result).toBeDefined()
     })
   })
+})
+
+describe('stdio mode without credentials', () => {
+  it('exits with actionable guidance instead of starting a server nobody can use', async () => {
+    const { code, stderr } = await new Promise<{ code: number | null; stderr: string }>((done, fail) => {
+      // Strip both credential shapes so the run is unconfigured regardless of
+      // what the developer has exported locally.
+      const { EMAIL_CREDENTIALS, EMAIL_USER, EMAIL_APP_PASSWORD, ...rest } = process.env
+      const proc = spawn(process.execPath, ['bin/cli.mjs'], {
+        env: { ...rest, NODE_ENV: 'test' },
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+      let err = ''
+      proc.stderr.on('data', (chunk: Buffer) => {
+        err += chunk.toString('utf8')
+      })
+      proc.once('error', fail)
+      proc.once('exit', (exitCode) => done({ code: exitCode, stderr: err }))
+    })
+
+    expect(code).toBe(1)
+    expect(stderr).toContain('Missing required env vars for stdio mode')
+    expect(stderr).toContain('EMAIL_CREDENTIALS')
+    expect(stderr).toContain('EMAIL_APP_PASSWORD')
+    // The alternative path must stay discoverable: HTTP mode needs no env creds.
+    expect(stderr).toContain('HTTP mode')
+  }, 30_000)
 })

--- a/tests/live/stdio-direct.live.test.ts
+++ b/tests/live/stdio-direct.live.test.ts
@@ -11,7 +11,8 @@ import { spawn } from 'node:child_process'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const CLI_PATH = resolve(__dirname, '..', 'bin', 'cli.mjs')
+// This file lives in tests/live/, so the bundle is two levels up — not one.
+const CLI_PATH = resolve(__dirname, '..', '..', 'bin', 'cli.mjs')
 
 interface JsonRpcResponse {
   jsonrpc: '2.0'
@@ -24,10 +25,14 @@ interface JsonRpcResponse {
   error?: { code: number; message: string }
 }
 
-describe('stdio direct mode', () => {
+const EMAIL_CREDS = process.env.EMAIL_CREDENTIALS ?? ''
+
+// stdio mode refuses to start without credentials (init-server.ts), so this
+// suite needs them; the unconfigured exit is asserted in mcp-protocol.live.
+describe.skipIf(!EMAIL_CREDS)('stdio direct mode', () => {
   it('responds to initialize over stdio with correct serverInfo', async () => {
     const proc = spawn(process.execPath, [CLI_PATH], {
-      env: { ...process.env, MCP_TRANSPORT: 'stdio' },
+      env: { ...process.env, EMAIL_CREDENTIALS: EMAIL_CREDS, MCP_TRANSPORT: 'stdio' },
       stdio: ['pipe', 'pipe', 'pipe']
     })
 

--- a/tests/live/vitest.live.config.ts
+++ b/tests/live/vitest.live.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['tests/live/**/*.test.ts'],
-    exclude: ['build/**', 'node_modules/**', 'bin/**']
+    exclude: ['build/**', 'node_modules/**', 'bin/**'],
+    // Every file here spawns a real server process and opens real IMAP/SMTP
+    // connections against one mailbox. Run in parallel they raced each other —
+    // the 15s connect hook timed out — so keep the live suite serial.
+    fileParallelism: false,
+    hookTimeout: 30_000
   }
 })


### PR DESCRIPTION
`tests/live/**` is excluded from the CI run, so nothing was watching these three files. All three had drifted into a state where they could not pass — found while establishing protocol-test coverage for the #1049 release.

## What was broken

| File | Fault | How it looked |
|---|---|---|
| `stdio-direct.live.test.ts` | `resolve(__dirname, '..', 'bin', 'cli.mjs')` from `tests/live/` points at `tests/bin/cli.mjs` | node exited 1 on a missing module; the test said *"process exited before responding"* — reads exactly like a server fault |
| `mcp-protocol.live.test.ts` | expected a tool named `setup` (registry has exposed `config` since the rename) and a server that boots with no credentials (the stdio-pure spec replaced that with an explicit exit) | connect hook timed out, 16 tests skipped |
| `vitest.live.config.ts` | both files spawn a real server + real IMAP against one mailbox, in parallel | intermittent 15s hook timeout |

The path bug is the instructive one: a harness that dies at startup is indistinguishable from "the server is broken" at a glance, which is why the coverage rules call for confirming the harness actually reached the tool call.

## What changed

- Correct the bundle path (two levels up).
- Point the protocol suite at the real tool set (`messages, folders, attachments, send, config, config__open_relay, help`) and run it with credentials, skipping when none are present.
- Assert the unconfigured path against what actually happens: exit code 1 plus guidance naming `EMAIL_CREDENTIALS`, `EMAIL_APP_PASSWORD` and the HTTP alternative. That path had no coverage at all before.
- Run the live suite serially (`fileParallelism: false`) with a 30s hook timeout, since these tests share one mailbox.

## Verification

Against a real Gmail account (app password from skret, first record of the multi-account string):

```
Test Files  3 passed (3)
     Tests  30 passed (30)
```

Three consecutive runs, all green. Covers `folders` listing INBOX, `send.new`, `messages` search/read/mark/flag/move/trash, `send.reply`, `send.forward`, `attachments.list`, plus the protocol surface (tools/list, resources, help, unknown-tool, no-arguments, ping).

Unit suite unaffected: 782 passed, 1 skipped. `biome check` + `tsc --noEmit` clean.