### PR TITLE
fix: bump mcp-core to 1.21.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "1.21.0-beta.2",
+        "@n24q02m/mcp-core": "1.21.0",
         "html-to-text": "^10.0.0",
         "imapflow": "^1.5.0",
         "mailparser": "^3.9.14",
@@ -204,7 +204,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.21.0-beta.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^13.0.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-Cdbm44B7YlVdx03s4pi1JE+S2ntuiOVMySs5yj1bd9o3Mn52zmj8pvwSS3xLSZAWj+hQl2DFBbj7GVsIJkmnaA=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.21.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^13.0.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-CiAJ6cn31QYV1r4RewEArR+vf4Yfr2LsoctW8giuf6V0LmvEj3/0PMyboDt2Ax3as0HzI7tFLyeSQxVdaDc03g=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "1.21.0-beta.2",
+    "@n24q02m/mcp-core": "1.21.0",
     "html-to-text": "^10.0.0",
     "imapflow": "^1.5.0",
     "mailparser": "^3.9.14",


### PR DESCRIPTION
Closes #1057.

Moves the pin off `1.21.0-beta.2` now that the identical code is published as stable, so a released better-email-mcp does not depend on a prerelease artifact.

The behaviour verified against beta.2 — a credential-save error short-circuits to `400 {ok:false, error}` instead of minting an auth code, which is what makes the #1052 message reach the form — is unchanged in 1.21.0.

Verified: bundled `local-oauth-app.js` in the installed 1.21.0 still carries the short-circuit; unit suite 782 passed / 1 skipped; `biome check` + `tsc --noEmit` clean.