### PR TITLE
fix: replace personal deploy host in README with self-host placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ npx @n24q02m/better-email-mcp auth user@outlook.com
 npx @n24q02m/better-email-mcp logout user@outlook.com
 ```
 
-`auth`/`logout` are only for Outlook/Hotmail/Live addresses -- other providers use an App Password in `EMAIL_CREDENTIALS`. See [Remote (HTTP Mode)](#remote-http-mode) for the hosted endpoint and HTTP config.
+`auth`/`logout` are only for Outlook/Hotmail/Live addresses -- other providers use an App Password in `EMAIL_CREDENTIALS`. See [Remote (HTTP Mode)](#remote-http-mode) for the HTTP config.
 
 ## Smithery
 
@@ -199,7 +199,7 @@ Run as a multi-user HTTP server with OAuth 2.1 authentication:
   "mcpServers": {
     "better-email": {
       "type": "http",
-      "url": "https://email.n24q02m.com/mcp"
+      "url": "https://<your-host>/mcp"
     }
   }
 }
@@ -220,7 +220,7 @@ Users provide their own email credentials through the OAuth flow / paste form. N
 
 ### Cloudflare serverless mode (KV-only)
 
-Deploy a per-user serverless instance at `https://email.n24q02m.com`: each JWT `sub`
+Self-hostable as a per-user serverless instance on Cloudflare Workers + Containers: each JWT `sub`
 gets its own Container Durable Object, and all credentials AND Outlook OAuth tokens are
 AES-256-GCM encrypted into Workers KV (one `subs/<sub>/config` blob per user) so they
 **survive scale-to-zero / container recreate with no re-auth**. The JWT signing key is


### PR DESCRIPTION
## Problem

`README.md` pointed readers at `https://email.n24q02m.com` in two places: the HTTP client config block and the Cloudflare serverless section. That host is the repo owner's personal deploy, sitting behind the `MCP_RELAY_PASSWORD` gate on `/authorize` — a reader without that password gets a dead end, and a public page ends up advertising private infrastructure. This README is re-rendered on npm and Docker Hub, so it appeared in three places.

## Change

Describe what the software can do, not what the maintainer happens to be running.

- HTTP client config now uses `https://<your-host>/mcp`, the same placeholder shape as `better-workspace-mcp`.
- The Cloudflare section opens with "Self-hostable as a per-user serverless instance on Cloudflare Workers + Containers". Every technical detail is untouched: per-JWT-`sub` Container Durable Object, AES-256-GCM encryption of credentials and Outlook OAuth tokens into Workers KV, one `subs/<sub>/config` blob per user, the `CREDENTIAL_SECRET`-derived EdDSA key, and the required secrets list.
- The CLI section no longer sends readers to "the hosted endpoint", which stopped existing with the first two changes.

Three lines, no section rewritten.

## Verification

- `grep -oE 'https://(email|notion|telegram|wet|mnemo|imagine|workspace)\.n24q02m\.com[^)"; ]*' README.md` → empty.
- Remaining `n24q02m.com` references are all `mcp.n24q02m.com`, the public docs site (no gate); all four resolve `200`.
- Every link in the file checked with `curl`. All `200` except: `glama.ai` (badge + page) is unreachable site-wide right now — its root and an unrelated server page also fail, so this is a Glama outage, not a bad link, and the markup is unchanged by this PR.
- Headings and TOC anchors unchanged.
- `pre-commit run --files README.md`: gitleaks, trailing-whitespace, merge-conflict, end-of-file, preserve-diacritics all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GHW1vpJJdtvJTwXncF3G
