### PR TITLE
feat: 🎨 palette: add placeholder and validation to IMAP fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,6 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+## 2025-07-28 - Schema-Driven Form Validation and Placeholders
+**Learning:** For dynamic or schema-driven forms, pushing validation patterns (like `^\d+$` for ports) and visual placeholders (like `imap.example.com` for hostnames) down to the schema level ensures immediate client-side feedback and clear guidance for the user. This improves form UX and reduces the chance of bad submissions that cause backend errors.
+**Action:** Always leverage available schema features (like `validation` and `placeholder` in `ConfigField`) to enhance native browser validation and provide in-context hints for complex inputs.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -50,6 +50,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Host',
         type: 'text',
         required: false,
+        placeholder: 'imap.example.com',
         helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
       },
       {
@@ -58,6 +59,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         type: 'text',
         required: false,
         placeholder: '993',
+        validation: '^\\d+$',
         helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
       }
     ]


### PR DESCRIPTION
💡 What: Added `placeholder: 'imap.example.com'` to the `imap_host` field and `validation: '^\\d+$'` to the `imap_port` field in the relay schema. Also recorded this learning in `.jules/palette.md`.
🎯 Why: To provide immediate, client-side visual guidance and validation for complex inputs, preventing bad submissions and improving the user experience during account configuration.
♿ Accessibility: Provides clearer expectations for users configuring custom IMAP servers.

---
*PR created automatically by Jules for task [10158710356105611606](https://jules.google.com/task/10158710356105611606) started by @n24q02m*