### PR TITLE
🛡️ Sentinel: Fix potential DoS in isSafeUrl by adding length limit

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -82,3 +82,8 @@ The browser-facing surface is already covered: every response returned from the
 Note the recurrence pattern: #1041 and #1045 carried an identical diff, and #1051
 repeated it with the helper exported. Three PRs, one idea, because nothing in
 this file recorded that it had been considered and declined.
+
+## 2026-07-28 - DoS via Unbounded URL Parsing
+**Vulnerability:** The `isSafeUrl` function used the `URL` constructor to validate the protocol of a given URL. The constructor is complex and parses the input string, which can become CPU-intensive. Since there was no prior constraint on the length of the string passed into `isSafeUrl`, an extremely long input could lead to a Denial of Service (DoS) due to excessive parsing time and memory allocation before the protocol is even checked.
+**Learning:** Functions that parse user-provided or unverified strings (especially using built-in constructors like `URL` or complex regular expressions) should impose reasonable bounds on the input size before doing the heavy lifting, to protect against algorithmic complexity attacks.
+**Prevention:** Implement length limit checks (e.g., `< 2048` characters for standard URLs) before invoking parsing logic or constructors.

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -109,6 +109,11 @@ describe('isSafeUrl', () => {
   it('blocks URLs with null bytes in protocol (XPIA vector)', () => {
     expect(isSafeUrl('ht\0tp://example.com')).toBe(false)
   })
+
+  it('blocks extremely long URLs to prevent DoS', () => {
+    const longUrl = `http://example.com/${'a'.repeat(3000)}`
+    expect(isSafeUrl(longUrl)).toBe(false)
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -25,6 +25,11 @@ const VALID_TOOL_NAMES = new Set(['messages', 'folders', 'attachments', 'send', 
  * Prevents XSS attacks via javascript:, data:, vbscript:, etc.
  */
 export function isSafeUrl(url: string): boolean {
+  // Prevent DoS from extremely long URLs during parsing
+  if (!url || url.length > 2048) {
+    return false
+  }
+
   try {
     // Try parsing as absolute URL
     const parsed = new URL(url)


### PR DESCRIPTION
🛡️ **Severity:** LOW/MEDIUM
💡 **Vulnerability:** The `isSafeUrl` function uses the `URL` constructor to validate the protocol of a given URL. Since there was no prior constraint on the length of the string passed in, an extremely long input could theoretically lead to a Denial of Service (DoS) due to excessive parsing time and memory allocation before the protocol is even checked.
🎯 **Impact:** Extremely long string inputs could tie up the main thread or cause memory pressure.
🔧 **Fix:** Added a length limit check (max 2048 characters) to `isSafeUrl` before invoking the `URL` constructor.
✅ **Verification:** Unit test added and verified. `bun run test` passes.

---
*PR created automatically by Jules for task [18222101264307067937](https://jules.google.com/task/18222101264307067937) started by @n24q02m*