### PR TITLE
feat: 🎨 palette: add inline validation and placeholders to relay schema

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,6 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+## 2025-05-24 - Declarative Form Validation
+**Learning:** Hardcoded validation logic inside form templates can be brittle and difficult to maintain. Using a declarative schema (like JSON or TS objects) to define validation rules (`pattern`) and placeholders allows for cleaner form generation and consistent UX across different environments (e.g., Python vs. TS servers).
+**Action:** Leverage the shared schema's `validation` and `placeholder` properties when configuring forms to provide immediate client-side feedback and guidance without writing custom JavaScript validation logic.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -50,6 +50,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Host',
         type: 'text',
         required: false,
+        placeholder: 'imap.example.com',
         helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
       },
       {
@@ -58,6 +59,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         type: 'text',
         required: false,
         placeholder: '993',
+        validation: '^\\d+$',
         helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
       }
     ]


### PR DESCRIPTION
Added validation regex to imap_port and a placeholder to imap_host to improve client-side form validation and provide better visual guidance without needing custom JavaScript.

---
*PR created automatically by Jules for task [15794392581063978577](https://jules.google.com/task/15794392581063978577) started by @n24q02m*