### PR TITLE
fix: 🛡️ sentinel: enforce length limit on URL parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -82,3 +82,8 @@ The browser-facing surface is already covered: every response returned from the
 Note the recurrence pattern: #1041 and #1045 carried an identical diff, and #1051
 repeated it with the helper exported. Three PRs, one idea, because nothing in
 this file recorded that it had been considered and declined.
+
+## 2026-07-25 - [DoS via URL Parsing]
+**Vulnerability:** The `isSafeUrl` function in `src/tools/helpers/security.ts` was relying exclusively on the native `URL` constructor without verifying the length of the input. Passing an extremely long string could cause a Denial of Service (DoS) due to CPU exhaustion during URL parsing or memory exhaustion.
+**Learning:** Functions evaluating untrusted or arbitrary input using complex parsers (like the native URL constructor) can be vulnerable to DoS attacks if the input is excessively large.
+**Prevention:** Always enforce strict length limits on strings before passing them to parsing mechanisms like `URL` or `RegExp`, ensuring bounded processing time and memory allocation.

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -109,6 +109,11 @@ describe('isSafeUrl', () => {
   it('blocks URLs with null bytes in protocol (XPIA vector)', () => {
     expect(isSafeUrl('ht\0tp://example.com')).toBe(false)
   })
+
+  it('blocks extremely long URLs to prevent DoS', () => {
+    const longUrl = 'http://example.com/' + 'a'.repeat(3000)
+    expect(isSafeUrl(longUrl)).toBe(false)
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -25,6 +25,10 @@ const VALID_TOOL_NAMES = new Set(['messages', 'folders', 'attachments', 'send', 
  * Prevents XSS attacks via javascript:, data:, vbscript:, etc.
  */
 export function isSafeUrl(url: string): boolean {
+  if (!url || url.length > 2048) {
+    return false
+  }
+
   try {
     // Try parsing as absolute URL
     const parsed = new URL(url)


### PR DESCRIPTION
Enforce a 2048-character length limit in `isSafeUrl` to prevent DoS via the native `URL` constructor. Includes unit tests and journal documentation.

---
*PR created automatically by Jules for task [15126230772964137548](https://jules.google.com/task/15126230772964137548) started by @n24q02m*