### PR TITLE
feat: 🎨 palette: add client-side validation to IMAP port field

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,6 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+## 2026-07-04 - Client-side Regex Validation for Optional Fields
+**Learning:** When adding `validation` patterns to form schemas (e.g., in `mcp-core` relay schemas) for optional fields, using a restrictive regex like `^\d+$` (which requires at least one character) can inadvertently block form submission if the field is left blank, as empty strings will fail the regex.
+**Action:** Always ensure that regex validation for optional fields explicitly allows empty strings by using `*` instead of `+` (e.g., `^\d*$`), or verify that the underlying form framework skips validation for empty non-required fields, to prevent blocking legitimate submissions.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -58,6 +58,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         type: 'text',
         required: false,
         placeholder: '993',
+        validation: '^\\d*$',
         helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
       }
     ]


### PR DESCRIPTION
💡 What: Added `validation: '^\\d*$'` to the `imap_port` field in `src/relay-schema.ts`.
🎯 Why: Provides immediate client-side feedback for the port field, preventing users from submitting non-numeric characters and waiting for a backend error.
📸 Before/After: N/A
♿ Accessibility: Improves form UX by preventing invalid submissions early.

---
*PR created automatically by Jules for task [10018412581019764634](https://jules.google.com/task/10018412581019764634) started by @n24q02m*