### PR TITLE
🛡️ Sentinel: [MEDIUM] Add length validation to isSafeUrl to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -82,3 +82,8 @@ The browser-facing surface is already covered: every response returned from the
 Note the recurrence pattern: #1041 and #1045 carried an identical diff, and #1051
 repeated it with the helper exported. Three PRs, one idea, because nothing in
 this file recorded that it had been considered and declined.
+
+## 2026-07-26 - DoS Vulnerability via Unbounded URL Parsing in isSafeUrl
+**Vulnerability:** The `isSafeUrl` function parsed user-provided URLs using the native `URL` constructor without any prior length validation. An attacker could potentially cause a Denial of Service (DoS) by passing an extremely long string, exhausting CPU or memory resources during parsing.
+**Learning:** Functions that parse complex data structures (like URLs or Regular Expressions) from untrusted input must always enforce strict length limits *before* passing the input to the parser, as these native implementations can be computationally expensive and vulnerable to exhaustion attacks.
+**Prevention:** Enforce a strict maximum length (e.g., 2048 characters) for untrusted strings before performing complex parsing operations like `new URL(url)`.

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -109,6 +109,11 @@ describe('isSafeUrl', () => {
   it('blocks URLs with null bytes in protocol (XPIA vector)', () => {
     expect(isSafeUrl('ht\0tp://example.com')).toBe(false)
   })
+
+  it('blocks extremely long URLs (DoS vector)', () => {
+    const longUrl = `http://example.com/${'a'.repeat(2500)}`
+    expect(isSafeUrl(longUrl)).toBe(false)
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -25,6 +25,9 @@ const VALID_TOOL_NAMES = new Set(['messages', 'folders', 'attachments', 'send', 
  * Prevents XSS attacks via javascript:, data:, vbscript:, etc.
  */
 export function isSafeUrl(url: string): boolean {
+  if (!url || url.length > 2048) {
+    return false
+  }
   try {
     // Try parsing as absolute URL
     const parsed = new URL(url)


### PR DESCRIPTION
Limits URL length to 2048 to prevent DoS attacks on the URL parser.

---
*PR created automatically by Jules for task [1425688227827093492](https://jules.google.com/task/1425688227827093492) started by @n24q02m*