### PR TITLE
feat: 🎨 palette: add inline validation to optional IMAP fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,7 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+
+## 2026-07-04 - Form Field Inline Regex Validation
+**Learning:** For optional fields in generated or schema-driven forms, relying solely on server-side validation can lead to frustrating user experiences (like form submission failing silently or returning cryptic error messages). Client-side HTML5 pattern matching helps, but it needs to be careful not to block submissions when optional fields are intentionally left blank.
+**Action:** When adding regex validation to optional form fields (e.g. `validation` in `RELAY_SCHEMA`), ensure the pattern accommodates empty strings. Use quantifiers like `*` (e.g. `^\S*$` for no whitespace, `^\d*$` for digits only) instead of `+` to allow for deliberate omissions.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -50,6 +50,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Host',
         type: 'text',
         required: false,
+        validation: '^\\S*$',
         helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
       },
       {
@@ -58,6 +59,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         type: 'text',
         required: false,
         placeholder: '993',
+        validation: '^\\d*$',
         helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
       }
     ]


### PR DESCRIPTION
💡 **What:** Added client-side regex validations (`validation`) to the optional `imap_host` and `imap_port` fields in `src/relay-schema.ts`.
🎯 **Why:** To prevent common user errors (like entering spaces in the host or letters in the port) before form submission, providing immediate inline feedback while ensuring that intentional empty states are still allowed.
♿ **Accessibility:** Prevents form submission errors from bubbling up to a generic alert, allowing native browser or custom inline validation to flag the specific incorrect fields immediately.

---
*PR created automatically by Jules for task [16068769284699639005](https://jules.google.com/task/16068769284699639005) started by @n24q02m*