### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce type guarding for authType in credential store

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -82,3 +82,7 @@ The browser-facing surface is already covered: every response returned from the
 Note the recurrence pattern: #1041 and #1045 carried an identical diff, and #1051
 repeated it with the helper exported. Three PRs, one idea, because nothing in
 this file recorded that it had been considered and declined.
+## 2026-08-04 - Strict Type Guarding for Credential Authentication Types
+**Vulnerability:** The `isValidAccount` type guard in `src/auth/cred-store.ts` verified that the `password` field was a string (which is required by the TS type even when empty for OAuth2) but failed to validate the `authType` field. An attacker capable of modifying the encrypted KV credential blob could theoretically inject arbitrary string values into `authType` (e.g. `'admin'`, `'bypass'`), potentially confusing downstream authentication logic that branches on this type.
+**Learning:** Structural validation of JSON payloads must explicitly constrain literal string union types to their allowed values (e.g., `'password' | 'oauth2'`), as `typeof x === 'string'` is insufficient to prevent unexpected states in union-typed properties.
+**Prevention:** Extend the `isValidAccount` validation to explicitly check `if (acc.authType !== undefined && acc.authType !== 'password' && acc.authType !== 'oauth2') return false;` to guarantee runtime enforcement of the type schema.

--- a/src/auth/cred-store.ts
+++ b/src/auth/cred-store.ts
@@ -68,6 +68,7 @@ function isValidAccount(a: unknown): boolean {
   // id/email must be non-empty; password is a string but may be empty for OAuth2
   // accounts (no password). imap/smtp must be well-formed server configs.
   if (!isNonEmptyString(acc.id) || !isNonEmptyString(acc.email) || typeof acc.password !== 'string') return false
+  if (acc.authType !== undefined && acc.authType !== 'password' && acc.authType !== 'oauth2') return false
   if (!isValidServer(acc.imap) || !isValidServer(acc.smtp)) return false
   if (acc.oauth2 !== undefined && !isValidOAuth2(acc.oauth2)) return false
   return true


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `isValidAccount` type guard in `src/auth/cred-store.ts` verified that the `password` field was a string but failed to validate the `authType` field. An attacker capable of modifying the encrypted KV credential blob could theoretically inject arbitrary string values into `authType` (e.g. `'admin'`, `'bypass'`), potentially confusing downstream authentication logic that branches on this type.
🎯 Impact: Unexpected authentication logic branching leading to errors or security bypasses on deserialization of malformed or malicious configurations.
🔧 Fix: Extended the `isValidAccount` type guard to explicitly validate that `authType` is strictly either `'password'` or `'oauth2'` if provided.
✅ Verification: Ran `bun run test` to verify `src/auth/cred-store.test.ts` integration functions appropriately without breaking valid parsing.

---
*PR created automatically by Jules for task [17465079722801784014](https://jules.google.com/task/17465079722801784014) started by @n24q02m*