### PR TITLE
fix: validate optional IMAP host and port fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,7 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+
+## 2023-10-25 - [Declarative Form Validation for Optional Fields]
+**Learning:** When configuring declarative regex validation (e.g. `validation` in `RELAY_SCHEMA`) for optional form fields, the pattern must explicitly allow empty strings (e.g. `^\d*$` instead of `^\d+$`). Otherwise, the client-side validation logic will incorrectly block form submission if the user intentionally leaves the optional field blank.
+**Action:** Always test regex patterns against empty strings when applying validation to optional fields.

--- a/src/relay-schema.test.ts
+++ b/src/relay-schema.test.ts
@@ -34,7 +34,9 @@ describe('RELAY_SCHEMA', () => {
 
     const imapHost = fields.find((f) => f.key === 'imap_host')
     expect(imapHost?.required).toBe(false)
+    expect(imapHost?.validation).toBe('^\\S*$')
     const imapPort = fields.find((f) => f.key === 'imap_port')
     expect(imapPort?.required).toBe(false)
+    expect(imapPort?.validation).toBe('^\\d*$')
   })
 })

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -50,6 +50,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Host',
         type: 'text',
         required: false,
+        validation: '^\\S*$',
         helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
       },
       {
@@ -57,6 +58,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Port',
         type: 'text',
         required: false,
+        validation: '^\\d*$',
         placeholder: '993',
         helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
       }


### PR DESCRIPTION
💡 What: Added declarative `validation` regex patterns to the `imap_host` and `imap_port` fields in the `RELAY_SCHEMA`.
🎯 Why: To provide immediate, client-side feedback during form entry, preventing users from accidentally submitting invalid characters (e.g., spaces in hostnames or letters in ports) while correctly permitting the fields to be left blank.
📸 Before/After: Not applicable (no direct UI change recorded, configuration change applied to mcp-core's form builder).
♿ Accessibility: Improves user experience by catching data-entry errors locally before form submission.

---
*PR created automatically by Jules for task [14370210346816463446](https://jules.google.com/task/14370210346816463446) started by @n24q02m*