### PR TITLE
🎨 Palette: Add client-side validation for IMAP host and port fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,7 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+
+## 2024-05-18 - [Optional Field Regex Validation]
+**Learning:** When adding regex validation (`pattern` attribute on `<input>`) to optional fields to improve UX inline feedback, the regex *must* explicitly allow empty strings (e.g., using `^\d*$` instead of `^\d+$` or `^\S*$` instead of `^\S+$`). Otherwise, the native HTML form validation will block submission if the user intentionally skips the optional field, because the empty string fails the regex check.
+**Action:** Always test regex validations on optional fields with empty inputs. Ensure patterns are "tolerant" by using `*` instead of `+` where appropriate.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -50,6 +50,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Host',
         type: 'text',
         required: false,
+        validation: '^\\S*$',
         helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
       },
       {
@@ -57,6 +58,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Port',
         type: 'text',
         required: false,
+        validation: '^\\d*$',
         placeholder: '993',
         helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
       }


### PR DESCRIPTION
Adds regex validation to `imap_host` and `imap_port` in the relay schema to improve UX with immediate inline feedback for invalid inputs (e.g., spaces in host or non-numeric characters in port).

---
*PR created automatically by Jules for task [9431711623987544059](https://jules.google.com/task/9431711623987544059) started by @n24q02m*