### PR TITLE
fix: 🎨 Palette: Add regex validation for optional schema fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,7 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+
+## 2025-06-15 - Optional Field Validation Regex
+**Learning:** Adding validation rules to optional form fields can inadvertently break the user experience if the validation pattern does not account for an empty state. If a field is optional, the user should be able to submit the form without filling it in.
+**Action:** When adding regex `validation` to optional fields in declarative schemas (like `RELAY_SCHEMA`), always use zero-or-more quantifiers (e.g., `*` instead of `+`) to explicitly allow empty strings (e.g., `^\d*$` instead of `^\d+$`).

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -50,7 +50,8 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Host',
         type: 'text',
         required: false,
-        helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
+        helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.',
+        validation: '^\\S*$'
       },
       {
         key: 'imap_port',
@@ -58,7 +59,8 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         type: 'text',
         required: false,
         placeholder: '993',
-        helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
+        helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.',
+        validation: '^\\d*$'
       }
     ]
   }


### PR DESCRIPTION
💡 What: Added zero-or-more regex validators (`^\S*$`, `^\d*$`) to optional `imap_host` and `imap_port` fields in `src/relay-schema.ts`.
🎯 Why: Prevents users from accidentally typing spaces in the host or letters in the port number, while still allowing the fields to be completely empty if they wish to use auto-discovery.
📸 Before/After: Visual changes are handled by the core renderer when invalid values are entered (red borders around fields).
♿ Accessibility: Improves form robustness by stopping invalid submissions early before they reach the backend validation.

---
*PR created automatically by Jules for task [5177005883852890736](https://jules.google.com/task/5177005883852890736) started by @n24q02m*