### PR TITLE
fix: 🛡️ Sentinel: Enforce URL length limit to mitigate DoS

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -88,6 +88,10 @@ function pickContainerEnv(env: Env): Record<string, string> {
 // public internet (kv.internal -> NXDOMAIN).
 
 const kvOutbound: OutboundHandler<Env> = async (request, env) => {
+  if (request.url.length > 2048) {
+    return new Response('URI Too Long', { status: 414 })
+  }
+
   const url = new URL(request.url)
   const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
   // Readiness probe (E.1): once this handler answers, outbound interception is
@@ -155,6 +159,10 @@ function withSecurityHeaders(response: Response): Response {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.url.length > 2048) {
+      return withSecurityHeaders(new Response('URI Too Long', { status: 414 }))
+    }
+
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential DoS via CPU/memory exhaustion by parsing oversized URLs in worker handlers.
🎯 Impact: Susceptibility to Denial of Service via large inputs to the URL constructor.
🔧 Fix: Enforced a 2048 character limit before URL parsing in both public and internal fetch handlers.
✅ Verification: Verified via bun run test.

---
*PR created automatically by Jules for task [12138241091599565769](https://jules.google.com/task/12138241091599565769) started by @n24q02m*