### PR TITLE
feat: 🎨 Palette: add regex validation to IMAP form fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -103,3 +103,7 @@
 ## 2023-10-27 - Inline Validation and Context-Aware Errors
 **Learning:** Native form validation combined with generic error messages (e.g., "Invalid value") leaves users confused. Additionally, relying solely on "submit" for validation frustrates users, as they must complete the entire form before receiving any feedback.
 **Action:** Enhance native validation events by dynamically using the field's `label` in error messages to provide context. Introduce a `blur` event listener to trigger validation specifically on fields the user has touched, providing immediate feedback while maintaining accessibility.
+
+## 2025-07-28 - Regex Validation for Optional Schema-Driven Form Fields
+**Learning:** When using schema-driven forms (like `RELAY_SCHEMA`) to render inputs, applying standard regex validation to optional fields can inadvertently block form submission if the user leaves the field intentionally blank, causing a frustrating UX.
+**Action:** When adding validation regex patterns to optional fields (e.g., `^\d*$` for ports or `^\S*$` for hostnames), ensure the pattern explicitly allows an empty string so the field can be bypassed correctly.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -50,6 +50,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Host',
         type: 'text',
         required: false,
+        validation: '^\\S*$',
         helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
       },
       {
@@ -57,6 +58,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'IMAP Port',
         type: 'text',
         required: false,
+        validation: '^\\d*$',
         placeholder: '993',
         helpText: 'Optional. Default 993. Set a custom port for a local IMAP proxy.'
       }


### PR DESCRIPTION
💡 What: Added inline regex validation to `imap_host` and `imap_port` fields in the credential form schema.
🎯 Why: Provides immediate client-side feedback for invalid inputs (e.g. spaces in hostnames, non-digits in ports) without blocking intentional empty states for optional fields.
📸 Before/After: Visual validation error is shown immediately on input if the format is incorrect.
♿ Accessibility: Provides more immediate inline feedback before full form submission.

---
*PR created automatically by Jules for task [865896346599100635](https://jules.google.com/task/865896346599100635) started by @n24q02m*