### PR TITLE
fix: 🛡️ Sentinel: Enforce URI length limit on worker endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -82,3 +82,8 @@ The browser-facing surface is already covered: every response returned from the
 Note the recurrence pattern: #1041 and #1045 carried an identical diff, and #1051
 repeated it with the helper exported. Three PRs, one idea, because nothing in
 this file recorded that it had been considered and declined.
+
+## 2026-07-29 - DoS Vulnerability via Unsanitized URI Length
+**Vulnerability:** The `fetch` entrypoint and `kvOutbound` handler in `src/worker.ts` passed inbound request URLs directly to the native `URL` constructor without any length limits. An attacker could exploit this by sending requests with extremely long URIs, causing high CPU/memory overhead or crashing the worker process due to URI parsing constraints.
+**Learning:** Native parsing functions like `URL` are susceptible to performance degradation and memory exhaustion when given excessively large inputs. This is a common attack vector for Denial of Service (DoS).
+**Prevention:** Always enforce strict length bounds (e.g., max 2048 characters) on untrusted request URIs before passing them into parsers. Return a 414 URI Too Long status code gracefully to prevent resource exhaustion.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -88,6 +88,9 @@ function pickContainerEnv(env: Env): Record<string, string> {
 // public internet (kv.internal -> NXDOMAIN).
 
 const kvOutbound: OutboundHandler<Env> = async (request, env) => {
+  if (request.url.length > 2048) {
+    return new Response('URI too long', { status: 414 })
+  }
   const url = new URL(request.url)
   const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
   // Readiness probe (E.1): once this handler answers, outbound interception is
@@ -155,6 +158,9 @@ function withSecurityHeaders(response: Response): Response {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.url.length > 2048) {
+      return withSecurityHeaders(new Response('URI too long', { status: 414 }))
+    }
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller


### PR DESCRIPTION
🚨 **Severity:** MEDIUM/HIGH

💡 **Vulnerability:** Unsanitized URL length passed to `URL` constructor could cause DoS via memory exhaustion or high CPU utilization on Cloudflare worker.
🎯 **Impact:** Potential worker crashes or performance degradation by sending excessively long request URIs to `fetch` or `kvOutbound` handlers.
🔧 **Fix:** Added a length check (`request.url.length > 2048`) on `request.url` in both handlers, returning a 414 URI Too Long status immediately.
✅ **Verification:** Ran test suite, passed lints, added learning to Sentinel journal.

---
*PR created automatically by Jules for task [15844667271643892345](https://jules.google.com/task/15844667271643892345) started by @n24q02m*