### PR TITLE
fix: 🛡️ Sentinel: Enforce URI length limits to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -82,3 +82,7 @@ The browser-facing surface is already covered: every response returned from the
 Note the recurrence pattern: #1041 and #1045 carried an identical diff, and #1051
 repeated it with the helper exported. Three PRs, one idea, because nothing in
 this file recorded that it had been considered and declined.
+## 2025-02-27 - [Enforce URI length limit to prevent DoS]
+**Vulnerability:** The native `URL` constructor in the `fetch` and `kvOutbound` handlers in `src/worker.ts` could be exploited by an attacker sending extremely long URLs, which could cause a Denial of Service (DoS) due to CPU/memory exhaustion during parsing.
+**Learning:** External or internal requests with unbounded URI lengths were not previously restricted before reaching complex string parsing methods like `new URL()`.
+**Prevention:** Always check and enforce a strict length limit (e.g., `< 2048`) on any URI or large string input before passing it to native parsing functions like `new URL` or regex processors.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -88,6 +88,9 @@ function pickContainerEnv(env: Env): Record<string, string> {
 // public internet (kv.internal -> NXDOMAIN).
 
 const kvOutbound: OutboundHandler<Env> = async (request, env) => {
+  if (request.url.length > 2048) {
+    return new Response('URI Too Long', { status: 414 })
+  }
   const url = new URL(request.url)
   const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
   // Readiness probe (E.1): once this handler answers, outbound interception is
@@ -155,6 +158,9 @@ function withSecurityHeaders(response: Response): Response {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.url.length > 2048) {
+      return withSecurityHeaders(new Response('URI Too Long', { status: 414 }))
+    }
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller


### PR DESCRIPTION
Enforced URI length limit of 2048 characters to prevent URL parsing Denial of Service.

---
*PR created automatically by Jules for task [5350211612986194700](https://jules.google.com/task/5350211612986194700) started by @n24q02m*