### PR TITLE
fix: align email skills with messages tool

### DIFF
--- a/skills/follow-up/SKILL.md
+++ b/skills/follow-up/SKILL.md
@@ -65,7 +65,7 @@ For each follow-up candidate:
 Check all accounts, same as inbox-review:
 
 ```
-messages(action="list_accounts")
+folders(action="list")
 # Iterate each account's Sent folder
 ```
 

--- a/skills/inbox-review/SKILL.md
+++ b/skills/inbox-review/SKILL.md
@@ -13,8 +13,8 @@ Systematic morning inbox review with email-specific intelligence.
 Always iterate ALL configured accounts, not just the default:
 
 ```
-# List accounts first
-messages(action="list_accounts")
+# List folders for all accounts first
+folders(action="list")
 
 # Then search each account
 messages(action="search", query="UNSEEN", account="work@company.com")


### PR DESCRIPTION
## Summary
- replace the removed messages(action="list_accounts") examples with folders(action="list")
- keep synced skills aligned with the stable six-tool MCP surface

## Verification
- bun run build
- bun run test (45 files passed, 841 tests passed, 1 skipped)
- bun run check