### PR TITLE
feat: 🎨 Palette: Add placeholder to imap_host field

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -107,3 +107,7 @@
 ## 2023-10-25 - [Declarative Form Validation for Optional Fields]
 **Learning:** When configuring declarative regex validation (e.g. `validation` in `RELAY_SCHEMA`) for optional form fields, the pattern must explicitly allow empty strings (e.g. `^\d*$` instead of `^\d+$`). Otherwise, the client-side validation logic will incorrectly block form submission if the user intentionally leaves the optional field blank.
 **Action:** Always test regex patterns against empty strings when applying validation to optional fields.
+
+## 2026-08-12 - Consistent Placeholders in Form Fields
+**Learning:** Having placeholders for some text fields but omitting them for others in the same form group (e.g. `imap_port` and `email` vs `imap_host`) creates inconsistency and leaves users guessing the expected input format for the un-hinted field.
+**Action:** Always provide placeholder examples for all user-facing text inputs in a form sequence to establish a consistent pattern and explicitly guide the required input format.

--- a/src/credential-form.test.ts
+++ b/src/credential-form.test.ts
@@ -38,6 +38,11 @@ describe('email credential form (core card-group renderer)', () => {
     expect(html).toContain('"imap_port"')
   })
 
+  it('renders the IMAP host placeholder on the imap_host field', () => {
+    const html = render('/auth')
+    expect(html).toMatch(/"key":"imap_host"[^{}]*"placeholder":"imap\.example\.com"/)
+  })
+
   it('titles each card by the email field', () => {
     const html = render('/auth')
     // titleField is threaded into the card-group script as TITLE_FIELD.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -51,6 +51,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         type: 'text',
         required: false,
         validation: '^\\S*$',
+        placeholder: 'imap.example.com',
         helpText: 'Optional. Leave empty for auto-detection. Accepts localhost or a proxy host.'
       },
       {


### PR DESCRIPTION
💡 **What:** Added `placeholder: 'imap.example.com'` to the `imap_host` field in `src/relay-schema.ts`.
🎯 **Why:** To improve UX by providing a consistent hint format across all text fields in the form, preventing users from guessing the expected input format.
♿ **Accessibility:** Improves cognitive accessibility by explicitly guiding user input.

---
*PR created automatically by Jules for task [17839022304428761203](https://jules.google.com/task/17839022304428761203) started by @n24q02m*