### PR TITLE
fix: update dependencies and Cloudflare dry-run

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -35,7 +35,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "off",
         "noImplicitAnyLet": "off",

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@n24q02m/mcp-core": "1.23.0",
         "html-to-text": "^10.0.0",
-        "imapflow": "^1.6.6",
+        "imapflow": "^1.7.0",
         "mailparser": "^3.9.15",
         "marked": "^18.0.9",
         "nodemailer": "^9.0.5",
@@ -19,7 +19,6 @@
         "@cloudflare/containers": "^0.3.7",
         "@types/html-to-text": "^9.0.4",
         "@types/mailparser": "^3.4.6",
-        "@types/marked": "^6.0.0",
         "@types/node": "^26.2.0",
         "@types/nodemailer": "^8.0.1",
         "@types/sanitize-html": "^2.16.1",
@@ -28,7 +27,7 @@
         "tsx": "^4.23.12",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10",
-        "wrangler": "^4.121.0",
+        "wrangler": "^4.122.0",
       },
     },
   },
@@ -70,15 +69,15 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260804.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-191/PPEFicRK2wK69eXzSjnLgHL79k7zR2VUpyIr8rhFgGns1b5bTHgnBuUrgU2LPbEtwbE5eL2hJ0uhLAFEow=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260811.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260804.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aI2cAFLsrNkSz3kLSQrgrO9ICTfY7jb2h0jgaWDE9mQLQQDfpXeYrKWt07tTgMmeNP79o9w3NZe3aqtt8mTGHQ=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260811.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260804.1", "", { "os": "linux", "cpu": "x64" }, "sha512-KBCjxBIlN2jucfQGaTK4EgmPsWzQgYR/zYhPfi3mkWwdoTyG1dgrt2aizKps/SYse85ci/SOxojKk0/K7vstPw=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260811.1", "", { "os": "linux", "cpu": "x64" }, "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260804.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-7lswfarBZ7xkHpTFrNb74ExwOltIalVaASc+GOYfCNtnwFxK/JZSVByfm/hnZEBtrHU7fMY2z7dYT64rwS0pHg=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260811.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260804.1", "", { "os": "win32", "cpu": "x64" }, "sha512-GOgRWYtxISN5rAWfx3K7zubt3xEn0/ZPFrbcLL+GwT4ouCKyNoHqfT1cPNB6Nx7t8BHEjnuTG7gkHO4Wd5ORdg=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -259,8 +258,6 @@
     "@types/html-to-text": ["@types/html-to-text@9.0.4", "", {}, "sha512-pUY3cKH/Nm2yYrEmDlPR1mR7yszjGx4DrwPjQ702C4/D5CwHuZTgZdIdwPkRbcuhs7BAh2L5rg3CL5cbRiGTCQ=="],
 
     "@types/mailparser": ["@types/mailparser@3.4.6", "", { "dependencies": { "@types/node": "*", "iconv-lite": "^0.6.3" } }, "sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q=="],
-
-    "@types/marked": ["@types/marked@6.0.0", "", { "dependencies": { "marked": "*" } }, "sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA=="],
 
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
@@ -470,7 +467,7 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
-    "imapflow": ["imapflow@1.6.6", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.15", "encoding-japanese": "2.2.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libmime": "5.4.2", "libqp": "2.1.1", "pino": "10.3.1", "socks": "2.8.9" } }, "sha512-/aDm268JL43M8CI8pGarXrBfVNwk8p/cFuMunND5OFWVTt4hPVKgqbm9+KeajCiP217XKD0NPZ2W4j72Q/D9AQ=="],
+    "imapflow": ["imapflow@1.7.0", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.15", "encoding-japanese": "2.2.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libmime": "5.4.2", "libqp": "2.1.1", "pino": "10.3.1", "socks": "2.8.9" } }, "sha512-wWs6g5SBC7OEobQ82T3Jou/KlKl2f37mTCCuGkBrUB0irvYUodkUYMe36GSq1TLs/FM+j/hLmmAgm3CBZkVMyQ=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -558,7 +555,7 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "miniflare": ["miniflare@5.20260804.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260804.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-J0QBHEj+d75TyFE9VhH+2dXgvdYt/pfyDlm+9IiYUFocQvqYy9iuW1DIqNawh1N7Kr6iMrDzVkgDSdt6pA75uA=="],
+    "miniflare": ["miniflare@5.20260811.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260811.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-sypXsD5fjY88fZNedPqnwrwR1dwfnfbfW7MfvMyIfPJdtRiCCOpUnjWGeFVYYZ+0fQVICye6Juu+vZgzTEx8XA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -724,9 +721,9 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "workerd": ["workerd@1.20260804.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260804.1", "@cloudflare/workerd-darwin-arm64": "1.20260804.1", "@cloudflare/workerd-linux-64": "1.20260804.1", "@cloudflare/workerd-linux-arm64": "1.20260804.1", "@cloudflare/workerd-windows-64": "1.20260804.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-b0P38g5/ssemwWxd/mafNYggEZ0ere7PCiUH6RCHkgqjRhhXTP45nDiL2L3iIvi8uF2IjNrGpVgMXEunCaeY/w=="],
+    "workerd": ["workerd@1.20260811.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260811.1", "@cloudflare/workerd-darwin-arm64": "1.20260811.1", "@cloudflare/workerd-linux-64": "1.20260811.1", "@cloudflare/workerd-linux-arm64": "1.20260811.1", "@cloudflare/workerd-windows-64": "1.20260811.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw=="],
 
-    "wrangler": ["wrangler@4.121.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260804.1-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260804.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260804.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-dcARWk6CyaD0vJBSLjJn4K2yo+mYko73hzryq+t/9DXnyAq877RWIMl7uOMcDKs5dDXdoickNhZTKxBYT9XKsA=="],
+    "wrangler": ["wrangler@4.122.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260811.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260811.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260811.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-qkskzgQ76Y1qvVe5JARgvc3RISq6BC2rPoxQhFoKH1dKIwQc3GDFttQ/7m2OfeQ+tmQRzynv2dy/DXnxFCj2Lw=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "docker:build": "docker build -t n24q02m/better-email-mcp:latest .",
     "docker:push": "docker push n24q02m/better-email-mcp:latest",
     "docker:run": "docker run --rm -i -e EMAIL_CREDENTIALS n24q02m/better-email-mcp:latest",
-    "cf:dryrun": "node scripts/cf-deploy.js -- --dry-run",
+    "cf:dryrun": "node scripts/cf-deploy.js --dry-run",
     "cf:deploy": "node scripts/cf-deploy.js"
   },
   "bin": {
@@ -62,7 +62,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@n24q02m/mcp-core": "1.23.0",
     "html-to-text": "^10.0.0",
-    "imapflow": "^1.6.6",
+    "imapflow": "^1.7.0",
     "mailparser": "^3.9.15",
     "marked": "^18.0.9",
     "nodemailer": "^9.0.5",
@@ -76,7 +76,6 @@
     "@cloudflare/containers": "^0.3.7",
     "@types/html-to-text": "^9.0.4",
     "@types/mailparser": "^3.4.6",
-    "@types/marked": "^6.0.0",
     "@types/node": "^26.2.0",
     "@types/nodemailer": "^8.0.1",
     "@types/sanitize-html": "^2.16.1",
@@ -85,7 +84,7 @@
     "tsx": "^4.23.12",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10",
-    "wrangler": "^4.121.0"
+    "wrangler": "^4.122.0"
   },
   "description": "Better MCP server for Email (IMAP/SMTP) with composite tools optimized for AI agents",
   "main": "build/src/init-server.js",

--- a/scripts/cf-deploy.js
+++ b/scripts/cf-deploy.js
@@ -29,11 +29,16 @@
 
 import { spawnSync } from 'node:child_process'
 import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const projectRoot = join(__dirname, '..')
+const require = createRequire(import.meta.url)
+const wranglerPackagePath = require.resolve('wrangler/package.json')
+const wranglerPackage = require(wranglerPackagePath)
+const wranglerCli = join(dirname(wranglerPackagePath), wranglerPackage.bin.wrangler)
 
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
 if (!accountId) {
@@ -88,9 +93,16 @@ const tempConfig = join(projectRoot, 'wrangler.deploy.jsonc')
 writeFileSync(tempConfig, resolved)
 
 const passthrough = process.argv.slice(2)
-const args = ['wrangler', 'deploy', '-c', tempConfig, ...passthrough]
-console.log(`cf:deploy: running npx ${args.join(' ')}`)
+while (passthrough[0] === '--') {
+  passthrough.shift()
+}
+const args = [wranglerCli, 'deploy', '-c', tempConfig, ...passthrough]
+console.log(`cf:deploy: running wrangler ${args.slice(1).join(' ')}`)
 
-const result = spawnSync('npx', args, { cwd: projectRoot, stdio: 'inherit', shell: process.platform === 'win32' })
-rmSync(tempConfig, { force: true })
+let result
+try {
+  result = spawnSync(process.execPath, args, { cwd: projectRoot, stdio: 'inherit' })
+} finally {
+  rmSync(tempConfig, { force: true })
+}
 process.exit(result.status ?? 1)

--- a/scripts/cf-deploy.test.js
+++ b/scripts/cf-deploy.test.js
@@ -1,0 +1,195 @@
+import { existsSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const childProcess = vi.hoisted(() => ({
+  spawnSync: vi.fn()
+}))
+const fileSystem = vi.hoisted(() => ({
+  sourceOverride: undefined
+}))
+
+vi.mock('node:child_process', () => childProcess)
+vi.mock('node:fs', async (importOriginal) => {
+  const original = await importOriginal()
+  return {
+    ...original,
+    readFileSync: (...args) => fileSystem.sourceOverride ?? original.readFileSync(...args)
+  }
+})
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const projectRoot = dirname(scriptDirectory)
+const scriptPath = join(scriptDirectory, 'cf-deploy.js')
+const tempConfigPath = join(projectRoot, 'wrangler.deploy.jsonc')
+const originalArgv = process.argv
+const originalEnvironment = Object.fromEntries(
+  ['CLOUDFLARE_ACCOUNT_ID', 'CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_KV_NAMESPACE_ID', 'PUBLIC_URL'].map((name) => [
+    name,
+    process.env[name]
+  ])
+)
+
+class ProcessExitError extends Error {
+  constructor(code) {
+    super(`process.exit(${code})`)
+    this.code = code
+  }
+}
+
+function restoreEnvironment() {
+  for (const [name, value] of Object.entries(originalEnvironment)) {
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = value
+    }
+  }
+}
+
+async function runDeployScript(passthrough, childResult) {
+  process.argv = ['node', scriptPath, ...passthrough]
+  childProcess.spawnSync.mockImplementation(childResult)
+  await import('./cf-deploy.js')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  childProcess.spawnSync.mockReset()
+  fileSystem.sourceOverride = undefined
+  process.env.CLOUDFLARE_ACCOUNT_ID = 'test-account'
+  process.env.CLOUDFLARE_API_TOKEN = 'test-token'
+  process.env.PUBLIC_URL = 'https://example.test'
+  delete process.env.CLOUDFLARE_KV_NAMESPACE_ID
+  rmSync(tempConfigPath, { force: true })
+  vi.spyOn(process, 'exit').mockImplementation(() => undefined)
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  fileSystem.sourceOverride = undefined
+  rmSync(tempConfigPath, { force: true })
+  process.argv = originalArgv
+  restoreEnvironment()
+  vi.restoreAllMocks()
+})
+
+describe('cf-deploy validation', () => {
+  it.each([
+    {
+      name: 'account id',
+      variable: 'CLOUDFLARE_ACCOUNT_ID',
+      message: 'cf:deploy: CLOUDFLARE_ACCOUNT_ID is required (substituted into the image ref).'
+    },
+    {
+      name: 'API token',
+      variable: 'CLOUDFLARE_API_TOKEN',
+      message: 'cf:deploy: CLOUDFLARE_API_TOKEN is required for wrangler auth.'
+    },
+    {
+      name: 'public URL',
+      variable: 'PUBLIC_URL',
+      message: 'cf:deploy: PUBLIC_URL is required (substituted into vars.PUBLIC_URL for relay/OAuth URLs).'
+    }
+  ])('rejects a missing $name before invoking Wrangler', async ({ variable, message }) => {
+    delete process.env[variable]
+    process.exit.mockImplementation((code) => {
+      throw new ProcessExitError(code)
+    })
+
+    await expect(runDeployScript([], () => ({ status: 0 }))).rejects.toMatchObject({ code: 1 })
+
+    expect(console.error).toHaveBeenCalledWith(message)
+    expect(childProcess.spawnSync).not.toHaveBeenCalled()
+    expect(existsSync(tempConfigPath)).toBe(false)
+  })
+
+  it('rejects a missing required config placeholder', async () => {
+    fileSystem.sourceOverride = '{"publicUrl":"<YOUR_PUBLIC_URL>"}'
+    process.exit.mockImplementation((code) => {
+      throw new ProcessExitError(code)
+    })
+
+    await expect(runDeployScript([], () => ({ status: 0 }))).rejects.toMatchObject({ code: 1 })
+
+    expect(console.error).toHaveBeenCalledWith(
+      'cf:deploy: expected <YOUR_ACCOUNT_ID> in wrangler.jsonc; not found. Aborting.'
+    )
+    expect(childProcess.spawnSync).not.toHaveBeenCalled()
+    expect(existsSync(tempConfigPath)).toBe(false)
+  })
+
+  it('allows the optional KV placeholder to be absent', async () => {
+    fileSystem.sourceOverride = '{"account":"<YOUR_ACCOUNT_ID>","publicUrl":"<YOUR_PUBLIC_URL>"}'
+
+    await runDeployScript(['--dry-run'], () => ({ status: 0 }))
+
+    expect(childProcess.spawnSync).toHaveBeenCalledOnce()
+    expect(process.exit).toHaveBeenCalledWith(0)
+    expect(existsSync(tempConfigPath)).toBe(false)
+  })
+})
+
+describe('cf-deploy argument forwarding', () => {
+  it.each([
+    {
+      name: 'direct Wrangler arguments',
+      input: ['--dry-run'],
+      expected: ['--dry-run']
+    },
+    {
+      name: 'one Bun/npm separator',
+      input: ['--', '--dry-run'],
+      expected: ['--dry-run']
+    },
+    {
+      name: 'repeated Bun/npm separators',
+      input: ['--', '--', '--dry-run'],
+      expected: ['--dry-run']
+    },
+    {
+      name: 'an interior Wrangler separator',
+      input: ['--dry-run', '--', 'artifact'],
+      expected: ['--dry-run', '--', 'artifact']
+    }
+  ])('normalizes $name without changing Wrangler arguments', async ({ input, expected }) => {
+    await runDeployScript(input, () => ({ status: 0 }))
+
+    expect(childProcess.spawnSync).toHaveBeenCalledOnce()
+    const [command, args, options] = childProcess.spawnSync.mock.calls[0]
+    expect(command).toBe(process.execPath)
+    expect(args[0].replaceAll('\\', '/')).toMatch(/node_modules\/wrangler\/bin\/wrangler\.js$/)
+    expect(args.slice(1, 4)).toEqual(['deploy', '-c', tempConfigPath])
+    expect(args.slice(4)).toEqual(expected)
+    expect(options).not.toHaveProperty('shell', true)
+  })
+})
+
+describe('cf-deploy temporary config cleanup', () => {
+  it.each([
+    { name: 'success', status: 0, expectedExit: 0 },
+    { name: 'Wrangler failure', status: 17, expectedExit: 17 },
+    { name: 'missing child status', status: null, expectedExit: 1 }
+  ])('removes the file after $name', async ({ status, expectedExit }) => {
+    await runDeployScript(['--dry-run'], () => ({ status }))
+
+    expect(existsSync(tempConfigPath)).toBe(false)
+    expect(process.exit).toHaveBeenCalledWith(expectedExit)
+  })
+
+  it('removes the file when launching Wrangler throws', async () => {
+    const launchError = new Error('launcher failed')
+
+    await expect(
+      runDeployScript(['--dry-run'], () => {
+        throw launchError
+      })
+    ).rejects.toThrow(launchError)
+
+    expect(existsSync(tempConfigPath)).toBe(false)
+    expect(process.exit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- update imapflow to 1.7.0 and Wrangler to 4.122.0
- remove redundant @types/marked and migrate Biome 2.5.8 config
- fix cf:dryrun argument forwarding so Wrangler receives --dry-run
- invoke the installed Wrangler CLI without a shell and always remove the temporary deploy config
- add focused validation, forwarding, failure, and cleanup tests

## Verification
- focused Vitest: 13 passed
- bun run check: passed
- bun run build: passed
- full coverage (foreign run): 878 passed, 1 skipped; 95.12% statements, 96.29% lines
- live read-only Cloudflare probe: deployment fingerprint 64156e2291e87727 before and after
- Wrangler 4.122.0 exited at --dry-run; temp config removed; DEP0190 absent