### PR TITLE
feat: add deterministic provider acceptance harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,22 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Setup uv and Python 3.13
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          python-version: "3.13"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Run Biome check
         run: bun run check
+
+      - name: Lint provider acceptance harness
+        run: bun run provider:accept:lint
+
+      - name: Test provider acceptance harness
+        run: bun run provider:accept:test
 
       - name: Build project
         run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ logs_*/
 *.log
 .jules/
 .venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
 
 # AI Agent
 JULES.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
         name: provider acceptance test
         entry: bun run provider:accept:test
         language: system
-        files: ^scripts/(provider_acceptance|test_provider_acceptance)\.py$
+        files: ^(?:package\.json|bun\.lock|tsconfig(?:\.build)?\.json|scripts/(?:provider_acceptance|test_provider_acceptance)\.py|scripts/start-server\.ts|src/.*\.ts)$
         pass_filenames: false
 
   # ============================================================================

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 #   2. Install hooks: pre-commit install
 #   3. Run manually: pre-commit run --all-files
 #
-# Bypass checks: git commit --no-verify (use only in emergency)
+# Hooks are mandatory. Fix the root cause and rerun the full hook set on failure.
 
 repos:
   # ============================================================================
@@ -50,6 +50,23 @@ repos:
         entry: bun run test
         language: system
         types: [ts]
+        pass_filenames: false
+
+  # Python provider-acceptance harness
+  - repo: local
+    hooks:
+      - id: provider-acceptance-lint
+        name: provider acceptance lint
+        entry: bun run provider:accept:lint
+        language: system
+        files: ^scripts/(provider_acceptance|test_provider_acceptance)\.py$
+        pass_filenames: false
+
+      - id: provider-acceptance-test
+        name: provider acceptance test
+        entry: bun run provider:accept:test
+        language: system
+        files: ^scripts/(provider_acceptance|test_provider_acceptance)\.py$
         pass_filenames: false
 
   # ============================================================================

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ surface. The old name is removed directly; there is no compatibility alias.
 | Tool | Actions | Description |
 |:-----|:--------|:------------|
 | `messages` | `search`, `read`, `mark_read`, `mark_unread`, `flag`, `unflag`, `move`, `archive`, `trash`, `new`, `reply`, `forward` | Search, read, organize, compose, reply to, and forward emails |
-| `folders` | `list` | List mailbox folders |
+| `folders` | `list`, `status` | List mailbox folders or read targeted IMAP STATUS metadata |
 | `attachments` | `list`, `download` | List and download email attachments |
 | `config` | `status`, `setup_status`, `setup_start`, `setup_reset`, `setup_complete`, `set`, `cache_clear` | Credential setup via browser relay, status check, reset, re-resolve, cache clear |
 | `config__open_relay` | - | Open the relay configuration form in the browser and return the relay URL |

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev": "tsx watch scripts/start-server.ts",
     "provider:accept": "uv run --with mcp==2.0.0 python -B scripts/provider_acceptance.py",
     "provider:accept:lint": "uv run --with ruff==0.16.2 ruff check scripts/provider_acceptance.py scripts/test_provider_acceptance.py",
-    "provider:accept:test": "uv run --with mcp==2.0.0 --with pytest==9.1.1 pytest -q scripts/test_provider_acceptance.py",
+    "provider:accept:test": "uv run --with mcp==2.0.0 --with pytest==9.1.1 --with coverage==7.10.6 coverage run --include=scripts/provider_acceptance.py -m pytest -q scripts/test_provider_acceptance.py && uv run --with coverage==7.10.6 coverage report --show-missing --fail-under=95",
     "test": "vitest --passWithNoTests",
     "test:watch": "vitest watch",
     "test:coverage": "vitest --coverage",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json && node scripts/build-cli.js",
     "dev": "tsx watch scripts/start-server.ts",
+    "provider:accept": "uv run --with mcp==2.0.0 python -B scripts/provider_acceptance.py",
+    "provider:accept:lint": "uv run --with ruff==0.16.2 ruff check scripts/provider_acceptance.py scripts/test_provider_acceptance.py",
+    "provider:accept:test": "uv run --with mcp==2.0.0 --with pytest==9.1.1 pytest -q scripts/test_provider_acceptance.py",
     "test": "vitest --passWithNoTests",
     "test:watch": "vitest watch",
     "test:coverage": "vitest --coverage",

--- a/scripts/provider_acceptance.py
+++ b/scripts/provider_acceptance.py
@@ -800,6 +800,8 @@ async def _run_gmail(
     token_path: Path | None,
     factory: SessionFactory,
 ) -> dict[str, Any]:
+    if not environment.get(SELECTOR_ENV["gmail"], "").strip():
+        return _record("gmail", "FAILED", "GMAIL_INPUT_MISSING")
     accounts = select_provider_accounts("gmail", environment)
     if not accounts:
         return _record("gmail", "FAILED", "GMAIL_INPUT_MISSING")
@@ -945,6 +947,8 @@ async def _run_outlook(
     environment: dict[str, str],
     factory: SessionFactory,
 ) -> dict[str, Any]:
+    if not environment.get(SELECTOR_ENV["gmail"], "").strip():
+        return _record("outlook-expired", "FAILED", "GMAIL_INPUT_MISSING")
     gmail_accounts = select_provider_accounts("gmail", environment)
     if not gmail_accounts:
         return _record("outlook-expired", "FAILED", "GMAIL_INPUT_MISSING")

--- a/scripts/provider_acceptance.py
+++ b/scripts/provider_acceptance.py
@@ -1,0 +1,1098 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+import time
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from pathlib import Path
+from typing import Any, Protocol, TextIO
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCENARIOS = ("gmail", "yahoo-large", "outlook-expired")
+PROVIDERS = ("gmail", "yahoo", "outlook")
+RESULT_LIMIT = 3
+YAHOO_MAILBOX_THRESHOLD = 10_000
+YAHOO_FIXTURE_MESSAGE_COUNT = 10_025
+IMAP_FALLBACK_WINDOW_SIZE = 500
+YAHOO_FIXTURE_ACCOUNT = "large-mailbox@yahoo.test"
+OUTLOOK_FIXTURE_ACCOUNT = "expired-fixture@outlook.com"
+FIXTURE_PASSWORD = "provider-acceptance-fixture-password"
+SELECTOR_ENV = {
+    "gmail": "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT",
+    "yahoo": "PROVIDER_ACCEPTANCE_YAHOO_ACCOUNT",
+    "outlook": "PROVIDER_ACCEPTANCE_OUTLOOK_ACCOUNT",
+}
+READ_ONLY_ACTIONS = {
+    "config": frozenset({"status"}),
+    "folders": frozenset({"list", "status"}),
+    "messages": frozenset({"search"}),
+}
+OUTPUT_FIELDS = (
+    "scenario",
+    "provider",
+    "verdict",
+    "operation",
+    "code",
+    "result_count",
+    "mailbox_evidence",
+    "skipped_count",
+    "healthy_result_count",
+)
+STRING_OUTPUT_VALUES = {
+    "scenario": frozenset(SCENARIOS),
+    "provider": frozenset(PROVIDERS),
+    "verdict": frozenset({"VERIFIED", "FAILED"}),
+    "operation": frozenset({"preflight", "messages.search"}),
+}
+CODE_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
+INTERACTIVE_AUTH_MARKERS = (
+    "device code",
+    "device_code",
+    "devicelogin",
+    "verification_uri",
+    "user_code",
+    "authorization url",
+    "open http",
+    "login.microsoftonline.com",
+    "oauth2 sign-in required",
+    "enter code",
+)
+
+
+class UnsafeOperation(ValueError):
+    pass
+
+
+class ProviderCallError(RuntimeError):
+    pass
+
+
+class SessionFactory(Protocol):
+    def __call__(
+        self,
+        scenario: str,
+        environment: dict[str, str],
+        token_path: Path | None,
+    ) -> Any: ...
+
+
+@dataclass(frozen=True)
+class AccountInput:
+    account: str
+    provider: str
+
+
+@dataclass
+class LocalImapFixture:
+    host: str
+    port: int
+    message_count: int
+    connections: int = 0
+    status_requests: int = 0
+    search_windows: list[tuple[int, int]] = dataclass_field(default_factory=list)
+    unbounded_search_attempted: bool = False
+    _writers: set[asyncio.StreamWriter] = dataclass_field(
+        default_factory=set, repr=False
+    )
+
+    def bounded_search_verified(self) -> bool:
+        return bool(self.search_windows) and all(
+            1 <= high - low + 1 <= IMAP_FALLBACK_WINDOW_SIZE
+            for low, high in self.search_windows
+        )
+
+
+@dataclass(frozen=True)
+class OutlookReplayFixture:
+    root: Path
+    original_token_path: Path
+    replay_token_path: Path
+    environment: dict[str, str]
+
+
+@dataclass
+class StderrCapture:
+    stream: TextIO
+
+    def getvalue(self) -> str:
+        self.stream.flush()
+        self.stream.seek(0)
+        text = self.stream.read()
+        self.stream.seek(0, os.SEEK_END)
+        return text
+
+
+def _provider_for_account(account: str, environment: Mapping[str, str]) -> str | None:
+    _, separator, domain = account.casefold().rpartition("@")
+    if not separator:
+        return None
+
+    if domain in {"gmail.com", "googlemail.com"}:
+        return "gmail"
+    if domain.startswith("yahoo.") or domain in {"ymail.com", "rocketmail.com"}:
+        return "yahoo"
+
+    outlook_domains = {"outlook.com", "hotmail.com", "live.com", "msn.com"}
+    outlook_domains.update(
+        value.strip().casefold()
+        for value in environment.get("OUTLOOK_EXTRA_DOMAINS", "").split(",")
+        if value.strip()
+    )
+    if domain in outlook_domains:
+        return "outlook"
+    return None
+
+
+def discover_accounts(environment: Mapping[str, str]) -> list[AccountInput]:
+    discovered: list[AccountInput] = []
+    seen: set[str] = set()
+
+    credentials = environment.get("EMAIL_CREDENTIALS", "")
+    for credential in credentials.split(","):
+        account = credential.strip().partition(":")[0].strip()
+        provider = _provider_for_account(account, environment)
+        key = account.casefold()
+        if account and provider and key not in seen:
+            discovered.append(AccountInput(account=account, provider=provider))
+            seen.add(key)
+
+    single_account = environment.get("EMAIL_USER", "").strip()
+    if single_account and single_account.casefold() not in seen:
+        explicit_provider = environment.get("EMAIL_PROVIDER", "").strip().casefold()
+        provider = explicit_provider if explicit_provider in PROVIDERS else None
+        provider = provider or _provider_for_account(single_account, environment)
+        if provider:
+            discovered.append(AccountInput(account=single_account, provider=provider))
+
+    return discovered
+
+
+def select_provider_accounts(
+    provider: str, environment: Mapping[str, str]
+) -> list[AccountInput]:
+    candidates = sorted(
+        (
+            account
+            for account in discover_accounts(environment)
+            if account.provider == provider
+        ),
+        key=lambda account: account.account.casefold(),
+    )
+    selector_name = SELECTOR_ENV[provider]
+    selector = environment.get(selector_name, "").strip()
+    if provider == "outlook" and not selector:
+        selector = environment.get(
+            "PROVIDER_ACCEPTANCE_OUTLOOK_EXPIRED_ACCOUNT", ""
+        ).strip()
+    if not selector:
+        return candidates
+    return [
+        account
+        for account in candidates
+        if account.account.casefold() == selector.casefold()
+    ]
+
+
+def _raw_credential_for_account(
+    account: AccountInput, environment: Mapping[str, str]
+) -> str:
+    if account.provider != "gmail":
+        raise ProviderCallError("Selected healthy account is not Gmail")
+
+    for entry in environment.get("EMAIL_CREDENTIALS", "").split(","):
+        raw_credential = entry.strip()
+        candidate = raw_credential.partition(":")[0].strip()
+        if candidate.casefold() == account.account.casefold():
+            return raw_credential
+    raise ProviderCallError("Selected Gmail account has no raw credential input")
+
+
+def validate_read_only_call(
+    tool: str,
+    arguments: Mapping[str, Any],
+    *,
+    require_account: bool = False,
+) -> None:
+    action = arguments.get("action")
+    if tool not in READ_ONLY_ACTIONS or action not in READ_ONLY_ACTIONS[tool]:
+        raise UnsafeOperation(f"Rejected non-read-only MCP call: {tool}.{action}")
+
+    allowed_keys = {
+        "config": {"action"},
+        "folders": {"action", "account", "folder"},
+        "messages": {"action", "query", "folder", "limit", "account"},
+    }[tool]
+    if set(arguments) - allowed_keys:
+        raise UnsafeOperation("Rejected unexpected MCP arguments")
+
+    account = arguments.get("account")
+    if require_account and (not isinstance(account, str) or not account.strip()):
+        raise UnsafeOperation("An explicit account is required for this call")
+    if account is not None and (not isinstance(account, str) or not account.strip()):
+        raise UnsafeOperation("Invalid account selector")
+
+    if tool == "folders":
+        folder = arguments.get("folder")
+        if action == "status" and (
+            not isinstance(account, str) or not account.strip()
+        ):
+            raise UnsafeOperation("Folder status requires one explicit account")
+        if action == "status" and (
+            not isinstance(folder, str) or not folder.strip()
+        ):
+            raise UnsafeOperation("Folder status requires one explicit folder")
+        if action == "list" and folder is not None:
+            raise UnsafeOperation("Folder list does not accept a folder selector")
+
+    if tool == "messages":
+        limit = arguments.get("limit")
+        if (
+            not isinstance(limit, int)
+            or isinstance(limit, bool)
+            or not 1 <= limit <= RESULT_LIMIT
+        ):
+            raise UnsafeOperation(
+                "Message searches must use the bounded acceptance limit"
+            )
+        if not isinstance(arguments.get("query"), str):
+            raise UnsafeOperation("Message searches require an explicit query")
+
+
+def sanitize_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for field in OUTPUT_FIELDS:
+        if field not in record:
+            continue
+        value = record[field]
+        if field in STRING_OUTPUT_VALUES:
+            if value in STRING_OUTPUT_VALUES[field]:
+                sanitized[field] = value
+            continue
+        if field == "code":
+            if isinstance(value, str) and CODE_PATTERN.fullmatch(value):
+                sanitized[field] = value
+            continue
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            sanitized[field] = value
+    return sanitized
+
+
+def serialize_record(record: Mapping[str, Any]) -> str:
+    return json.dumps(
+        sanitize_record(record), ensure_ascii=False, separators=(",", ":")
+    )
+
+
+def _record(
+    scenario: str,
+    verdict: str,
+    code: str,
+    *,
+    operation: str = "preflight",
+    **metrics: int,
+) -> dict[str, Any]:
+    provider = {
+        "gmail": "gmail",
+        "yahoo-large": "yahoo",
+        "outlook-expired": "outlook",
+    }[scenario]
+    return {
+        "scenario": scenario,
+        "provider": provider,
+        "verdict": verdict,
+        "operation": operation,
+        "code": code,
+        **metrics,
+    }
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fixture_environment(
+    environment: Mapping[str, str], credentials: str
+) -> dict[str, str]:
+    """Build a child environment without forwarding unrelated credentials."""
+    process_keys = (
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "BUN_INSTALL",
+        "CI",
+        "LANG",
+        "LC_ALL",
+    )
+    child: dict[str, str] = {}
+    for key in process_keys:
+        value = environment.get(key) or os.environ.get(key)
+        if value:
+            child[key] = value
+    child.update(
+        {
+            "EMAIL_CREDENTIALS": credentials,
+            "NODE_ENV": "test",
+            "NO_COLOR": "1",
+        }
+    )
+    return child
+
+
+async def _send_imap(writer: asyncio.StreamWriter, *lines: str) -> None:
+    writer.write("".join(lines).encode("utf-8"))
+    await writer.drain()
+
+
+def _search_window(command: str) -> tuple[int, int] | None:
+    matches = re.findall(r"\bUID\s+(\d+):(\d+)\b", command, flags=re.IGNORECASE)
+    if not matches:
+        return None
+    first, second = (int(value) for value in matches[-1])
+    return min(first, second), max(first, second)
+
+
+def _expand_uid_set(sequence_set: str) -> list[int]:
+    result: list[int] = []
+    for part in sequence_set.split(","):
+        if ":" in part:
+            first_text, second_text = part.split(":", 1)
+            if not first_text.isdigit() or not second_text.isdigit():
+                continue
+            first, second = int(first_text), int(second_text)
+            step = 1 if first <= second else -1
+            result.extend(range(first, second + step, step))
+        elif part.isdigit():
+            result.append(int(part))
+    return result
+
+
+def _fixture_message(uid: int, recipient: str) -> bytes:
+    return (
+        "From: Fixture Sender <fixture@example.test>\r\n"
+        f"To: {recipient}\r\n"
+        f"Subject: Fixture message {uid}\r\n"
+        f"Message-ID: <fixture-{uid}@example.test>\r\n"
+        "Date: Thu, 13 Aug 2026 00:00:00 +0000\r\n"
+        "\r\n"
+        f"Read-only provider acceptance fixture message {uid}.\r\n"
+    ).encode()
+
+
+async def _send_fetch_response(
+    writer: asyncio.StreamWriter, uid: int, recipient: str
+) -> None:
+    source = _fixture_message(uid, recipient)
+    envelope = (
+        '("Thu, 13 Aug 2026 00:00:00 +0000" '
+        f'"Fixture message {uid}" '
+        '(("Fixture Sender" NIL "fixture" "example.test")) '
+        '(("Fixture Sender" NIL "fixture" "example.test")) '
+        '(("Fixture Sender" NIL "fixture" "example.test")) '
+        f'((NIL NIL "{recipient.partition("@")[0]}" '
+        f'"{recipient.partition("@")[2]}")) NIL NIL NIL '
+        f'"<fixture-{uid}@example.test>")'
+    )
+    prefix = (
+        f"* {uid} FETCH (UID {uid} FLAGS () ENVELOPE {envelope} "
+        f"BODY[]<0> {{{len(source)}}}\r\n"
+    ).encode()
+    writer.write(prefix)
+    writer.write(source)
+    writer.write(b")\r\n")
+    await writer.drain()
+
+
+async def _serve_fixture_connection(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    fixture: LocalImapFixture,
+    recipient: str,
+) -> None:
+    fixture.connections += 1
+    fixture._writers.add(writer)
+    await _send_imap(
+        writer,
+        "* OK [CAPABILITY IMAP4rev1 NAMESPACE UIDPLUS] "
+        "Provider acceptance fixture ready\r\n",
+    )
+    try:
+        while line_bytes := await reader.readline():
+            if len(line_bytes) > 16_384:
+                break
+            line = line_bytes.decode("utf-8", errors="replace").strip()
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            tag, command = parts[0], parts[1].upper()
+
+            if command == "CAPABILITY":
+                await _send_imap(
+                    writer,
+                    "* CAPABILITY IMAP4rev1 NAMESPACE UIDPLUS\r\n",
+                    f"{tag} OK CAPABILITY completed\r\n",
+                )
+            elif command == "LOGIN":
+                await _send_imap(
+                    writer,
+                    f"{tag} OK [CAPABILITY IMAP4rev1 NAMESPACE UIDPLUS] "
+                    "LOGIN completed\r\n",
+                )
+            elif command == "AUTHENTICATE":
+                if len(parts) < 4:
+                    await _send_imap(writer, "+ \r\n")
+                    await reader.readline()
+                await _send_imap(writer, f"{tag} OK AUTHENTICATE completed\r\n")
+            elif command == "NAMESPACE":
+                await _send_imap(
+                    writer,
+                    '* NAMESPACE (("" "/")) NIL NIL\r\n',
+                    f"{tag} OK NAMESPACE completed\r\n",
+                )
+            elif command in {"LIST", "LSUB"}:
+                await _send_imap(
+                    writer,
+                    '* LIST (\\HasNoChildren) "/" "INBOX"\r\n',
+                    f"{tag} OK {command} completed\r\n",
+                )
+            elif command == "STATUS":
+                fixture.status_requests += 1
+                await _send_imap(
+                    writer,
+                    '* STATUS "INBOX" '
+                    f"(MESSAGES {fixture.message_count} UNSEEN 17 "
+                    f"UIDNEXT {fixture.message_count + 1})\r\n",
+                    f"{tag} OK STATUS completed\r\n",
+                )
+            elif command in {"SELECT", "EXAMINE"}:
+                access = "READ-ONLY" if command == "EXAMINE" else "READ-WRITE"
+                await _send_imap(
+                    writer,
+                    "* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft)\r\n",
+                    f"* {fixture.message_count} EXISTS\r\n",
+                    "* 0 RECENT\r\n",
+                    "* OK [UIDVALIDITY 1] UIDs valid\r\n",
+                    f"* OK [UIDNEXT {fixture.message_count + 1}] Predicted next UID\r\n",
+                    f"{tag} OK [{access}] {command} completed\r\n",
+                )
+            elif command == "UID" and len(parts) >= 3:
+                subcommand = parts[2].upper()
+                if subcommand == "SEARCH":
+                    window = _search_window(line)
+                    if window is None:
+                        fixture.unbounded_search_attempted = True
+                        await _send_imap(
+                            writer, f"{tag} BAD Bounded UID range required\r\n"
+                        )
+                        continue
+                    low, high = window
+                    fixture.search_windows.append(window)
+                    upper = min(high, fixture.message_count)
+                    lower = max(low, upper - RESULT_LIMIT + 1)
+                    matches = list(range(lower, upper + 1)) if upper >= low else []
+                    suffix = " " + " ".join(str(uid) for uid in matches) if matches else ""
+                    await _send_imap(
+                        writer,
+                        f"* SEARCH{suffix}\r\n",
+                        f"{tag} OK UID SEARCH completed\r\n",
+                    )
+                elif subcommand == "FETCH" and len(parts) >= 4:
+                    uids = [
+                        uid
+                        for uid in _expand_uid_set(parts[3])
+                        if 1 <= uid <= fixture.message_count
+                    ]
+                    for uid in uids[:RESULT_LIMIT]:
+                        await _send_fetch_response(writer, uid, recipient)
+                    await _send_imap(writer, f"{tag} OK UID FETCH completed\r\n")
+                else:
+                    await _send_imap(writer, f"{tag} BAD Unsupported UID command\r\n")
+            elif command in {"NOOP", "CLOSE", "UNSELECT"}:
+                await _send_imap(writer, f"{tag} OK {command} completed\r\n")
+            elif command == "LOGOUT":
+                await _send_imap(
+                    writer,
+                    "* BYE Provider acceptance fixture closing\r\n",
+                    f"{tag} OK LOGOUT completed\r\n",
+                )
+                break
+            else:
+                await _send_imap(writer, f"{tag} BAD Unsupported command\r\n")
+    finally:
+        fixture._writers.discard(writer)
+        writer.close()
+        with suppress(Exception):
+            await writer.wait_closed()
+
+
+@asynccontextmanager
+async def local_imap_fixture(
+    recipient: str, message_count: int
+) -> AsyncIterator[LocalImapFixture]:
+    fixture = LocalImapFixture("127.0.0.1", 0, message_count)
+    server = await asyncio.start_server(
+        lambda reader, writer: _serve_fixture_connection(
+            reader, writer, fixture, recipient
+        ),
+        fixture.host,
+        0,
+    )
+    sockets = server.sockets or []
+    if len(sockets) != 1:
+        server.close()
+        await server.wait_closed()
+        raise ProviderCallError("Local IMAP fixture did not bind exactly one socket")
+    fixture.port = int(sockets[0].getsockname()[1])
+    try:
+        yield fixture
+    finally:
+        server.close()
+        await server.wait_closed()
+        writers = tuple(fixture._writers)
+        for writer in writers:
+            writer.close()
+        for writer in writers:
+            with suppress(Exception):
+                await writer.wait_closed()
+
+
+@asynccontextmanager
+async def outlook_replay_fixture(
+    environment: Mapping[str, str],
+    gmail_account: AccountInput,
+) -> AsyncIterator[OutlookReplayFixture]:
+    with tempfile.TemporaryDirectory(
+        prefix="better-email-outlook-acceptance-"
+    ) as temporary_root:
+        root = Path(temporary_root)
+        original_token_path = root / "original-tokens.json"
+        replay_token_path = root / "replay-tokens.json"
+        now = int(time.time())
+        original_store = {
+            OUTLOOK_FIXTURE_ACCOUNT: {
+                "accessToken": "provider-acceptance-access-token",
+                "refreshToken": "provider-acceptance-valid-refresh-token",
+                "expiresAt": now + 3_600,
+                "clientId": "provider-acceptance-client-id",
+            }
+        }
+        original_token_path.write_text(
+            json.dumps(original_store, sort_keys=True), encoding="utf-8"
+        )
+        original_digest = _sha256(original_token_path)
+        shutil.copy2(original_token_path, replay_token_path)
+
+        replay_store = json.loads(replay_token_path.read_text(encoding="utf-8"))
+        replay_token = replay_store[OUTLOOK_FIXTURE_ACCOUNT]
+        replay_token["expiresAt"] = now - 3_600
+        replay_token["refreshToken"] = (
+            "provider-acceptance-intentionally-unrefreshable-token"
+        )
+        replay_token_path.write_text(
+            json.dumps(replay_store, sort_keys=True), encoding="utf-8"
+        )
+        if _sha256(replay_token_path) == original_digest:
+            raise ProviderCallError("Outlook replay token copy was not changed")
+
+        gmail_credential = _raw_credential_for_account(gmail_account, environment)
+        credentials = f"{gmail_credential},{OUTLOOK_FIXTURE_ACCOUNT}"
+        fixture = OutlookReplayFixture(
+            root=root,
+            original_token_path=original_token_path,
+            replay_token_path=replay_token_path,
+            environment=_fixture_environment(environment, credentials),
+        )
+        try:
+            yield fixture
+        finally:
+            if _sha256(original_token_path) != original_digest:
+                raise ProviderCallError("Original Outlook token fixture was mutated")
+
+
+@asynccontextmanager
+async def source_session(
+    scenario: str,
+    environment: dict[str, str],
+    token_path: Path | None,
+) -> AsyncIterator[tuple[ClientSession, StderrCapture]]:
+    source_token_digest = (
+        _sha256(token_path) if token_path is not None and token_path.is_file() else None
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="better-email-provider-acceptance-"
+    ) as temporary_home:
+        profile = Path(temporary_home)
+        token_directory = profile / ".better-email-mcp"
+        token_directory.mkdir(parents=True, exist_ok=True)
+        if token_path is not None and token_path.is_file():
+            shutil.copy2(token_path, token_directory / "tokens.json")
+
+        child_environment = dict(environment)
+        child_environment["HOME"] = str(profile)
+        child_environment["USERPROFILE"] = str(profile)
+        server_args = ["run", "scripts/start-server.ts"]
+        if scenario == "outlook-expired":
+            preload_path = profile / "reject-outlook-refresh.mjs"
+            preload_path.write_text(
+                """
+const nativeFetch = globalThis.fetch.bind(globalThis)
+globalThis.fetch = async (input, init) => {
+  const value = typeof input === 'string' ? input : input.url
+  const url = new URL(value)
+  if (
+    url.hostname === 'login.microsoftonline.com' &&
+    url.pathname.endsWith('/oauth2/v2.0/token')
+  ) {
+    return new Response(
+      JSON.stringify({
+        error: 'invalid_grant',
+        error_description: 'provider acceptance fixture rejected refresh'
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } }
+    )
+  }
+  return nativeFetch(input, init)
+}
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            server_args = [
+                f"--preload={preload_path}",
+                "run",
+                "scripts/start-server.ts",
+            ]
+        parameters = StdioServerParameters(
+            command=shutil.which("bun") or "bun",
+            args=server_args,
+            env=child_environment,
+            cwd=str(REPO_ROOT),
+        )
+        stderr_path = profile / "server.stderr.log"
+        with stderr_path.open("w+", encoding="utf-8") as stderr_stream:
+            stderr = StderrCapture(stderr_stream)
+            try:
+                async with (
+                    stdio_client(parameters, errlog=stderr_stream) as streams,
+                    ClientSession(*streams) as session,
+                ):
+                    yield session, stderr
+            finally:
+                if (
+                    source_token_digest is not None
+                    and token_path is not None
+                    and _sha256(token_path) != source_token_digest
+                ):
+                    raise ProviderCallError("Source token store was mutated")
+
+
+async def _initialize_and_check_tools(session: Any) -> None:
+    await session.initialize()
+    response = await session.list_tools()
+    tool_names = {
+        getattr(tool, "name", None) for tool in getattr(response, "tools", [])
+    }
+    if not {"messages", "folders"}.issubset(tool_names):
+        raise ProviderCallError("Required public tool is missing")
+
+
+async def _call_read_only(
+    session: Any,
+    tool: str,
+    arguments: dict[str, Any],
+    *,
+    require_account: bool = False,
+) -> dict[str, Any]:
+    validate_read_only_call(tool, arguments, require_account=require_account)
+    result = await session.call_tool(tool, arguments)
+    if bool(getattr(result, "isError", False)):
+        raise ProviderCallError("MCP tool returned an error")
+
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, Mapping):
+        return dict(structured)
+
+    decoder = json.JSONDecoder()
+    for block in getattr(result, "content", []):
+        text = getattr(block, "text", None)
+        if not isinstance(text, str):
+            continue
+        for offset, character in enumerate(text):
+            if character != "{":
+                continue
+            try:
+                payload, _ = decoder.raw_decode(text[offset:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                return payload
+    raise ProviderCallError("MCP tool did not return a structured payload")
+
+
+def _stderr_text(stderr: Any) -> str:
+    if isinstance(stderr, str):
+        return stderr
+    getvalue = getattr(stderr, "getvalue", None)
+    return getvalue() if callable(getvalue) else ""
+
+
+def _attempted_interactive_auth(stderr: Any) -> bool:
+    lowered = _stderr_text(stderr).casefold()
+    return any(marker in lowered for marker in INTERACTIVE_AUTH_MARKERS)
+
+
+def _messages(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    messages = payload.get("messages", [])
+    if not isinstance(messages, list):
+        raise ProviderCallError("Invalid messages payload")
+    return [message for message in messages if isinstance(message, Mapping)]
+
+
+def _unavailable_accounts(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    unavailable = payload.get(
+        "unavailable_accounts", payload.get("skippedAccounts", [])
+    )
+    if not isinstance(unavailable, list):
+        raise ProviderCallError("Invalid unavailable-account payload")
+    return [account for account in unavailable if isinstance(account, Mapping)]
+
+
+def _status_message_count(payload: Mapping[str, Any]) -> int:
+    messages = payload.get("messages")
+    if (
+        payload.get("action") != "status"
+        or payload.get("folder") != "INBOX"
+        or not isinstance(messages, int)
+        or isinstance(messages, bool)
+        or messages < 0
+    ):
+        raise ProviderCallError("Invalid folders.status mailbox evidence")
+    return messages
+
+
+def _account_identifiers(item: Mapping[str, Any]) -> set[str]:
+    fields = ("account", "account_email", "accountEmail", "email")
+    return {
+        value.casefold()
+        for field in fields
+        if isinstance((value := item.get(field)), str) and value.strip()
+    }
+
+
+async def _run_gmail(
+    environment: dict[str, str],
+    token_path: Path | None,
+    factory: SessionFactory,
+) -> dict[str, Any]:
+    accounts = select_provider_accounts("gmail", environment)
+    if not accounts:
+        return _record("gmail", "FAILED", "GMAIL_INPUT_MISSING")
+    account = accounts[0]
+    try:
+        gmail_credential = _raw_credential_for_account(account, environment)
+    except ProviderCallError:
+        return _record("gmail", "FAILED", "GMAIL_INPUT_MISSING")
+    child_environment = _fixture_environment(environment, gmail_credential)
+
+    try:
+        async with factory("gmail", child_environment, token_path) as (session, stderr):
+            await _initialize_and_check_tools(session)
+            payload = await _call_read_only(
+                session,
+                "messages",
+                {
+                    "action": "search",
+                    "query": "ALL",
+                    "limit": RESULT_LIMIT,
+                    "account": account.account,
+                },
+                require_account=True,
+            )
+            messages = _messages(payload)
+            unavailable = _unavailable_accounts(payload)
+            interactive_auth = _attempted_interactive_auth(stderr)
+    except Exception:  # noqa: BLE001 - redact all protocol/provider failures at the scenario boundary
+        return _record(
+            "gmail", "FAILED", "PROVIDER_CALL_FAILED", operation="messages.search"
+        )
+
+    if interactive_auth or unavailable:
+        code = (
+            "INTERACTIVE_AUTH_ATTEMPT" if interactive_auth else "PROVIDER_AUTH_FAILED"
+        )
+        return _record("gmail", "FAILED", code, operation="messages.search")
+    return _record(
+        "gmail",
+        "VERIFIED",
+        "OK",
+        operation="messages.search",
+        result_count=len(messages),
+    )
+
+
+async def _run_yahoo(
+    environment: dict[str, str],
+    factory: SessionFactory,
+) -> dict[str, Any]:
+    try:
+        async with local_imap_fixture(
+            YAHOO_FIXTURE_ACCOUNT, YAHOO_FIXTURE_MESSAGE_COUNT
+        ) as imap:
+            credentials = (
+                f"{YAHOO_FIXTURE_ACCOUNT}:{FIXTURE_PASSWORD}:"
+                f"{imap.host}:{imap.port}"
+            )
+            fixture_environment = _fixture_environment(environment, credentials)
+            async with factory(
+                "yahoo-large", fixture_environment, None
+            ) as (session, stderr):
+                await _initialize_and_check_tools(session)
+                status_payload = await _call_read_only(
+                    session,
+                    "folders",
+                    {
+                        "action": "status",
+                        "account": YAHOO_FIXTURE_ACCOUNT,
+                        "folder": "INBOX",
+                    },
+                    require_account=True,
+                )
+                mailbox_evidence = _status_message_count(status_payload)
+                payload = await _call_read_only(
+                    session,
+                    "messages",
+                    {
+                        "action": "search",
+                        "query": "ALL",
+                        "folder": "INBOX",
+                        "limit": RESULT_LIMIT,
+                        "account": YAHOO_FIXTURE_ACCOUNT,
+                    },
+                    require_account=True,
+                )
+                messages = _messages(payload)
+                unavailable = _unavailable_accounts(payload)
+                interactive_auth = _attempted_interactive_auth(stderr)
+
+            if imap.connections and (
+                imap.status_requests != 1
+                or imap.unbounded_search_attempted
+                or not imap.bounded_search_verified()
+            ):
+                raise ProviderCallError("Yahoo IMAP replay was not bounded")
+    except Exception:  # noqa: BLE001 - redact all protocol/provider failures at the scenario boundary
+        return _record(
+            "yahoo-large", "FAILED", "PROVIDER_CALL_FAILED", operation="messages.search"
+        )
+
+    if interactive_auth:
+        return _record(
+            "yahoo-large",
+            "FAILED",
+            "INTERACTIVE_AUTH_ATTEMPT",
+            operation="messages.search",
+        )
+    if unavailable:
+        return _record(
+            "yahoo-large",
+            "FAILED",
+            "PROVIDER_AUTH_FAILED",
+            operation="messages.search",
+        )
+    if mailbox_evidence < YAHOO_MAILBOX_THRESHOLD:
+        return _record(
+            "yahoo-large",
+            "FAILED",
+            "MAILBOX_THRESHOLD_UNPROVEN",
+            operation="messages.search",
+            mailbox_evidence=mailbox_evidence,
+        )
+    if not messages or len(messages) > RESULT_LIMIT:
+        return _record(
+            "yahoo-large",
+            "FAILED",
+            "BOUNDED_RESULTS_UNPROVEN",
+            operation="messages.search",
+            mailbox_evidence=mailbox_evidence,
+        )
+    return _record(
+        "yahoo-large",
+        "VERIFIED",
+        "OK",
+        operation="messages.search",
+        result_count=len(messages),
+        mailbox_evidence=mailbox_evidence,
+    )
+
+
+async def _run_outlook(
+    environment: dict[str, str],
+    factory: SessionFactory,
+) -> dict[str, Any]:
+    gmail_accounts = select_provider_accounts("gmail", environment)
+    if not gmail_accounts:
+        return _record("outlook-expired", "FAILED", "GMAIL_INPUT_MISSING")
+    gmail_account = gmail_accounts[0]
+    try:
+        _raw_credential_for_account(gmail_account, environment)
+    except ProviderCallError:
+        return _record("outlook-expired", "FAILED", "GMAIL_INPUT_MISSING")
+
+    try:
+        async with (
+            outlook_replay_fixture(environment, gmail_account) as fixture,
+            factory(
+                "outlook-expired",
+                fixture.environment,
+                fixture.replay_token_path,
+            ) as (session, stderr),
+        ):
+            await _initialize_and_check_tools(session)
+            payload = await _call_read_only(
+                session,
+                "messages",
+                {
+                    "action": "search",
+                    "query": "ALL",
+                    "folder": "INBOX",
+                    "limit": RESULT_LIMIT,
+                },
+            )
+            messages = _messages(payload)
+            unavailable = _unavailable_accounts(payload)
+            auth_evidence = _stderr_text(stderr) + json.dumps(
+                payload, ensure_ascii=False, default=str
+            )
+            interactive_auth = _attempted_interactive_auth(auth_evidence)
+    except Exception:  # noqa: BLE001 - redact all protocol/provider failures at the scenario boundary
+        return _record(
+            "outlook-expired",
+            "FAILED",
+            "PROVIDER_CALL_FAILED",
+            operation="messages.search",
+        )
+
+    if interactive_auth:
+        return _record(
+            "outlook-expired",
+            "FAILED",
+            "INTERACTIVE_AUTH_ATTEMPT",
+            operation="messages.search",
+        )
+
+    target_key = OUTLOOK_FIXTURE_ACCOUNT.casefold()
+    target_skipped = [
+        account
+        for account in unavailable
+        if target_key in _account_identifiers(account)
+        and account.get("code") == "OAUTH_REFRESH_FAILED"
+    ]
+    healthy_results = [
+        message
+        for message in messages
+        if gmail_account.account.casefold() in _account_identifiers(message)
+    ]
+    if len(target_skipped) != 1:
+        return _record(
+            "outlook-expired",
+            "FAILED",
+            "EXPIRED_TARGET_NOT_SKIPPED",
+            operation="messages.search",
+            result_count=len(messages),
+        )
+    if not healthy_results:
+        return _record(
+            "outlook-expired",
+            "FAILED",
+            "HEALTHY_RESULTS_MISSING",
+            operation="messages.search",
+            result_count=len(messages),
+            skipped_count=len(target_skipped),
+        )
+    return _record(
+        "outlook-expired",
+        "VERIFIED",
+        "OK",
+        operation="messages.search",
+        result_count=len(messages),
+        skipped_count=len(target_skipped),
+        healthy_result_count=len(healthy_results),
+    )
+
+
+async def run_acceptance_async(
+    requested_scenario: str,
+    *,
+    environment: dict[str, str],
+    token_path: Path | None,
+    factory: SessionFactory,
+) -> tuple[list[dict[str, Any]], int]:
+    scenarios = SCENARIOS if requested_scenario == "all" else (requested_scenario,)
+    records: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        if scenario == "gmail":
+            record = await _run_gmail(environment, token_path, factory)
+        elif scenario == "yahoo-large":
+            record = await _run_yahoo(environment, factory)
+        else:
+            record = await _run_outlook(environment, factory)
+        records.append(record)
+    exit_code = 0 if all(record["verdict"] == "VERIFIED" for record in records) else 1
+    return records, exit_code
+
+
+def run_acceptance(
+    requested_scenario: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    session_factory: SessionFactory = source_session,
+    token_metadata: Mapping[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    if requested_scenario not in (*SCENARIOS, "all"):
+        raise ValueError(f"Unsupported scenario: {requested_scenario}")
+
+    environment = dict(os.environ if env is None else env)
+    # Kept as a compatibility-only keyword for callers from the earlier harness.
+    # Exact provider replays never read caller-supplied or machine token metadata.
+    del token_metadata
+
+    return asyncio.run(
+        run_acceptance_async(
+            requested_scenario,
+            environment=environment,
+            token_path=None,
+            factory=session_factory,
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run read-only provider acceptance scenarios"
+    )
+    parser.add_argument("--scenario", required=True, choices=(*SCENARIOS, "all"))
+    arguments = parser.parse_args(argv)
+    records, exit_code = run_acceptance(arguments.scenario)
+    for record in records:
+        print(serialize_record(record), flush=True)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_provider_acceptance.py
+++ b/scripts/test_provider_acceptance.py
@@ -76,7 +76,10 @@ def session_factory(session: FakeSession, transcript: str = "") -> Any:
 
 
 def gmail_environment() -> dict[str, str]:
-    return {"EMAIL_CREDENTIALS": "gmail.acceptance@gmail.com:app-password"}
+    return {
+        "EMAIL_CREDENTIALS": "gmail.acceptance@gmail.com:app-password",
+        "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": "gmail.acceptance@gmail.com",
+    }
 
 
 def gmail_success() -> FakeResult:
@@ -326,6 +329,78 @@ def test_redacted_jsonl_has_a_strict_field_allowlist() -> None:
     assert "https://" not in line
 
 
+def test_gmail_requires_explicit_selector_when_multiple_accounts_are_discovered() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("Missing Gmail selector must fail before spawning the server")
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env={
+            "EMAIL_CREDENTIALS": (
+                "first@gmail.com:first-app-password,"
+                "second@gmail.com:second-app-password"
+            )
+        },
+        session_factory=forbidden_factory,
+    )
+
+    assert exit_code == 1
+    assert records[0]["code"] == "GMAIL_INPUT_MISSING"
+
+
+def test_gmail_explicit_selector_without_matching_candidate_fails_before_spawn() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise AssertionError("An unmatched Gmail selector must fail before spawning")
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env={
+            "EMAIL_CREDENTIALS": "available@gmail.com:app-password",
+            "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": "missing@gmail.com",
+        },
+        session_factory=forbidden_factory,
+    )
+
+    assert exit_code == 1
+    assert records == [
+        {
+            "scenario": "gmail",
+            "provider": "gmail",
+            "verdict": "FAILED",
+            "operation": "preflight",
+            "code": "GMAIL_INPUT_MISSING",
+        }
+    ]
+
+
+def test_gmail_explicit_selected_account_without_raw_credential_fails_before_spawn() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise AssertionError("A missing Gmail raw credential must fail before spawning")
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env={
+            "EMAIL_USER": "selected@gmail.com",
+            "EMAIL_PROVIDER": "gmail",
+            "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": "selected@gmail.com",
+        },
+        session_factory=forbidden_factory,
+    )
+
+    assert exit_code == 1
+    assert records == [
+        {
+            "scenario": "gmail",
+            "provider": "gmail",
+            "verdict": "FAILED",
+            "operation": "preflight",
+            "code": "GMAIL_INPUT_MISSING",
+        }
+    ]
+
+
 def test_gmail_missing_input_and_provider_failure_are_failed_never_user_gate() -> None:
     def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
         raise AssertionError("Missing Gmail input must fail before spawning the server")
@@ -550,6 +625,72 @@ def test_yahoo_large_uses_targeted_status_before_bounded_search() -> None:
     ]
 
 
+def test_yahoo_unbounded_fixture_search_fails_before_acceptance() -> None:
+    session = FakeSession(
+        [
+            FakeResult(
+                {
+                    "action": "status",
+                    "account_email": acceptance.YAHOO_FIXTURE_ACCOUNT,
+                    "folder": "INBOX",
+                    "messages": 10_025,
+                }
+            ),
+            FakeResult(
+                {
+                    "action": "search",
+                    "messages": [
+                        {
+                            "uid": 10_025,
+                            "account_email": acceptance.YAHOO_FIXTURE_ACCOUNT,
+                        }
+                    ],
+                    "unavailable_accounts": [],
+                }
+            ),
+        ]
+    )
+
+    @asynccontextmanager
+    async def unbounded_factory(
+        scenario: str, environment: dict[str, str], token_path: Path | None
+    ) -> Any:
+        del scenario, token_path
+        credential = environment["EMAIL_CREDENTIALS"]
+        _, host, port_text = credential.rsplit(":", 2)
+        reader, writer = await asyncio.open_connection(host, int(port_text))
+        try:
+            await asyncio.wait_for(reader.readline(), timeout=5)
+            writer.write(b"a001 STATUS INBOX (MESSAGES)\r\n")
+            await writer.drain()
+            await asyncio.wait_for(reader.readline(), timeout=5)
+            await asyncio.wait_for(reader.readline(), timeout=5)
+            writer.write(b"a002 UID SEARCH ALL\r\n")
+            await writer.drain()
+            await asyncio.wait_for(reader.readline(), timeout=5)
+            yield session, io.StringIO()
+        finally:
+            writer.close()
+            await asyncio.wait_for(writer.wait_closed(), timeout=5)
+
+    records, exit_code = acceptance.run_acceptance(
+        "yahoo-large",
+        env={},
+        session_factory=unbounded_factory,
+    )
+
+    assert exit_code == 1
+    assert records == [
+        {
+            "scenario": "yahoo-large",
+            "provider": "yahoo",
+            "verdict": "FAILED",
+            "operation": "messages.search",
+            "code": "PROVIDER_CALL_FAILED",
+        }
+    ]
+
+
 def test_yahoo_count_evidence_accepts_only_folders_status_messages() -> None:
     assert acceptance._status_message_count(
         {"action": "status", "folder": "INBOX", "messages": 10_025}
@@ -726,13 +867,43 @@ def test_outlook_missing_or_unmatched_gmail_is_failed_before_server_spawn() -> N
         assert "USER_GATE" not in acceptance.serialize_record(records[0])
 
 
+def test_outlook_explicit_selected_gmail_account_without_raw_credential_fails_before_spawn() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise AssertionError("A missing Gmail raw credential must fail before spawning")
+
+    records, exit_code = acceptance.run_acceptance(
+        "outlook-expired",
+        env={
+            "EMAIL_USER": "selected@gmail.com",
+            "EMAIL_PROVIDER": "gmail",
+            "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": "selected@gmail.com",
+        },
+        session_factory=forbidden_factory,
+    )
+
+    assert exit_code == 1
+    assert records == [
+        {
+            "scenario": "outlook-expired",
+            "provider": "outlook",
+            "verdict": "FAILED",
+            "operation": "preflight",
+            "code": "GMAIL_INPUT_MISSING",
+        }
+    ]
+
+
 def test_outlook_interactive_auth_output_is_failed() -> None:
     healthy_account = "healthy.acceptance@gmail.com"
     session = FakeSession([outlook_success(healthy_account)])
 
     records, exit_code = acceptance.run_acceptance(
         "outlook-expired",
-        env={"EMAIL_CREDENTIALS": f"{healthy_account}:app-password"},
+        env={
+            "EMAIL_CREDENTIALS": f"{healthy_account}:app-password",
+            "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": healthy_account,
+        },
         session_factory=session_factory(
             session,
             transcript="Open https://microsoft.com/devicelogin and enter device code ABCD",
@@ -761,7 +932,10 @@ def test_outlook_single_account_without_raw_credential_fails_before_spawn() -> N
 
 def test_outlook_failure_verdicts_cover_protocol_and_replay_evidence() -> None:
     healthy_account = "healthy.acceptance@gmail.com"
-    environment = {"EMAIL_CREDENTIALS": f"{healthy_account}:app-password"}
+    environment = {
+        "EMAIL_CREDENTIALS": f"{healthy_account}:app-password",
+        "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": healthy_account,
+    }
     cases = [
         (
             FakeResult(is_error=True),

--- a/scripts/test_provider_acceptance.py
+++ b/scripts/test_provider_acceptance.py
@@ -1,0 +1,701 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import provider_acceptance as acceptance
+
+
+class FakeResult:
+    def __init__(
+        self, payload: dict[str, Any] | None = None, *, is_error: bool = False
+    ) -> None:
+        self.structuredContent = payload
+        self.content: list[Any] = []
+        self.isError = is_error
+
+
+class FakeSession:
+    def __init__(self, responses: list[FakeResult]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.initialized = False
+        self.listed = False
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def list_tools(self) -> Any:
+        self.listed = True
+        return SimpleNamespace(
+            tools=[
+                SimpleNamespace(name="messages"),
+                SimpleNamespace(name="folders"),
+                SimpleNamespace(name="config"),
+            ]
+        )
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> FakeResult:
+        self.calls.append((name, arguments))
+        if not self.responses:
+            raise AssertionError("Unexpected extra MCP tool call")
+        return self.responses.pop(0)
+
+
+def session_factory(session: FakeSession, transcript: str = "") -> Any:
+    calls: list[str] = []
+    environments: list[dict[str, str]] = []
+    token_paths: list[Path | None] = []
+
+    @asynccontextmanager
+    async def factory(
+        scenario: str, environment: dict[str, str], token_path: Path | None
+    ) -> Any:
+        calls.append(scenario)
+        environments.append(dict(environment))
+        token_paths.append(token_path)
+        stderr = io.StringIO()
+        stderr.write(transcript)
+        yield session, stderr
+
+    factory.calls = calls
+    factory.environments = environments
+    factory.token_paths = token_paths
+    return factory
+
+
+def gmail_environment() -> dict[str, str]:
+    return {"EMAIL_CREDENTIALS": "gmail.acceptance@gmail.com:app-password"}
+
+
+def gmail_success() -> FakeResult:
+    return FakeResult(
+        {
+            "action": "search",
+            "total": 1,
+            "accounts_searched": ["gmail.acceptance@gmail.com"],
+            "messages": [{"uid": 42, "account_email": "gmail.acceptance@gmail.com"}],
+            "unavailable_accounts": [],
+        }
+    )
+
+
+def test_provider_selection_uses_provider_metadata_instead_of_credential_order() -> (
+    None
+):
+    environment = {
+        "EMAIL_CREDENTIALS": (
+            "first@outlook.com:one,selected@gmail.com:two,last@yahoo.com:three"
+        )
+    }
+
+    selected = acceptance.select_provider_accounts("gmail", environment)
+
+    assert [account.account for account in selected] == ["selected@gmail.com"]
+    assert selected[0].provider == "gmail"
+    assert not hasattr(selected[0], "password")
+
+
+def test_explicit_selector_must_name_an_account_for_the_requested_provider() -> None:
+    environment = {
+        "EMAIL_CREDENTIALS": "one@gmail.com:one,two@gmail.com:two",
+        "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": "two@gmail.com",
+    }
+
+    selected = acceptance.select_provider_accounts("gmail", environment)
+    assert [account.account for account in selected] == ["two@gmail.com"]
+
+    environment["PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT"] = "missing@gmail.com"
+    assert acceptance.select_provider_accounts("gmail", environment) == []
+
+
+def test_read_only_guard_rejects_mutating_and_setup_calls() -> None:
+    acceptance.validate_read_only_call(
+        "messages",
+        {"action": "search", "query": "ALL", "limit": 3, "account": "safe@gmail.com"},
+        require_account=True,
+    )
+    acceptance.validate_read_only_call(
+        "folders",
+        {
+            "action": "status",
+            "account": "safe@yahoo.test",
+            "folder": "INBOX",
+        },
+        require_account=True,
+    )
+
+    for tool, arguments in [
+        ("messages", {"action": "send"}),
+        ("messages", {"action": "reply"}),
+        ("messages", {"action": "move"}),
+        ("messages", {"action": "trash"}),
+        ("messages", {"action": "delete"}),
+        ("messages", {"action": "flag"}),
+        ("messages", {"action": "mark"}),
+        ("config", {"action": "setup", "mode": "save"}),
+        ("config", {"action": "setup", "mode": "reset"}),
+        ("folders", {"action": "status", "account": "safe@yahoo.test"}),
+        ("folders", {"action": "status", "folder": "INBOX"}),
+        ("folders", {"action": "list", "folder": "INBOX"}),
+    ]:
+        with pytest.raises(acceptance.UnsafeOperation):
+            acceptance.validate_read_only_call(tool, arguments)
+
+
+def test_source_session_uses_a_subprocess_compatible_redacted_stderr_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+    source_token_path = tmp_path / "source-tokens.json"
+    source_token_bytes = b'{"fixture":{"accessToken":"source-only"}}'
+    source_token_path.write_bytes(source_token_bytes)
+
+    @asynccontextmanager
+    async def fake_stdio_client(parameters: Any, *, errlog: Any) -> Any:
+        captured["fileno"] = errlog.fileno()
+        profile = Path(parameters.env["USERPROFILE"])
+        child_token_path = profile / ".better-email-mcp" / "tokens.json"
+        captured["profile"] = profile
+        captured["child_token_path"] = child_token_path
+        assert child_token_path.read_bytes() == source_token_bytes
+        child_token_path.write_text('{"fixture":"child-mutated"}', encoding="utf-8")
+        errlog.write("server started without account data")
+        errlog.flush()
+        yield "read", "write"
+
+    class FakeClientSessionContext:
+        def __init__(self, *streams: Any) -> None:
+            captured["streams"] = streams
+
+        async def __aenter__(self) -> Any:
+            return SimpleNamespace()
+
+        async def __aexit__(self, *args: object) -> None:
+            del args
+
+    monkeypatch.setattr(acceptance, "stdio_client", fake_stdio_client)
+    monkeypatch.setattr(acceptance, "ClientSession", FakeClientSessionContext)
+
+    async def inspect_session() -> None:
+        async with acceptance.source_session(
+            "gmail", {}, source_token_path
+        ) as (_, stderr):
+            assert "server started" in acceptance._stderr_text(stderr)
+
+    asyncio.run(inspect_session())
+
+    assert isinstance(captured["fileno"], int)
+    assert captured["streams"] == ("read", "write")
+    assert source_token_path.read_bytes() == source_token_bytes
+    assert not captured["profile"].exists()
+
+
+def test_outlook_source_session_preloads_only_the_refresh_rejection_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    @asynccontextmanager
+    async def fake_stdio_client(parameters: Any, *, errlog: Any) -> Any:
+        del errlog
+        captured["args"] = parameters.args
+        _, separator, preload_value = parameters.args[0].partition("=")
+        assert separator == "="
+        preload_path = Path(preload_value)
+        assert preload_path.is_file()
+        preload_text = preload_path.read_text(encoding="utf-8")
+        assert "invalid_grant" in preload_text
+        assert "devicecode" not in preload_text.casefold()
+        yield "read", "write"
+
+    class FakeClientSessionContext:
+        def __init__(self, *streams: Any) -> None:
+            del streams
+
+        async def __aenter__(self) -> Any:
+            return SimpleNamespace()
+
+        async def __aexit__(self, *args: object) -> None:
+            del args
+
+    monkeypatch.setattr(acceptance, "stdio_client", fake_stdio_client)
+    monkeypatch.setattr(acceptance, "ClientSession", FakeClientSessionContext)
+
+    async def inspect_session() -> None:
+        async with acceptance.source_session("outlook-expired", {}, None):
+            pass
+
+    asyncio.run(inspect_session())
+
+    assert captured["args"][0].startswith("--preload=")
+    assert captured["args"][1:] == ["run", "scripts/start-server.ts"]
+
+
+def test_redacted_jsonl_has_a_strict_field_allowlist() -> None:
+    line = acceptance.serialize_record(
+        {
+            "scenario": "gmail",
+            "provider": "gmail",
+            "verdict": "FAILED",
+            "operation": "messages.search",
+            "code": "PROVIDER_CALL_FAILED",
+            "result_count": 0,
+            "account": "private@gmail.com",
+            "detail": "Bearer secret-token https://login.example.test",
+            "subject": "private subject",
+        }
+    )
+    payload = json.loads(line)
+
+    assert payload == {
+        "scenario": "gmail",
+        "provider": "gmail",
+        "verdict": "FAILED",
+        "operation": "messages.search",
+        "code": "PROVIDER_CALL_FAILED",
+        "result_count": 0,
+    }
+    assert "@" not in line
+    assert "secret-token" not in line
+    assert "https://" not in line
+
+
+def test_gmail_missing_input_and_provider_failure_are_failed_never_user_gate() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("Missing Gmail input must fail before spawning the server")
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail", env={}, session_factory=forbidden_factory, token_metadata={}
+    )
+    assert exit_code != 0
+    assert records[0]["verdict"] == "FAILED"
+
+    session = FakeSession([FakeResult(is_error=True)])
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env=gmail_environment(),
+        session_factory=session_factory(session),
+        token_metadata={},
+    )
+    assert exit_code != 0
+    assert records[0]["verdict"] == "FAILED"
+    assert records[0]["verdict"] != "USER_GATE"
+
+
+def test_gmail_runs_real_protocol_shape_with_explicit_bounded_account_call() -> None:
+    session = FakeSession([gmail_success()])
+    factory = session_factory(session)
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env=gmail_environment(),
+        session_factory=factory,
+        token_metadata={},
+    )
+
+    assert exit_code == 0
+    assert records == [
+        {
+            "scenario": "gmail",
+            "provider": "gmail",
+            "verdict": "VERIFIED",
+            "operation": "messages.search",
+            "code": "OK",
+            "result_count": 1,
+        }
+    ]
+    assert session.initialized is True
+    assert session.listed is True
+    assert factory.calls == ["gmail"]
+    assert session.calls == [
+        (
+            "messages",
+            {
+                "action": "search",
+                "query": "ALL",
+                "limit": 3,
+                "account": "gmail.acceptance@gmail.com",
+            },
+        )
+    ]
+
+
+def test_gmail_child_process_receives_only_the_selected_credential() -> None:
+    selected_account = "selected.acceptance@gmail.com"
+    selected_credential = f"{selected_account}:selected-app-password"
+    environment = {
+        "EMAIL_CREDENTIALS": (
+            "other@gmail.com:other-app-password,"
+            f"{selected_credential},"
+            "unrelated@outlook.com"
+        ),
+        "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": selected_account,
+        "UNRELATED_SECRET": "must-not-reach-the-child",
+    }
+    session = FakeSession(
+        [
+            FakeResult(
+                {
+                    "action": "search",
+                    "messages": [{"uid": 42, "account_email": selected_account}],
+                    "unavailable_accounts": [],
+                }
+            )
+        ]
+    )
+    factory = session_factory(session)
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env=environment,
+        session_factory=factory,
+    )
+
+    assert exit_code == 0
+    assert records[0]["verdict"] == "VERIFIED"
+    child_environment = factory.environments[0]
+    assert child_environment["EMAIL_CREDENTIALS"] == selected_credential
+    assert "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT" not in child_environment
+    assert "UNRELATED_SECRET" not in child_environment
+    assert set(child_environment) <= {
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "BUN_INSTALL",
+        "CI",
+        "LANG",
+        "LC_ALL",
+        "EMAIL_CREDENTIALS",
+        "NODE_ENV",
+        "NO_COLOR",
+    }
+
+
+def test_yahoo_large_uses_targeted_status_before_bounded_search() -> None:
+    session = FakeSession(
+        [
+            FakeResult(
+                {
+                    "action": "status",
+                    "account_email": acceptance.YAHOO_FIXTURE_ACCOUNT,
+                    "folder": "INBOX",
+                    "messages": 10_025,
+                    "unseen": 17,
+                    "uid_next": 10_026,
+                }
+            ),
+            FakeResult(
+                {
+                    "action": "search",
+                    "total": 1,
+                    "messages": [
+                        {
+                            "uid": 10_025,
+                            "account_email": acceptance.YAHOO_FIXTURE_ACCOUNT,
+                        }
+                    ],
+                    "unavailable_accounts": [],
+                }
+            ),
+        ]
+    )
+    records, exit_code = acceptance.run_acceptance(
+        "yahoo-large",
+        env={},
+        session_factory=session_factory(session),
+    )
+
+    assert exit_code == 0
+    assert records[0]["verdict"] == "VERIFIED"
+    assert records[0]["mailbox_evidence"] == 10_025
+    assert session.calls == [
+        (
+            "folders",
+            {
+                "action": "status",
+                "account": acceptance.YAHOO_FIXTURE_ACCOUNT,
+                "folder": "INBOX",
+            },
+        ),
+        (
+            "messages",
+            {
+                "action": "search",
+                "query": "ALL",
+                "folder": "INBOX",
+                "limit": 3,
+                "account": acceptance.YAHOO_FIXTURE_ACCOUNT,
+            },
+        ),
+    ]
+
+
+def test_yahoo_count_evidence_accepts_only_folders_status_messages() -> None:
+    assert acceptance._status_message_count(
+        {"action": "status", "folder": "INBOX", "messages": 10_025}
+    ) == 10_025
+    with pytest.raises(acceptance.ProviderCallError):
+        acceptance._status_message_count(
+            {
+                "action": "list",
+                "folders": [{"path": "INBOX"}],
+            }
+        )
+
+
+def outlook_success(healthy_account: str) -> FakeResult:
+    return FakeResult(
+        {
+            "action": "search",
+            "messages": [
+                {"uid": 7, "account_email": healthy_account}
+            ],
+            "unavailable_accounts": [
+                {
+                    "account_email": acceptance.OUTLOOK_FIXTURE_ACCOUNT,
+                    "code": "OAUTH_REFRESH_FAILED",
+                }
+            ],
+        }
+    )
+
+
+def test_outlook_expired_selects_and_isolates_one_real_gmail_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected_account = "selected.acceptance@gmail.com"
+    selected_raw_credential = f"{selected_account}:selected:app-password"
+    environment = {
+        "EMAIL_CREDENTIALS": (
+            "unrelated@outlook.com,"
+            "other@gmail.com:other-app-password,"
+            f"{selected_raw_credential},"
+            "last@yahoo.com:yahoo-app-password"
+        ),
+        "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": selected_account,
+    }
+    session = FakeSession([outlook_success(selected_account)])
+    factory = session_factory(session)
+
+    @asynccontextmanager
+    async def forbidden_local_imap_fixture(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise AssertionError("Outlook replay must retain a real Gmail credential")
+        yield
+
+    monkeypatch.setattr(
+        acceptance, "local_imap_fixture", forbidden_local_imap_fixture
+    )
+
+    records, exit_code = acceptance.run_acceptance(
+        "outlook-expired",
+        env=environment,
+        session_factory=factory,
+    )
+
+    assert exit_code == 0
+    assert records == [
+        {
+            "scenario": "outlook-expired",
+            "provider": "outlook",
+            "verdict": "VERIFIED",
+            "operation": "messages.search",
+            "code": "OK",
+            "result_count": 1,
+            "skipped_count": 1,
+            "healthy_result_count": 1,
+        }
+    ]
+    assert session.calls == [
+        (
+            "messages",
+            {"action": "search", "query": "ALL", "folder": "INBOX", "limit": 3},
+        )
+    ]
+    assert factory.token_paths[0] is not None
+    assert not factory.token_paths[0].exists()
+    child_credentials = factory.environments[0]["EMAIL_CREDENTIALS"].split(",")
+    assert child_credentials == [
+        selected_raw_credential,
+        acceptance.OUTLOOK_FIXTURE_ACCOUNT,
+    ]
+    assert "other@gmail.com:other-app-password" not in child_credentials
+    assert "unrelated@outlook.com" not in child_credentials
+    serialized = acceptance.serialize_record(records[0])
+    assert selected_account not in serialized
+    assert "selected:app-password" not in serialized
+
+
+def test_outlook_missing_or_unmatched_gmail_is_failed_before_server_spawn() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise AssertionError("Missing Gmail input must fail before spawning the server")
+
+    for environment in (
+        {},
+        {"EMAIL_CREDENTIALS": "only@outlook.com"},
+        {
+            "EMAIL_CREDENTIALS": "available@gmail.com:app-password",
+            "PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT": "missing@gmail.com",
+        },
+    ):
+        records, exit_code = acceptance.run_acceptance(
+            "outlook-expired",
+            env=environment,
+            session_factory=forbidden_factory,
+        )
+
+        assert exit_code != 0
+        assert records == [
+            {
+                "scenario": "outlook-expired",
+                "provider": "outlook",
+                "verdict": "FAILED",
+                "operation": "preflight",
+                "code": "GMAIL_INPUT_MISSING",
+            }
+        ]
+        assert "USER_GATE" not in acceptance.serialize_record(records[0])
+
+
+def test_outlook_interactive_auth_output_is_failed() -> None:
+    healthy_account = "healthy.acceptance@gmail.com"
+    session = FakeSession([outlook_success(healthy_account)])
+
+    records, exit_code = acceptance.run_acceptance(
+        "outlook-expired",
+        env={"EMAIL_CREDENTIALS": f"{healthy_account}:app-password"},
+        session_factory=session_factory(
+            session,
+            transcript="Open https://microsoft.com/devicelogin and enter device code ABCD",
+        ),
+    )
+
+    assert exit_code != 0
+    assert records[0]["verdict"] == "FAILED"
+    assert records[0]["code"] == "INTERACTIVE_AUTH_ATTEMPT"
+
+
+def test_outlook_fixture_expires_only_a_copy_and_cleans_every_temp_file() -> None:
+    captured: dict[str, Path] = {}
+    environment = gmail_environment()
+    gmail_account = acceptance.select_provider_accounts("gmail", environment)[0]
+
+    async def inspect_fixture() -> None:
+        async with acceptance.outlook_replay_fixture(
+            environment, gmail_account
+        ) as fixture:
+            captured["root"] = fixture.root
+            captured["original"] = fixture.original_token_path
+            captured["copy"] = fixture.replay_token_path
+            original = json.loads(fixture.original_token_path.read_text(encoding="utf-8"))
+            replay = json.loads(fixture.replay_token_path.read_text(encoding="utf-8"))
+            original_token = original[acceptance.OUTLOOK_FIXTURE_ACCOUNT]
+            replay_token = replay[acceptance.OUTLOOK_FIXTURE_ACCOUNT]
+            assert original_token["expiresAt"] > replay_token["expiresAt"]
+            assert original_token["refreshToken"] != replay_token["refreshToken"]
+            assert original_token["accessToken"] == replay_token["accessToken"]
+
+    asyncio.run(inspect_fixture())
+
+    assert not captured["root"].exists()
+    assert not captured["original"].exists()
+    assert not captured["copy"].exists()
+
+
+def test_exact_yahoo_fixture_replay_runs_current_source_without_user_gate() -> None:
+    yahoo_records, yahoo_exit = acceptance.run_acceptance("yahoo-large", env={})
+
+    assert yahoo_exit == 0
+    assert yahoo_records[0]["verdict"] == "VERIFIED"
+    assert yahoo_records[0]["mailbox_evidence"] >= 10_000
+    assert 0 < yahoo_records[0]["result_count"] <= 3
+    serialized = "\n".join(
+        acceptance.serialize_record(record) for record in yahoo_records
+    )
+    assert "USER_GATE" not in serialized
+    assert "@" not in serialized
+    assert "http://" not in serialized
+    assert "https://" not in serialized
+
+
+@pytest.mark.skipif(
+    not os.environ.get("PROVIDER_ACCEPTANCE_GMAIL_ACCOUNT"),
+    reason="Exact Outlook source replay requires an explicitly selected real Gmail input",
+)
+def test_exact_outlook_replay_runs_current_source_without_user_gate() -> None:
+    records, exit_code = acceptance.run_acceptance(
+        "outlook-expired", env=dict(os.environ)
+    )
+
+    assert exit_code == 0
+    assert records[0]["verdict"] == "VERIFIED"
+    assert records[0]["skipped_count"] == 1
+    assert records[0]["healthy_result_count"] > 0
+    serialized = acceptance.serialize_record(records[0])
+    assert "USER_GATE" not in serialized
+    assert "@" not in serialized
+    assert "http://" not in serialized
+    assert "https://" not in serialized
+
+
+def test_all_is_nonzero_when_gmail_input_is_missing() -> None:
+    session = FakeSession(
+        [
+            FakeResult(
+                {
+                    "action": "status",
+                    "folder": "INBOX",
+                    "messages": 10_025,
+                    "unseen": 17,
+                    "uid_next": 10_026,
+                }
+            ),
+            FakeResult(
+                {
+                    "action": "search",
+                    "messages": [
+                        {
+                            "uid": 10_025,
+                            "account_email": acceptance.YAHOO_FIXTURE_ACCOUNT,
+                        }
+                    ],
+                    "unavailable_accounts": [],
+                }
+            ),
+        ]
+    )
+    factory = session_factory(session)
+
+    records, exit_code = acceptance.run_acceptance(
+        "all",
+        env={},
+        session_factory=factory,
+    )
+
+    assert [record["verdict"] for record in records] == [
+        "FAILED",
+        "VERIFIED",
+        "FAILED",
+    ]
+    assert exit_code != 0
+    assert records[2]["code"] == "GMAIL_INPUT_MISSING"
+    assert factory.calls == ["yahoo-large"]

--- a/scripts/test_provider_acceptance.py
+++ b/scripts/test_provider_acceptance.py
@@ -120,6 +120,40 @@ def test_explicit_selector_must_name_an_account_for_the_requested_provider() -> 
     assert acceptance.select_provider_accounts("gmail", environment) == []
 
 
+def test_account_discovery_supports_single_input_and_legacy_outlook_selector() -> None:
+    single_environment = {
+        "EMAIL_USER": "single@gmail.com",
+        "EMAIL_PROVIDER": "gmail",
+    }
+
+    assert acceptance.discover_accounts(single_environment) == [
+        acceptance.AccountInput(account="single@gmail.com", provider="gmail")
+    ]
+    assert acceptance._provider_for_account("unknown@example.test", {}) is None
+
+    outlook_environment = {
+        "EMAIL_CREDENTIALS": "legacy@outlook.com",
+        "PROVIDER_ACCEPTANCE_OUTLOOK_EXPIRED_ACCOUNT": "legacy@outlook.com",
+    }
+    assert acceptance.select_provider_accounts("outlook", outlook_environment) == [
+        acceptance.AccountInput(account="legacy@outlook.com", provider="outlook")
+    ]
+
+
+def test_raw_gmail_credential_requires_a_matching_gmail_input() -> None:
+    with pytest.raises(acceptance.ProviderCallError, match="not Gmail"):
+        acceptance._raw_credential_for_account(
+            acceptance.AccountInput(account="user@yahoo.com", provider="yahoo"),
+            {"EMAIL_CREDENTIALS": "user@yahoo.com:password"},
+        )
+
+    with pytest.raises(acceptance.ProviderCallError, match="no raw credential"):
+        acceptance._raw_credential_for_account(
+            acceptance.AccountInput(account="missing@gmail.com", provider="gmail"),
+            {"EMAIL_CREDENTIALS": "other@gmail.com:password"},
+        )
+
+
 def test_read_only_guard_rejects_mutating_and_setup_calls() -> None:
     acceptance.validate_read_only_call(
         "messages",
@@ -152,6 +186,25 @@ def test_read_only_guard_rejects_mutating_and_setup_calls() -> None:
     ]:
         with pytest.raises(acceptance.UnsafeOperation):
             acceptance.validate_read_only_call(tool, arguments)
+
+
+@pytest.mark.parametrize(
+    ("arguments", "require_account"),
+    [
+        ({"action": "search", "query": "ALL", "limit": 3, "extra": True}, False),
+        ({"action": "search", "query": "ALL", "limit": 3}, True),
+        ({"action": "search", "query": "ALL", "limit": 3, "account": 7}, False),
+        ({"action": "search", "query": "ALL", "limit": 4}, False),
+        ({"action": "search", "limit": 3}, False),
+    ],
+)
+def test_read_only_guard_rejects_unbounded_or_malformed_searches(
+    arguments: dict[str, Any], require_account: bool
+) -> None:
+    with pytest.raises(acceptance.UnsafeOperation):
+        acceptance.validate_read_only_call(
+            "messages", arguments, require_account=require_account
+        )
 
 
 def test_source_session_uses_a_subprocess_compatible_redacted_stderr_file(
@@ -293,6 +346,55 @@ def test_gmail_missing_input_and_provider_failure_are_failed_never_user_gate() -
     assert exit_code != 0
     assert records[0]["verdict"] == "FAILED"
     assert records[0]["verdict"] != "USER_GATE"
+
+
+def test_gmail_single_account_without_raw_credential_fails_before_spawn() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise AssertionError("Missing raw credential must fail before spawning")
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env={"EMAIL_USER": "single@gmail.com", "EMAIL_PROVIDER": "gmail"},
+        session_factory=forbidden_factory,
+    )
+
+    assert exit_code == 1
+    assert records[0]["code"] == "GMAIL_INPUT_MISSING"
+
+
+@pytest.mark.parametrize(
+    ("transcript", "unavailable", "expected_code"),
+    [
+        ("Enter device code ABCD", [], "INTERACTIVE_AUTH_ATTEMPT"),
+        ("", [{"account_email": "gmail.acceptance@gmail.com"}], "PROVIDER_AUTH_FAILED"),
+    ],
+)
+def test_gmail_rejects_interactive_or_unavailable_provider_results(
+    transcript: str,
+    unavailable: list[dict[str, str]],
+    expected_code: str,
+) -> None:
+    session = FakeSession(
+        [
+            FakeResult(
+                {
+                    "action": "search",
+                    "messages": [],
+                    "unavailable_accounts": unavailable,
+                }
+            )
+        ]
+    )
+
+    records, exit_code = acceptance.run_acceptance(
+        "gmail",
+        env=gmail_environment(),
+        session_factory=session_factory(session, transcript),
+    )
+
+    assert exit_code == 1
+    assert records[0]["code"] == expected_code
 
 
 def test_gmail_runs_real_protocol_shape_with_explicit_bounded_account_call() -> None:
@@ -461,6 +563,54 @@ def test_yahoo_count_evidence_accepts_only_folders_status_messages() -> None:
         )
 
 
+def test_yahoo_failure_verdicts_cover_each_acceptance_boundary() -> None:
+    message = {"uid": 10_025, "account_email": acceptance.YAHOO_FIXTURE_ACCOUNT}
+    cases = [
+        (10_025, [message], [], "Enter device code ABCD", "INTERACTIVE_AUTH_ATTEMPT"),
+        (10_025, [message], [{"code": "AUTH_FAILED"}], "", "PROVIDER_AUTH_FAILED"),
+        (9_999, [message], [], "", "MAILBOX_THRESHOLD_UNPROVEN"),
+        (10_025, [], [], "", "BOUNDED_RESULTS_UNPROVEN"),
+    ]
+
+    for mailbox_count, messages, unavailable, transcript, expected_code in cases:
+        session = FakeSession(
+            [
+                FakeResult(
+                    {
+                        "action": "status",
+                        "folder": "INBOX",
+                        "messages": mailbox_count,
+                    }
+                ),
+                FakeResult(
+                    {
+                        "action": "search",
+                        "messages": messages,
+                        "unavailable_accounts": unavailable,
+                    }
+                ),
+            ]
+        )
+
+        records, exit_code = acceptance.run_acceptance(
+            "yahoo-large",
+            env={},
+            session_factory=session_factory(session, transcript),
+        )
+
+        assert exit_code == 1
+        assert records[0]["code"] == expected_code
+
+    failed_session = FakeSession([FakeResult(is_error=True)])
+    records, exit_code = acceptance.run_acceptance(
+        "yahoo-large",
+        env={},
+        session_factory=session_factory(failed_session),
+    )
+    assert exit_code == 1
+    assert records[0]["code"] == "PROVIDER_CALL_FAILED"
+
+
 def outlook_success(healthy_account: str) -> FakeResult:
     return FakeResult(
         {
@@ -594,6 +744,67 @@ def test_outlook_interactive_auth_output_is_failed() -> None:
     assert records[0]["code"] == "INTERACTIVE_AUTH_ATTEMPT"
 
 
+def test_outlook_single_account_without_raw_credential_fails_before_spawn() -> None:
+    def forbidden_factory(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise AssertionError("Missing raw credential must fail before spawning")
+
+    records, exit_code = acceptance.run_acceptance(
+        "outlook-expired",
+        env={"EMAIL_USER": "single@gmail.com", "EMAIL_PROVIDER": "gmail"},
+        session_factory=forbidden_factory,
+    )
+
+    assert exit_code == 1
+    assert records[0]["code"] == "GMAIL_INPUT_MISSING"
+
+
+def test_outlook_failure_verdicts_cover_protocol_and_replay_evidence() -> None:
+    healthy_account = "healthy.acceptance@gmail.com"
+    environment = {"EMAIL_CREDENTIALS": f"{healthy_account}:app-password"}
+    cases = [
+        (
+            FakeResult(is_error=True),
+            "PROVIDER_CALL_FAILED",
+        ),
+        (
+            FakeResult(
+                {
+                    "action": "search",
+                    "messages": [{"account_email": healthy_account}],
+                    "unavailable_accounts": [],
+                }
+            ),
+            "EXPIRED_TARGET_NOT_SKIPPED",
+        ),
+        (
+            FakeResult(
+                {
+                    "action": "search",
+                    "messages": [],
+                    "unavailable_accounts": [
+                        {
+                            "account_email": acceptance.OUTLOOK_FIXTURE_ACCOUNT,
+                            "code": "OAUTH_REFRESH_FAILED",
+                        }
+                    ],
+                }
+            ),
+            "HEALTHY_RESULTS_MISSING",
+        ),
+    ]
+
+    for result, expected_code in cases:
+        records, exit_code = acceptance.run_acceptance(
+            "outlook-expired",
+            env=environment,
+            session_factory=session_factory(FakeSession([result])),
+        )
+
+        assert exit_code == 1
+        assert records[0]["code"] == expected_code
+
+
 def test_outlook_fixture_expires_only_a_copy_and_cleans_every_temp_file() -> None:
     captured: dict[str, Path] = {}
     environment = gmail_environment()
@@ -699,3 +910,76 @@ def test_all_is_nonzero_when_gmail_input_is_missing() -> None:
     assert exit_code != 0
     assert records[2]["code"] == "GMAIL_INPUT_MISSING"
     assert factory.calls == ["yahoo-large"]
+
+
+def test_fixture_parsers_handle_missing_windows_and_mixed_uid_sets() -> None:
+    assert acceptance._search_window("A1 SEARCH ALL") is None
+    assert acceptance._expand_uid_set("3:1,bad:2,7") == [3, 2, 1, 7]
+
+
+def test_protocol_payload_fallback_skips_non_json_content() -> None:
+    decoded_result = FakeResult()
+    decoded_result.content = [
+        SimpleNamespace(),
+        SimpleNamespace(text="not-json {broken"),
+        SimpleNamespace(text='prefix {"messages":[]} suffix'),
+    ]
+    decoded = asyncio.run(
+        acceptance._call_read_only(
+            FakeSession([decoded_result]),
+            "messages",
+            {"action": "search", "query": "ALL", "limit": 3},
+        )
+    )
+    assert decoded == {"messages": []}
+
+    invalid_result = FakeResult()
+    invalid_result.content = [SimpleNamespace(), SimpleNamespace(text="{broken")]
+    with pytest.raises(acceptance.ProviderCallError, match="structured payload"):
+        asyncio.run(
+            acceptance._call_read_only(
+                FakeSession([invalid_result]),
+                "messages",
+                {"action": "search", "query": "ALL", "limit": 3},
+            )
+        )
+
+
+def test_protocol_validators_reject_missing_tools_and_invalid_payload_lists() -> None:
+    class MissingToolSession:
+        async def initialize(self) -> None:
+            return None
+
+        async def list_tools(self) -> Any:
+            return SimpleNamespace(tools=[SimpleNamespace(name="messages")])
+
+    with pytest.raises(acceptance.ProviderCallError, match="public tool"):
+        asyncio.run(acceptance._initialize_and_check_tools(MissingToolSession()))
+    with pytest.raises(acceptance.ProviderCallError, match="messages payload"):
+        acceptance._messages({"messages": "invalid"})
+    with pytest.raises(acceptance.ProviderCallError, match="unavailable-account"):
+        acceptance._unavailable_accounts({"unavailable_accounts": "invalid"})
+
+
+def test_run_acceptance_rejects_unknown_scenario_and_main_serializes_records(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(ValueError, match="Unsupported scenario"):
+        acceptance.run_acceptance("unknown", env={})
+
+    expected_record = {
+        "scenario": "gmail",
+        "provider": "gmail",
+        "verdict": "FAILED",
+        "operation": "preflight",
+        "code": "GMAIL_INPUT_MISSING",
+    }
+    monkeypatch.setattr(
+        acceptance,
+        "run_acceptance",
+        lambda scenario: ([expected_record], 1),
+    )
+
+    assert acceptance.main(["--scenario", "gmail"]) == 1
+    assert capsys.readouterr().out.strip() == acceptance.serialize_record(expected_record)

--- a/src/docs/folders.md
+++ b/src/docs/folders.md
@@ -1,10 +1,11 @@
 # Folders Tool - Full Documentation
 
 ## Overview
-List mailbox folders for one or all email accounts.
+List mailbox folders, or read targeted IMAP STATUS metadata for exactly one account and folder.
 
 ## Important
 - Returns folder **names, paths, flags, and children**
+- `status` is read-only and does not select or enumerate the mailbox
 - Gmail uses labels (e.g. `[Gmail]/All Mail`, `[Gmail]/Trash`)
 - Outlook uses standard folders (Inbox, Sent, Drafts, Archive, Junk)
 - Folder paths are case-sensitive
@@ -13,16 +14,40 @@ List mailbox folders for one or all email accounts.
 
 ### list
 List all folders for all accounts or a specific account.
+
 ```json
 {"action": "list"}
 ```
+
 ```json
 {"action": "list", "account": "user@gmail.com"}
 ```
 
+### status
+
+Read `MESSAGES`, `UNSEEN`, and `UIDNEXT` from IMAP STATUS for one exact mailbox. Both `account` and `folder` are required; the action never falls back to all accounts.
+
+```json
+{"action": "status", "account": "user@yahoo.com", "folder": "INBOX"}
+```
+
+```json
+{
+  "action": "status",
+  "account_id": "user_yahoo_com",
+  "account_email": "user@yahoo.com",
+  "folder": "INBOX",
+  "messages": 10025,
+  "unseen": 17,
+  "uid_next": 10026
+}
+```
+
 ## Parameters
-- `action` - Action to perform (required): list
-- `account` - Account email filter (optional, defaults to all)
+
+- `action` - Action to perform (required): `list` or `status`
+- `account` - Account email or ID (optional for `list`; required for `status`)
+- `folder` - Exact mailbox path (required only for `status`)
 
 ## Common Folder Names
 

--- a/src/docs/help.md
+++ b/src/docs/help.md
@@ -23,7 +23,7 @@ This tool has no `action` parameter — it takes only `tool_name`.
 ## Valid tool_name values
 
 - `messages` — Search, read, and manage email messages
-- `folders` — List mailbox folders
+- `folders` — List mailbox folders or read targeted IMAP STATUS metadata
 - `attachments` — List and download email attachments
 - `config` — Credential setup and runtime configuration
 - `help` — This documentation

--- a/src/tools/composite/folders.test.ts
+++ b/src/tools/composite/folders.test.ts
@@ -3,12 +3,14 @@ import type { AccountConfig } from '../helpers/config.js'
 
 // --- Mocks ---
 vi.mock('../helpers/imap-client.js', () => ({
+  getFolderStatus: vi.fn(),
   listFolders: vi.fn()
 }))
 
-import { listFolders } from '../helpers/imap-client.js'
+import { getFolderStatus, listFolders } from '../helpers/imap-client.js'
 import { folders } from './folders.js'
 
+const mockGetFolderStatus = vi.mocked(getFolderStatus)
 const mockListFolders = vi.mocked(listFolders)
 
 const accounts: AccountConfig[] = [
@@ -75,5 +77,40 @@ describe('folders - list', () => {
 
   it('throws for unknown action', async () => {
     await expect(folders(accounts, { action: 'unknown' as any })).rejects.toThrow()
+  })
+})
+
+describe('folders - status', () => {
+  it('returns read-only STATUS metadata for one exact account and folder', async () => {
+    mockGetFolderStatus.mockResolvedValue({ messages: 10_025, unseen: 17, uid_next: 10_026 })
+
+    const result = await folders(accounts, {
+      action: 'status',
+      account: 'user1@gmail.com',
+      folder: 'INBOX'
+    })
+
+    expect(mockGetFolderStatus).toHaveBeenCalledWith(accounts[0], 'INBOX')
+    expect(result).toEqual({
+      action: 'status',
+      account_id: 'user1_gmail_com',
+      account_email: 'user1@gmail.com',
+      folder: 'INBOX',
+      messages: 10_025,
+      unseen: 17,
+      uid_next: 10_026
+    })
+  })
+
+  it('requires an explicit account', async () => {
+    await expect(folders(accounts, { action: 'status', folder: 'INBOX' })).rejects.toThrow(
+      'account is required for status action'
+    )
+  })
+
+  it('requires an explicit folder', async () => {
+    await expect(folders(accounts, { action: 'status', account: 'user1@gmail.com' })).rejects.toThrow(
+      'folder is required for status action'
+    )
   })
 })

--- a/src/tools/composite/folders.ts
+++ b/src/tools/composite/folders.ts
@@ -4,15 +4,18 @@
  */
 
 import type { AccountConfig } from '../helpers/config.js'
-import { resolveAccounts } from '../helpers/config.js'
-import { createUnknownActionError, withErrorHandling } from '../helpers/errors.js'
-import { listFolders } from '../helpers/imap-client.js'
+import { resolveAccounts, resolveSingleAccount } from '../helpers/config.js'
+import { createUnknownActionError, EmailMCPError, withErrorHandling } from '../helpers/errors.js'
+import { getFolderStatus, listFolders } from '../helpers/imap-client.js'
 
 export interface FoldersInput {
-  action: 'list'
+  action: 'list' | 'status'
 
   // Target account (optional - defaults to all)
   account?: string
+
+  // Exact mailbox path (required for status)
+  folder?: string
 }
 
 /**
@@ -24,10 +27,44 @@ export async function folders(accounts: AccountConfig[], input: FoldersInput): P
       case 'list':
         return await handleList(accounts, input)
 
+      case 'status':
+        return await handleStatus(accounts, input)
+
       default:
-        throw createUnknownActionError(input.action, 'list')
+        throw createUnknownActionError(input.action, 'list, status')
     }
   })()
+}
+
+/**
+ * Read STATUS metadata for one exact account and mailbox.
+ */
+async function handleStatus(accounts: AccountConfig[], input: FoldersInput): Promise<any> {
+  if (!input.account?.trim()) {
+    throw new EmailMCPError(
+      'account is required for status action',
+      'VALIDATION_ERROR',
+      'Provide exactly one configured account email or account ID'
+    )
+  }
+  if (!input.folder?.trim()) {
+    throw new EmailMCPError(
+      'folder is required for status action',
+      'VALIDATION_ERROR',
+      'Provide one exact mailbox path, such as INBOX'
+    )
+  }
+
+  const account = resolveSingleAccount(accounts, input.account)
+  const status = await getFolderStatus(account, input.folder)
+
+  return {
+    action: 'status',
+    account_id: account.id,
+    account_email: account.email,
+    folder: input.folder,
+    ...status
+  }
 }
 
 /**

--- a/src/tools/helpers/imap-client.test.ts
+++ b/src/tools/helpers/imap-client.test.ts
@@ -669,6 +669,18 @@ describe('getFolderStatus', () => {
 
     await expect(getFolderStatus(account, 'INBOX')).rejects.toThrow('IMAP STATUS returned incomplete metadata')
   })
+
+  it('rejects UIDNEXT zero because IMAP UIDs start at one', async () => {
+    mockClient.status.mockResolvedValue({ path: 'INBOX', messages: 0, unseen: 0, uidNext: 0 })
+
+    await expect(getFolderStatus(account, 'INBOX')).rejects.toThrow('IMAP STATUS returned incomplete metadata')
+  })
+
+  it('rejects UIDNEXT values above the unsigned 32-bit range', async () => {
+    mockClient.status.mockResolvedValue({ path: 'INBOX', messages: 0, unseen: 0, uidNext: 0x1_0000_0000 })
+
+    await expect(getFolderStatus(account, 'INBOX')).rejects.toThrow('IMAP STATUS returned incomplete metadata')
+  })
 })
 
 // ============================================================================

--- a/src/tools/helpers/imap-client.test.ts
+++ b/src/tools/helpers/imap-client.test.ts
@@ -20,6 +20,7 @@ const { mockClient, mockRelease } = vi.hoisted(() => {
     messageMove: vi.fn().mockResolvedValue(undefined),
     messageDelete: vi.fn().mockResolvedValue(undefined),
     list: vi.fn(),
+    status: vi.fn(),
     append: vi.fn().mockResolvedValue({ destination: 'Sent', uid: 1 })
   }
   return { mockClient, mockRelease }
@@ -51,6 +52,7 @@ import {
   appendToFolder,
   clearSentFolderCache,
   getAttachment,
+  getFolderStatus,
   listFolders,
   modifyFlags,
   moveEmails,
@@ -103,6 +105,7 @@ beforeEach(() => {
   mockClient.messageFlagsRemove.mockResolvedValue(undefined)
   mockClient.messageMove.mockResolvedValue(undefined)
   mockClient.messageDelete.mockResolvedValue(undefined)
+  mockClient.status.mockResolvedValue({ path: 'INBOX', messages: 10_025, unseen: 17, uidNext: 10_026 })
 })
 
 // ============================================================================
@@ -636,6 +639,35 @@ describe('listFolders', () => {
     const folders = await listFolders(account)
     expect(folders[0].flags).toEqual([])
     expect(folders[0].delimiter).toBe('/')
+  })
+})
+
+// ============================================================================
+// getFolderStatus
+// ============================================================================
+
+describe('getFolderStatus', () => {
+  it('requests targeted IMAP STATUS metadata for exactly one folder', async () => {
+    const result = await getFolderStatus(account, 'INBOX')
+
+    expect(mockClient.status).toHaveBeenCalledWith('INBOX', {
+      messages: true,
+      unseen: true,
+      uidNext: true
+    })
+    expect(result).toEqual({ messages: 10_025, unseen: 17, uid_next: 10_026 })
+  })
+
+  it('rejects an incomplete IMAP STATUS response', async () => {
+    mockClient.status.mockResolvedValue({ path: 'INBOX', messages: 10_025, uidNext: 10_026 })
+
+    await expect(getFolderStatus(account, 'INBOX')).rejects.toThrow('IMAP STATUS returned incomplete metadata')
+  })
+
+  it('rejects negative IMAP STATUS counters', async () => {
+    mockClient.status.mockResolvedValue({ path: 'INBOX', messages: -1, unseen: 0, uidNext: 1 })
+
+    await expect(getFolderStatus(account, 'INBOX')).rejects.toThrow('IMAP STATUS returned incomplete metadata')
   })
 })
 

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -72,6 +72,12 @@ export interface FolderInfo {
   delimiter: string
 }
 
+export interface FolderStatusInfo {
+  messages: number
+  unseen: number
+  uid_next: number
+}
+
 /**
  * Create an ImapFlow client for the given account.
  * Uses XOAUTH2 for OAuth2 accounts, plain password otherwise.
@@ -776,6 +782,46 @@ export async function listFolders(account: AccountConfig): Promise<FolderInfo[]>
       flags: Array.from(mb.flags || []),
       delimiter: mb.delimiter || '/'
     }))
+  })
+}
+
+/**
+ * Read STATUS metadata for one mailbox without selecting or enumerating it.
+ */
+export async function getFolderStatus(account: AccountConfig, folder: string): Promise<FolderStatusInfo> {
+  return withConnection(account, async (client) => {
+    const status = await client.status(folder, {
+      messages: true,
+      unseen: true,
+      uidNext: true
+    })
+    const messages = status?.messages
+    const unseen = status?.unseen
+    const uidNext = status?.uidNext
+
+    if (
+      typeof messages !== 'number' ||
+      !Number.isSafeInteger(messages) ||
+      messages < 0 ||
+      typeof unseen !== 'number' ||
+      !Number.isSafeInteger(unseen) ||
+      unseen < 0 ||
+      typeof uidNext !== 'number' ||
+      !Number.isSafeInteger(uidNext) ||
+      uidNext < 0
+    ) {
+      throw new EmailMCPError(
+        'IMAP STATUS returned incomplete metadata',
+        'IMAP_STATUS_FAILED',
+        'Verify that the folder exists and the IMAP server supports MESSAGES, UNSEEN, and UIDNEXT status items'
+      )
+    }
+
+    return {
+      messages,
+      unseen,
+      uid_next: uidNext
+    }
   })
 }
 

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -808,7 +808,8 @@ export async function getFolderStatus(account: AccountConfig, folder: string): P
       unseen < 0 ||
       typeof uidNext !== 'number' ||
       !Number.isSafeInteger(uidNext) ||
-      uidNext < 0
+      uidNext < 1 ||
+      uidNext > 0xffff_ffff
     ) {
       throw new EmailMCPError(
         'IMAP STATUS returned incomplete metadata',

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -45,7 +45,7 @@ describe('TOOLS structure', () => {
     {
       name: 'folders',
       requiredFields: ['action'],
-      actions: ['list'],
+      actions: ['list', 'status'],
       readOnly: true
     },
     {
@@ -100,9 +100,9 @@ describe('TOOLS structure', () => {
     expect(messages.actions).toContain('forward')
   })
 
-  it('folders tool has 1 action', () => {
+  it('folders tool has 2 actions', () => {
     const folders = EXPECTED_TOOLS.find((t) => t.name === 'folders')!
-    expect(folders.actions).toEqual(['list'])
+    expect(folders.actions).toEqual(['list', 'status'])
   })
 
   it('attachments tool has 2 actions', () => {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -129,7 +129,7 @@ const TOOLS = [
   {
     name: 'folders',
     description:
-      'List mailbox folders.\n\nActions (required params -> optional):\n- list (-> account): folder names, paths, and flags for one or all accounts',
+      'List mailbox folders or read targeted mailbox status metadata.\n\nActions (required params -> optional):\n- list (-> account): folder names, paths, and flags for one or all accounts\n- status (account, folder): IMAP STATUS messages, unseen, and uid_next for exactly one mailbox',
     annotations: {
       title: 'Folders',
       readOnlyHint: true,
@@ -142,10 +142,14 @@ const TOOLS = [
       properties: {
         action: {
           type: 'string',
-          enum: ['list'],
+          enum: ['list', 'status'],
           description: 'Action to perform'
         },
-        account: { type: 'string', description: 'Account email filter (optional, defaults to all)' }
+        account: {
+          type: 'string',
+          description: 'Account email or ID (required for status; optional list filter, defaults to all)'
+        },
+        folder: { type: 'string', description: 'Exact mailbox path (required for status, for example INBOX)' }
       },
       required: ['action']
     },

--- a/tests/tool-names.test.ts
+++ b/tests/tool-names.test.ts
@@ -26,11 +26,12 @@ const EXPECTED_MESSAGE_ACTIONS = [
   'reply',
   'forward'
 ]
+const EXPECTED_FOLDER_ACTIONS = ['list', 'status']
 const EXPECTED_HELP_TOPICS = ['messages', 'folders', 'attachments', 'config', 'help']
 // Each case launches a fresh CLI process over stdio. On Windows with the
-// current MCP SDK, cold module startup can exceed 15 seconds even though the
-// protocol exchange itself completes normally.
-const MCP_PROTOCOL_TEST_TIMEOUT_MS = 30_000
+// current MCP SDK, cold module startup under concurrent transform load can
+// exceed 30 seconds even though the protocol exchange itself completes normally.
+const MCP_PROTOCOL_TEST_TIMEOUT_MS = 60_000
 
 describe('public MCP tool surface', { timeout: MCP_PROTOCOL_TEST_TIMEOUT_MS }, () => {
   let client: Client | undefined
@@ -80,6 +81,10 @@ describe('public MCP tool surface', { timeout: MCP_PROTOCOL_TEST_TIMEOUT_MS }, (
 
     const messages = result.tools.find((tool) => tool.name === 'messages')
     expect(messages?.inputSchema.properties?.action).toMatchObject({ enum: EXPECTED_MESSAGE_ACTIONS })
+
+    const folders = result.tools.find((tool) => tool.name === 'folders')
+    expect(folders?.inputSchema.properties?.action).toMatchObject({ enum: EXPECTED_FOLDER_ACTIONS })
+    expect(folders?.inputSchema.properties).toHaveProperty('folder')
   })
 
   it('exposes only current documentation resources and help topics', async () => {


### PR DESCRIPTION
## Summary

- add the public read-only `folders.status` contract and IMAP STATUS implementation
- add deterministic current-source acceptance scenarios for real Gmail, a local Yahoo-shaped mailbox with 10,025 messages, and an expired Outlook token alongside a healthy real Gmail account
- isolate child-process credentials and pin the cross-platform Python harness in CI and pre-commit

Relates to #1083 and #1078.

## Verification

- `bun run check`
- `bun run build`
- `bun run test -- --coverage` (884 passed, 1 skipped; statements 95.17%)
- `pre-commit run`
- `bun run provider:accept:test` (34 passed, 1 skipped; provider harness 95% coverage)
- `provider:accept --scenario all` from final source:
  - real Gmail credential: VERIFIED, 3 results
  - Yahoo large-mailbox protocol replay: VERIFIED at 10,025 messages; this is deterministic local IMAP evidence, not Yahoo provider-auth evidence
  - expired Outlook isolation: VERIFIED with one skipped expired account plus 3 healthy real-Gmail results; the source token store remains unchanged, and this does not claim successful Outlook authentication