### PR TITLE
fix: migrate Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
   },
   "packageRules": [
     {
+      "matchCategories": ["golang"],
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
       "description": "Group minor updates for review (prod scope by default)",
       "matchUpdateTypes": ["minor"],
       "groupName": "minor dependencies",
@@ -61,7 +65,7 @@
     },
     {
       "description": "Pin PSR to v10 — block Renovate downgrades",
-      "matchPackagePatterns": ["^python-semantic-release/"],
+      "matchPackageNames": ["/^python-semantic-release//"],
       "matchManagers": ["github-actions"],
       "allowedVersions": ">=10.0.0"
     },
@@ -92,8 +96,5 @@
   "commitMessageAction": "update",
   "commitMessageTopic": "{{depName}}",
   "semanticCommitType": "fix",
-  "semanticCommitScope": "deps",
-  "golang": {
-    "postUpdateOptions": ["gomodTidy"]
-  }
+  "semanticCommitScope": "deps"
 }


### PR DESCRIPTION
## Summary
- migrate deprecated global golang postUpdateOptions into packageRules
- migrate matchPackagePatterns to matchPackageNames regex syntax

## Verification
- RED before change: bunx -p renovate renovate-config-validator --strict renovate.json -> Config migration necessary (exit 1)
- GREEN on d508753: same official validator -> Config validated successfully against 1 file(s) (exit 0)
- git diff --check