### PR TITLE
fix: 🎨 Palette: Add descriptive placeholder to password field

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -111,3 +111,6 @@
 ## 2026-08-12 - Consistent Placeholders in Form Fields
 **Learning:** Having placeholders for some text fields but omitting them for others in the same form group (e.g. `imap_port` and `email` vs `imap_host`) creates inconsistency and leaves users guessing the expected input format for the un-hinted field.
 **Action:** Always provide placeholder examples for all user-facing text inputs in a form sequence to establish a consistent pattern and explicitly guide the required input format.
+## 2025-05-18 - App Password Field Placeholder
+**Learning:** Avoid using mask characters (e.g., '••••••••') as a placeholder for password fields. This is an anti-pattern as it visually mimics a pre-filled or saved password, potentially confusing users into skipping the field.
+**Action:** Use a descriptive placeholder (e.g., 'Enter app password') or leave it blank, relying on existing contextual help text to guide the user without falsely implying pre-filled state.

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -42,6 +42,7 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
         label: 'Password',
         type: 'password',
         required: false,
+        placeholder: 'Enter app password',
         helpText:
           'App Password for Gmail/Yahoo/iCloud (not your normal password). Leave blank for Outlook/Hotmail/Live — OAuth runs automatically after submit.'
       },


### PR DESCRIPTION
💡 What: Added 'Enter app password' placeholder to the password field in `RELAY_SCHEMA`.
🎯 Why: To maintain consistent form UX by providing placeholders across all text inputs, while explicitly avoiding the '••••••••' mask anti-pattern which falsely implies a pre-filled state and can confuse users.
♿ Accessibility: Improves clarity for users scanning the form, reducing cognitive load when identifying required input formats.

---
*PR created automatically by Jules for task [17647151320834266658](https://jules.google.com/task/17647151320834266658) started by @n24q02m*