### PR TITLE
feat(attachments): add optional save_to path to write attachments to disk

### DIFF
--- a/src/docs/attachments.md
+++ b/src/docs/attachments.md
@@ -5,8 +5,8 @@ List and download email attachments.
 
 ## Important
 - **list** returns metadata only (filename, content_type, size)
-- **download** returns base64-encoded content
-- Large attachments may consume significant tokens - check size before downloading
+- **download** returns base64-encoded content by default
+- Large attachments may consume significant tokens - check size before downloading, or use `save_to` to avoid the base64 payload entirely
 - `account` and `uid` are required for all actions
 
 ## Actions
@@ -26,12 +26,22 @@ Download a specific attachment by filename. Returns base64-encoded content.
 {"action": "download", "account": "user@gmail.com", "uid": 12345, "filename": "report.pdf"}
 ```
 
+Pass `save_to` to write the attachment directly to a filesystem path on the
+machine running the server, instead of returning `content_base64`. Useful when
+the caller only needs the file on disk (e.g. an MCP client whose LLM context
+would otherwise have to carry the full base64 payload) -- the response stays
+small regardless of attachment size. The parent directory must already exist.
+```json
+{"action": "download", "account": "user@gmail.com", "uid": 12345, "filename": "report.pdf", "save_to": "/tmp/report.pdf"}
+```
+
 ## Parameters
 - `action` - Action to perform (required): list, download
 - `account` - Account email (required)
 - `uid` - Email UID (required)
 - `folder` - Mailbox folder (default: INBOX)
 - `filename` - Attachment filename (required for download, case-insensitive)
+- `save_to` - Download only. Absolute path to write the attachment to server-side. When set, the response returns `saved_to` instead of `content_base64`.
 
 ## Response Fields
 
@@ -45,4 +55,5 @@ Download a specific attachment by filename. Returns base64-encoded content.
 - `filename` - Attachment filename
 - `content_type` - MIME type
 - `size` - Size in bytes
-- `content_base64` - Base64-encoded file content
+- `content_base64` - Base64-encoded file content (omitted when `save_to` was set)
+- `saved_to` - Absolute path the file was written to (only present when `save_to` was set)

--- a/src/tools/composite/attachments.test.ts
+++ b/src/tools/composite/attachments.test.ts
@@ -111,6 +111,27 @@ describe('attachments - download', () => {
     expect(result.filename).toBe('report.pdf')
   })
 
+  it('forwards save_to to getAttachment and returns saved_to without content_base64', async () => {
+    mockGetAttachment.mockResolvedValue({
+      filename: 'report.pdf',
+      content_type: 'application/pdf',
+      size: 5000,
+      saved_to: '/tmp/report.pdf'
+    } as any)
+
+    const result = await attachments(accounts, {
+      action: 'download',
+      account: 'user1@gmail.com',
+      uid: 10,
+      filename: 'report.pdf',
+      save_to: '/tmp/report.pdf'
+    })
+
+    expect(mockGetAttachment).toHaveBeenCalledWith(accounts[0], 10, 'INBOX', 'report.pdf', '/tmp/report.pdf')
+    expect(result.saved_to).toBe('/tmp/report.pdf')
+    expect(result.content_base64).toBeUndefined()
+  })
+
   it('throws when filename is missing', async () => {
     await expect(
       attachments(accounts, {

--- a/src/tools/composite/attachments.ts
+++ b/src/tools/composite/attachments.ts
@@ -18,6 +18,11 @@ export interface AttachmentsInput {
   // Optional
   folder?: string
   filename?: string
+
+  // Optional (download only): write the attachment to this filesystem path
+  // server-side instead of returning content_base64. Keeps the response
+  // small for large attachments.
+  save_to?: string
 }
 
 /**
@@ -75,7 +80,8 @@ async function handleList(accounts: AccountConfig[], input: AttachmentsInput): P
 }
 
 /**
- * Download a specific attachment (returns base64)
+ * Download a specific attachment. Returns base64-encoded content by default,
+ * or writes to `input.save_to` server-side and returns `saved_to` instead.
  */
 async function handleDownload(accounts: AccountConfig[], input: AttachmentsInput): Promise<any> {
   if (!input.filename) {
@@ -89,7 +95,7 @@ async function handleDownload(accounts: AccountConfig[], input: AttachmentsInput
   const account = resolveSingleAccount(accounts, input.account)
   const folder = input.folder || 'INBOX'
 
-  const attachment = await getAttachment(account, input.uid, folder, input.filename)
+  const attachment = await getAttachment(account, input.uid, folder, input.filename, input.save_to)
 
   return {
     action: 'download',

--- a/src/tools/helpers/imap-client.test.ts
+++ b/src/tools/helpers/imap-client.test.ts
@@ -37,6 +37,10 @@ vi.mock('mailparser', () => ({
   simpleParser: vi.fn()
 }))
 
+vi.mock('node:fs', () => ({
+  writeFileSync: vi.fn()
+}))
+
 vi.mock('./html-utils.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./html-utils.js')>()),
   htmlToCleanText: vi.fn((html: string) => `cleaned: ${html}`)
@@ -46,6 +50,7 @@ vi.mock('./oauth2.js', () => ({
   ensureValidToken: vi.fn().mockResolvedValue('mock-access-token')
 }))
 
+import { writeFileSync } from 'node:fs'
 import { ImapFlow } from 'imapflow'
 import { simpleParser } from 'mailparser'
 import {
@@ -64,6 +69,7 @@ import {
 import { ensureValidToken } from './oauth2.js'
 
 const mockSimpleParser = vi.mocked(simpleParser)
+const mockWriteFileSync = vi.mocked(writeFileSync)
 
 const account: AccountConfig = {
   id: 'test_gmail_com',
@@ -711,7 +717,7 @@ describe('getAttachment', () => {
     expect(result.filename).toBe('report.pdf')
     expect(result.content_type).toBe('application/pdf')
     expect(result.size).toBe(12345)
-    expect(result.content_base64).toBe(content.toString('base64'))
+    expect((result as { content_base64: string }).content_base64).toBe(content.toString('base64'))
   })
 
   it('matches attachment filename case-insensitively', async () => {
@@ -768,6 +774,50 @@ describe('getAttachment', () => {
       attachments: null
     } as any)
     await expect(getAttachment(account, 1, 'INBOX', 'f')).rejects.toThrow('not found')
+  })
+
+  it('writes to savePath and returns saved_to instead of content_base64 when provided', async () => {
+    const content = Buffer.from('file content')
+    mockClient.fetchOne.mockResolvedValue({ uid: 10, source: Buffer.from('raw email') })
+    mockSimpleParser.mockResolvedValue({
+      attachments: [{ filename: 'report.pdf', contentType: 'application/pdf', size: 12345, content }]
+    } as any)
+
+    const result = await getAttachment(account, 10, 'INBOX', 'report.pdf', '/tmp/report.pdf')
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/report.pdf', content)
+    expect(result.filename).toBe('report.pdf')
+    expect(result.content_type).toBe('application/pdf')
+    expect(result.size).toBe(12345)
+    expect((result as { saved_to: string }).saved_to).toBe('/tmp/report.pdf')
+    expect('content_base64' in result).toBe(false)
+  })
+
+  it('does not call writeFileSync when savePath is omitted', async () => {
+    mockClient.fetchOne.mockResolvedValue({ uid: 10, source: Buffer.from('raw email') })
+    mockSimpleParser.mockResolvedValue({
+      attachments: [{ filename: 'report.pdf', contentType: 'application/pdf', size: 100, content: Buffer.from('x') }]
+    } as any)
+
+    const result = await getAttachment(account, 10, 'INBOX', 'report.pdf')
+
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+    expect((result as { content_base64: string }).content_base64).toBeDefined()
+    expect('saved_to' in result).toBe(false)
+  })
+
+  it('throws EmailMCPError with SAVE_PATH_ERROR when writing to savePath fails', async () => {
+    mockClient.fetchOne.mockResolvedValue({ uid: 10, source: Buffer.from('raw email') })
+    mockSimpleParser.mockResolvedValue({
+      attachments: [{ filename: 'report.pdf', contentType: 'application/pdf', size: 100, content: Buffer.from('x') }]
+    } as any)
+    mockWriteFileSync.mockImplementationOnce(() => {
+      throw new Error('ENOENT: no such file or directory')
+    })
+
+    await expect(getAttachment(account, 10, 'INBOX', 'report.pdf', '/nonexistent/report.pdf')).rejects.toThrow(
+      'Failed to write attachment'
+    )
   })
 })
 

--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -3,6 +3,7 @@
  * Manages connections to multiple IMAP servers with connection pooling
  */
 
+import { writeFileSync } from 'node:fs'
 import { type FetchMessageObject, ImapFlow, type ListResponse, type SearchObject } from 'imapflow'
 import {
   type AddressObject,
@@ -12,7 +13,7 @@ import {
   simpleParser
 } from 'mailparser'
 import type { AccountConfig } from './config.js'
-import { EmailMCPError } from './errors.js'
+import { EmailMCPError, sanitizeErrorDetails } from './errors.js'
 import { fastExtractSnippet, htmlToCleanText } from './html-utils.js'
 import { ensureValidToken } from './oauth2.js'
 
@@ -826,15 +827,36 @@ export async function getFolderStatus(account: AccountConfig, folder: string): P
   })
 }
 
+export interface AttachmentDownload {
+  filename: string
+  content_type: string
+  size: number
+  content_base64: string
+}
+
+export interface AttachmentSaved {
+  filename: string
+  content_type: string
+  size: number
+  saved_to: string
+}
+
 /**
- * Get attachment content by filename
+ * Get attachment content by filename.
+ *
+ * Pass `savePath` to write the decoded bytes directly to that filesystem path
+ * server-side instead of returning `content_base64`. This keeps the response
+ * small regardless of attachment size -- useful for callers (e.g. an MCP
+ * client's LLM context) where a large base64 payload would otherwise have to
+ * pass through as tool-call output.
  */
 export async function getAttachment(
   account: AccountConfig,
   uid: number,
   folder: string,
-  filename: string
-): Promise<{ filename: string; content_type: string; size: number; content_base64: string }> {
+  filename: string,
+  savePath?: string
+): Promise<AttachmentDownload | AttachmentSaved> {
   const fetchResult = await withConnection(account, async (client) => {
     const lock = await client.getMailboxLock(folder)
     try {
@@ -865,10 +887,34 @@ export async function getAttachment(
     )
   }
 
+  const resolvedFilename = attachment.filename || 'unnamed'
+  const resolvedContentType = attachment.contentType || 'application/octet-stream'
+  const resolvedSize = attachment.size || 0
+
+  if (savePath) {
+    try {
+      writeFileSync(savePath, attachment.content)
+    } catch (error) {
+      throw new EmailMCPError(
+        `Failed to write attachment to "${savePath}"`,
+        'SAVE_PATH_ERROR',
+        'Ensure the parent directory exists and is writable, then try again.',
+        sanitizeErrorDetails(error)
+      )
+    }
+
+    return {
+      filename: resolvedFilename,
+      content_type: resolvedContentType,
+      size: resolvedSize,
+      saved_to: savePath
+    }
+  }
+
   return {
-    filename: attachment.filename || 'unnamed',
-    content_type: attachment.contentType || 'application/octet-stream',
-    size: attachment.size || 0,
+    filename: resolvedFilename,
+    content_type: resolvedContentType,
+    size: resolvedSize,
     content_base64: attachment.content.toString('base64')
   }
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -158,7 +158,7 @@ const TOOLS = [
   {
     name: 'attachments',
     description:
-      'List and download email attachments.\n\nActions (required params -> optional):\n- list (account, uid -> folder): show attachments with filename, content_type, size\n- download (account, uid, filename -> folder): get base64-encoded content\n\nUse list first to get exact filenames. Case-sensitive. Max 25MB per provider.',
+      'List and download email attachments.\n\nActions (required params -> optional):\n- list (account, uid -> folder): show attachments with filename, content_type, size\n- download (account, uid, filename -> folder, save_to): get base64-encoded content, or write to save_to server-side and get saved_to instead\n\nUse list first to get exact filenames. Case-sensitive. Max 25MB per provider.',
     annotations: {
       title: 'Attachments',
       readOnlyHint: true,
@@ -180,6 +180,11 @@ const TOOLS = [
         filename: {
           type: 'string',
           description: 'Exact attachment filename from list action (required for download). Case-sensitive.'
+        },
+        save_to: {
+          type: 'string',
+          description:
+            'Download only. Absolute filesystem path to write the attachment to server-side, instead of returning content_base64. Response returns saved_to (the path) in place of content_base64. Parent directory must already exist.'
         }
       },
       required: ['action', 'account', 'uid']


### PR DESCRIPTION
## Summary

Large attachment downloads return `content_base64` inline. For an MCP client that keeps the tool response in an LLM's context window, this becomes expensive fast — and there's an edge case: a decoded attachment that lands just under the client's own response-size threshold gets returned fully inline, so the client can't get it onto disk without round-tripping the same base64 payload through *another* tool call, doubling the cost for no benefit.

This PR adds an optional `save_to` parameter to the `attachments` tool's `download` action. When set, the server writes the already-decoded attachment `Buffer` directly to that filesystem path (no base64 round-trip) and returns `saved_to` instead of `content_base64` — so the response stays small regardless of attachment size.

- Omitting `save_to` preserves the exact existing behavior — **fully backward compatible, no breaking changes**.
- The parent directory of `save_to` must already exist; a write failure surfaces as `EmailMCPError` with code `SAVE_PATH_ERROR` and an actionable suggestion.
- Docs (`src/docs/attachments.md`) and the tool's `inputSchema`/description in `registry.ts` are updated accordingly.

## Test plan

- [x] `bun run check` (Biome + `tsc --noEmit`) passes
- [x] `bun run test` passes (892/893, 1 pre-existing skip unrelated to this change)
- [x] `bun run build` succeeds
- [x] New unit tests cover: writing to `save_to` and returning `saved_to` without `content_base64`; default behavior unchanged when `save_to` is omitted; the `SAVE_PATH_ERROR` failure path when the write fails
- [x] Composite-layer test confirms `save_to` is forwarded from `attachments()` → `getAttachment()` and the response omits `content_base64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)