### PR TITLE
fix: pin CI workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           node-version: "24"
 
       - name: Setup uv and Python 3.13
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
Workflow-only branch from origin/main. Pins setup-uv to v10.0.1 in CI; no release or deployment workflow is dispatched.