### PR TITLE
feat: dehost managed Cloudflare runtime

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -393,7 +393,7 @@ jobs:
     # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
     # rollback is a tracked follow-up.
     needs: [release]
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && vars.CF_HOSTED_ENABLED != 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ PSR v10 (workflow_dispatch) -> npm + Docker (amd64+arm64) + GHCR + MCP Registry.
 Two transports, selected in `init-server.ts:52-53`. There is no `MCP_MODE` env var; the old `remote-relay` / `local-relay` distinction was removed (see `transports/http.ts:5`).
 
 - **stdio (default)**: MCP SDK `StdioServerTransport` directly. Reads credentials from `EMAIL_CREDENTIALS` OR `EMAIL_USER` + `EMAIL_APP_PASSWORD`. Outlook accounts use an App Password in this mode.
-- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Single multi-user relay: `/authorize` form for App-Password providers (paste `email:app-password`) plus bundled Outlook device-code OAuth. Per-user credentials keyed by JWT `sub`. Outlook token file: `~/.better-email-mcp/tokens.json`. Deploy at `https://email.n24q02m.com`.
+- **http (opt-in, self-hosted)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Single multi-user relay: `/authorize` form for App-Password providers (paste `email:app-password`) plus bundled Outlook device-code OAuth. Per-user credentials are keyed by JWT `sub`; the Outlook token file is `~/.better-email-mcp/tokens.json`. The project no longer operates a public n24q02m HTTP deployment.
 
 ## Known bugs (phat hien 2026-04-18 E2E)
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -50,6 +50,9 @@ export interface Env {
   OUTLOOK_TENANT?: string
   OUTLOOK_SCOPES?: string
   OUTLOOK_EXTRA_DOMAINS?: string
+  // Dehost / tombstone drill flag (W4)
+  DEHOSTED?: string
+  TOMBSTONE?: string
 }
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the
@@ -159,8 +162,30 @@ function withSecurityHeaders(response: Response): Response {
   })
 }
 
+function tombstoneResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      message:
+        'The hosted Cloudflare endpoint for better-email-mcp has been retired. The package remains active via local stdio (npx @n24q02m/better-email-mcp / docker run -i n24q02m/better-email-mcp) and self-hosted HTTP. See https://mcp.n24q02m.com/servers/better-email-mcp/ for instructions.',
+      successor: 'https://mcp.n24q02m.com/servers/better-email-mcp/'
+    }),
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Dehosted-Successor': 'https://mcp.n24q02m.com/servers/better-email-mcp/'
+      }
+    }
+  )
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    if (env.DEHOSTED === 'true' || env.TOMBSTONE === 'true') {
+      return withSecurityHeaders(tombstoneResponse())
+    }
     if (request.url.length > MAX_REQUEST_URL_LENGTH) {
       return withSecurityHeaders(new Response('URI Too Long', { status: 414 }))
     }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -313,3 +313,55 @@ describe('worker (KV-only)', () => {
     })
   })
 })
+
+describe('tombstone contract (W4 dehost preparation & drill)', () => {
+  test('returns 410 Gone with non-sensitive successor message and security headers before edge auth when DEHOSTED is true', async () => {
+    const doFetch = vi.fn()
+    const env = {
+      EMAIL: { idFromName: vi.fn(() => 'stub-id'), get: vi.fn(() => ({ fetch: doFetch })) },
+      DEHOSTED: 'true'
+    }
+
+    const res = await worker.fetch(
+      new Request('https://email.n24q02m.com/mcp', {
+        method: 'POST'
+      }),
+      env as never
+    )
+
+    expect(res.status).toBe(410)
+    expect(res.headers.get('Content-Type')).toBe('application/json')
+    expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/better-email-mcp/')
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
+
+    const body = await res.json()
+    expect(body).toMatchObject({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      successor: 'https://mcp.n24q02m.com/servers/better-email-mcp/'
+    })
+    expect(body.message).toContain('retired')
+    expect(body.message).toContain('stdio')
+
+    // CRITICAL: 0 requests reach the Container DO
+    expect(doFetch).not.toHaveBeenCalled()
+  })
+
+  test('returns 410 Gone on all routes before auth/DO for DEHOSTED and the existing TOMBSTONE drill alias', async () => {
+    for (const flag of ['DEHOSTED', 'TOMBSTONE'] as const) {
+      const doFetch = vi.fn()
+      const env = {
+        EMAIL: { idFromName: vi.fn(() => 'stub-id'), get: vi.fn(() => ({ fetch: doFetch })) },
+        [flag]: 'true'
+      }
+
+      for (const path of ['/authorize', '/health', '/.well-known/jwks.json', '/mcp/v1']) {
+        const res = await worker.fetch(new Request(`https://email.n24q02m.com${path}`, { method: 'GET' }), env as never)
+        expect(res.status).toBe(410)
+        expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/better-email-mcp/')
+      }
+
+      expect(doFetch).not.toHaveBeenCalled()
+    }
+  })
+})

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -25,6 +25,7 @@
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["EmailContainer"] }],
   "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
   "vars": {
+    "DEHOSTED": "true",
     "PUBLIC_URL": "${PUBLIC_URL}",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",


### PR DESCRIPTION
## Summary
- gate future Cloudflare host deployment with `CF_HOSTED_ENABLED=false`
- keep a deterministic HTTP 410 sentinel if an operator explicitly re-enables the template
- document HTTP mode as self-hosted/operator-controlled
- keep npm, OCI, CI, security, release, and repository maintenance active

## Live dehost state
- `better-email-mcp-worker` Worker script and Container application were deleted on 2026-08-24
- `email.n24q02m.com` no longer resolves and cannot start an MCP/OAuth session
- repository variable `CF_HOSTED_ENABLED=false` is set
- KV namespace, rollback image `1.39.0`, skret secrets, encrypted backup, and isolated restore proof are retained

## Verification
- Worker Vitest suite: 24 passed
- repository remains public, active, and unarchived

Normal protected-branch review remains required; do not bypass it.