### PR TITLE
fix(deps): update n24q02m/better-semantic-release action to v1.4.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
       # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and
       # same prerelease inputs as the real step, run against the same untouched checkout,
       # so the computed version is identical.
-      - uses: n24q02m/better-semantic-release@c6051539169a3434b4739ddce1a88a56c50f2b53 # v1.3.0
+      - uses: n24q02m/better-semantic-release@087b84e8d2ba75bdec350924d3bf8247088e0b1a # v1.4.0
         id: dryrun
         with:
           github_token: ${{ steps.app-token.outputs.token }}
@@ -136,7 +136,7 @@ jobs:
           echo "::error::Could not verify whether ${PKG}@${COMPUTED_VERSION} exists on npm: 'npm view' failed without an E404 (likely a transient registry/network error, rate limit, or outage). Refusing to proceed so a genuine collision cannot slip through as a false 'free'. Re-run the release once the registry is reachable. npm output: ${output}"
           exit 1
 
-      - uses: n24q02m/better-semantic-release@c6051539169a3434b4739ddce1a88a56c50f2b53 # v1.3.0
+      - uses: n24q02m/better-semantic-release@087b84e8d2ba75bdec350924d3bf8247088e0b1a # v1.4.0
         id: release
         with:
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Bumps the pinned `n24q02m/better-semantic-release` action to v1.4.0 (`087b84e8d2ba`). Release: https://github.com/n24q02m/better-semantic-release/releases/tag/v1.4.0

- pin bump only; no behavior change in this repository
- CI on this PR verifies the workflow file stays valid