### PR TITLE
fix: ⚡ Bolt: eliminate Object.assign overhead in buildSearchCriteria

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -175,7 +175,7 @@ function buildSearchCriteria(query: string): SearchObject {
   const upper = trimmed.toUpperCase()
   if (upper === 'ALL' || upper === '*') return {}
 
-  const criteria: SearchObject = {}
+  const criteria: Record<string, any> = {}
   let remaining = trimmed
 
   // 1. Extract standalone flag keywords (no arguments).
@@ -183,7 +183,7 @@ function buildSearchCriteria(query: string): SearchObject {
   for (const { pattern, key, value } of FLAG_MATCHERS) {
     const nextRemaining = remaining.replace(pattern, ' ')
     if (nextRemaining !== remaining) {
-      Object.assign(criteria, { [key]: value })
+      criteria[key] = value
       remaining = nextRemaining.trim()
     }
   }
@@ -194,7 +194,7 @@ function buildSearchCriteria(query: string): SearchObject {
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      Object.assign(criteria, { [criteriaKey]: new Date(dateMatch[1]!) })
+      criteria[criteriaKey] = new Date(dateMatch[1]!)
       remaining = remaining.replace(dateMatch[0], ' ').trim()
     } else {
       const nextRemaining = remaining.replace(invalid, ' ')
@@ -213,7 +213,7 @@ function buildSearchCriteria(query: string): SearchObject {
     const kvMatch = remaining.match(KV_MATCHERS[keyword])
     if (kvMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      Object.assign(criteria, { [criteriaKey]: kvMatch[1]!.replace(RE_QUOTES, '') })
+      criteria[criteriaKey] = kvMatch[1]!.replace(RE_QUOTES, '')
       remaining = remaining.replace(kvMatch[0], ' ').trim()
     }
   }
@@ -230,7 +230,7 @@ function buildSearchCriteria(query: string): SearchObject {
     criteria.subject = remaining
   }
 
-  return Object.keys(criteria).length > 0 ? criteria : {}
+  return Object.keys(criteria).length > 0 ? (criteria as SearchObject) : {}
 }
 
 /**


### PR DESCRIPTION
💡 What: Replaced Object.assign with direct property assignment in buildSearchCriteria.\n🎯 Why: Using Object.assign(obj, { [key]: value }) allocates an intermediate object for every dynamic property assignment, causing unnecessary garbage collection overhead in hot loops.\n📊 Impact: Eliminates intermediate allocations, speeding up IMAP query parsing.\n🔬 Measurement: Run \`bun run test\` and \`bun run check\` to verify correctness and typings.

---
*PR created automatically by Jules for task [7434069182094536434](https://jules.google.com/task/7434069182094536434) started by @n24q02m*