### PR TITLE
fix(http): update active credentials on authorize when MCP_AUTH_DISABLE=1 (fixes #1144)

### DIFF
--- a/src/tools/helpers/imap-client.ts
+++ b/src/tools/helpers/imap-client.ts
@@ -168,6 +168,14 @@ const KV_KEYWORDS = ['FROM', 'TO'] as const
 const UID_SEARCH_WINDOW_SIZE = 500
 const RE_UID_SEQUENCE_SET = /^\d+(?::\d+)?(?:,\d+(?::\d+)?)*$/
 
+function setSearchCriterion<K extends keyof SearchObject>(
+  criteria: SearchObject,
+  key: K,
+  value: SearchObject[K]
+): void {
+  criteria[key] = value
+}
+
 function buildSearchCriteria(query: string): SearchObject {
   const trimmed = query.trim()
   if (!trimmed) return {}
@@ -183,7 +191,7 @@ function buildSearchCriteria(query: string): SearchObject {
   for (const { pattern, key, value } of FLAG_MATCHERS) {
     const nextRemaining = remaining.replace(pattern, ' ')
     if (nextRemaining !== remaining) {
-      Object.assign(criteria, { [key]: value })
+      setSearchCriterion(criteria, key, value)
       remaining = nextRemaining.trim()
     }
   }
@@ -194,7 +202,7 @@ function buildSearchCriteria(query: string): SearchObject {
     const dateMatch = remaining.match(valid)
     if (dateMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      Object.assign(criteria, { [criteriaKey]: new Date(dateMatch[1]!) })
+      setSearchCriterion(criteria, criteriaKey, new Date(dateMatch[1]!))
       remaining = remaining.replace(dateMatch[0], ' ').trim()
     } else {
       const nextRemaining = remaining.replace(invalid, ' ')
@@ -213,7 +221,7 @@ function buildSearchCriteria(query: string): SearchObject {
     const kvMatch = remaining.match(KV_MATCHERS[keyword])
     if (kvMatch) {
       const criteriaKey = keyword.toLowerCase() as keyof SearchObject
-      Object.assign(criteria, { [criteriaKey]: kvMatch[1]!.replace(RE_QUOTES, '') })
+      setSearchCriterion(criteria, criteriaKey, kvMatch[1]!.replace(RE_QUOTES, ''))
       remaining = remaining.replace(kvMatch[0], ' ').trim()
     }
   }

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -278,6 +278,46 @@ describe('http transport', () => {
       expect(result).toBeNull()
     })
 
+    it('updates shared credentials when MCP_AUTH_DISABLE=1 even if context.sub is present (#1144)', async () => {
+      const mockAccounts = [
+        {
+          email: 'gateway-user@gmail.com',
+          imap: { host: 'imap.gmail.com', port: 993, secure: true },
+          authType: 'password'
+        }
+      ] as unknown as AccountConfig[]
+      vi.mocked(parseCredentials).mockResolvedValue(mockAccounts)
+      vi.mocked(isOutlookDomain).mockReturnValue(false)
+      process.env.MCP_AUTH_DISABLE = '1'
+      delete process.env.EMAIL_CREDENTIALS
+
+      const mockConnect = vi.fn().mockResolvedValue(undefined)
+      const mockLogout = vi.fn().mockResolvedValue(undefined)
+      ;(ImapFlow as unknown as Mock).mockImplementation(function (this: {
+        connect: unknown
+        logout: unknown
+        close: unknown
+      }) {
+        this.connect = mockConnect
+        this.logout = mockLogout
+        this.close = vi.fn()
+      })
+
+      const result = await onCredentialsSaved(
+        { EMAIL_CREDENTIALS: 'gateway-user@gmail.com:newpass' },
+        { sub: 'relay-session-123' }
+      )
+
+      expect(writeConfig).toHaveBeenCalledWith('better-email-mcp', {
+        EMAIL_CREDENTIALS: 'gateway-user@gmail.com:newpass'
+      })
+      expect(process.env.EMAIL_CREDENTIALS).toBe('gateway-user@gmail.com:newpass')
+      expect(setState).toHaveBeenCalledWith('configured')
+      expect(result).toBeNull()
+
+      delete process.env.MCP_AUTH_DISABLE
+    })
+
     it('returns error if IMAP connection fails', async () => {
       const mockAccounts = [{ email: 'test@gmail.com', imap: {}, authType: 'password' }]
       vi.mocked(parseCredentials).mockResolvedValue(mockAccounts as any)

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -234,16 +234,18 @@ function buildOptions(args: {
 
     // Persistence is mode-dependent to avoid cross-user credential bleed.
     //
-    // Multi-user (JWT `sub` present): write ONLY to the per-user store, keyed by
+    // Multi-user (JWT `sub` present AND auth is enabled): write ONLY to the per-user store, keyed by
     // `sub`. We must NOT touch the shared `config.enc`, `process.env`, or the
     // single-user `currentAccounts` closure — those are process-global and would
     // leak one subject's mailboxes into every other subject's tool calls.
     //
-    // Single-user (no `sub`: stdio self-host / auth-disabled gateway): exactly
-    // one caller, so persist to the shared `config.enc` + env + closure so
-    // credentials survive restarts and are visible to non-HTTP-scoped calls.
+    // Single-user / auth-disabled (no `sub` OR MCP_AUTH_DISABLE=1): unauthenticated
+    // deployments have no per-request `sub` routing tool calls (#1144).
+    // Persist to the shared `config.enc` + env + closure so credentials survive
+    // restarts and are immediately active for unauthenticated tool calls.
     const sub = context?.sub
-    if (sub) {
+    const authDisabled = process.env.MCP_AUTH_DISABLE === '1'
+    if (sub && !authDisabled) {
       try {
         await credStore.save(sub, { accounts })
       } catch (err) {
@@ -261,7 +263,6 @@ function buildOptions(args: {
       onAccountsLoaded(accounts)
       console.error(`[${SERVER_NAME}] ${accounts.length} email account(s) configured via /authorize`)
     }
-
     const outlookResult = await initiateOutlookOAuth(outlookAccounts, sub)
     if (outlookResult) return outlookResult
 
@@ -409,6 +410,11 @@ export async function startHttp(): Promise<void> {
   const setupUrl = `${baseUrl}/authorize`
   setSetupUrl(setupUrl)
   console.error(`[${SERVER_NAME}] HTTP mode on ${baseUrl}/mcp`)
+  if (authDisabled && process.env.EMAIL_CREDENTIALS) {
+    console.error(
+      `[${SERVER_NAME}] Notice: MCP_AUTH_DISABLE=1 in HTTP mode with pre-set EMAIL_CREDENTIALS. Submissions via ${setupUrl} will update the active credentials (#1144).`
+    )
+  }
   if (currentAccounts.length === 0) {
     console.error(`[${SERVER_NAME}] Open ${setupUrl} to configure your email accounts`)
   }


### PR DESCRIPTION
Resolves #1144 by ensuring that in HTTP mode when MCP_AUTH_DISABLE=1, submissions via /authorize update the active in-memory credentials and shared config, rather than silently routing only to the per-sub store.