### PR TITLE
fix: align Docker builder with lockfile v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
 
       - name: Build project
         run: bun run build
+      - name: Build stdio Docker target
+        if: matrix.os == 'ubuntu-latest'
+        run: docker build --target stdio --tag better-email-mcp:ci-stdio .
 
       - name: Run tests with coverage
         run: bun run test -- --coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage (shared by both targets)
-FROM oven/bun:1-alpine@sha256:5acc90a93e91ff07bf72aa90a7c9f0fa189765aec90b47bdbf2152d2196383c0 AS builder
+FROM oven/bun:1-alpine@sha256:07235578f79ef8c6f97d94aee7938e76f5cdba5f21ae5dbfdd3d3d38058437eb AS builder
 
 WORKDIR /app
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@n24q02m/mcp-core": "1.23.0",
+        "@n24q02m/mcp-core": "1.23.1",
         "html-to-text": "^10.0.1",
         "imapflow": "^1.7.2",
         "mailparser": "^3.9.15",
@@ -199,7 +199,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.23.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.2", "env-paths": "^4.0.0", "jose": "^6.2.6" } }, "sha512-YXKnTe7N8fZSg1bXYmXtxk+SFTn7KSr9MDoxpZBaL2DzItMMHBg3M8N8jAPNvQVHb4iQ+MY+tuJZXDlolb1cKw=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.23.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.3", "env-paths": "^4.0.0", "jose": "^6.2.10" } }, "sha512-hAH+NbM/29mvW9aqOA89m2r/E8dKlMqNR1XhajRXB8wqwpVBEutOF+qiYObhPSA92lKFszFAkceWbQoyN4H8QQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.147.0", "", {}, "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@n24q02m/mcp-core": "1.23.0",
+    "@n24q02m/mcp-core": "1.23.1",
     "html-to-text": "^10.0.1",
     "imapflow": "^1.7.2",
     "mailparser": "^3.9.15",

--- a/src/mcp-core-pin.test.ts
+++ b/src/mcp-core-pin.test.ts
@@ -4,17 +4,9 @@ import { describe, expect, test } from 'vitest'
 describe('mcp-core dependency pin', () => {
   const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'))
 
-  test('depends on a >=1.18.1 stable release that ships the storage backends + EdDSA', () => {
+  test('pins the stable 1.23.1 release', () => {
     const dep: string = pkg.dependencies['@n24q02m/mcp-core']
-    // Storage backends (CfKvBackend/backendFromEnv) + EdDSA-from-CREDENTIAL_SECRET
-    // shipped in the 1.18.0-beta line and are stable as of 1.18.1; the old exact
-    // 1.17.4 pin lacks them, and beta pins should not reach the stable build.
-    const [major, minor, patch] = dep
-      .replace(/^[^\d]*/, '')
-      .split('.')
-      .map(Number)
-    const meetsFloor = major > 1 || (major === 1 && minor > 18) || (major === 1 && minor === 18 && patch >= 1)
-    expect(meetsFloor).toBe(true)
+    expect(dep).toBe('1.23.1')
   })
 
   test('does not use a path/workspace source for mcp-core (npm dependency only)', () => {

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -3,7 +3,7 @@ import { runHttpServer, writeConfig } from '@n24q02m/mcp-core'
 import { ImapFlow } from 'imapflow'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { getMarkSetupComplete, resolveCredentialState, setSetupUrl, setState } from '../credential-state.js'
-import { loadConfig, parseCredentials } from '../tools/helpers/config.js'
+import { type AccountConfig, loadConfig, parseCredentials } from '../tools/helpers/config.js'
 import { initiateOutlookDeviceCode, isOutlookDomain } from '../tools/helpers/oauth2.js'
 import { registerTools } from '../tools/registry.js'
 


### PR DESCRIPTION
## Problem
Stable run 33252960646 released npm/GitHub artifacts but both Docker architectures failed: Bun 1.3.14 could not read the committed `lockfileVersion: 2` under `--frozen-lockfile`.

## Fix
- pin the immutable Bun 1.4.0 Alpine digest already proven compatible with lockfile v2
- add an Ubuntu CI Docker build of the real `stdio` target so this contract fails before release
- bump `@n24q02m/mcp-core` to stable 1.23.1 and regenerate `bun.lock`
- tighten the existing core-pin regression test

## Verification
- `bun test src/mcp-core-pin.test.ts` — 3 passed
- `bun install --frozen-lockfile` — no changes
- local Docker daemon was unavailable; this PR's new CI Docker job is the required real-surface proof

Forward-only remediation; no published tag is rewritten.