### PR TITLE
fix: bump mcp-core to 1.23.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-email-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@n24q02m/mcp-core": "1.23.1",
+        "@n24q02m/mcp-core": "1.23.2",
         "html-to-text": "^10.0.1",
         "imapflow": "^1.7.2",
         "mailparser": "^3.9.15",
@@ -199,7 +199,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.23.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.3", "env-paths": "^4.0.0", "jose": "^6.2.10" } }, "sha512-hAH+NbM/29mvW9aqOA89m2r/E8dKlMqNR1XhajRXB8wqwpVBEutOF+qiYObhPSA92lKFszFAkceWbQoyN4H8QQ=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.23.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.3", "env-paths": "^4.0.0", "jose": "^6.2.10" } }, "sha512-xKfcdYBkkGuFjbhvMYpxIMPUshfzcHgSxO26tbKg36XHXsw2iLg8kh425d07N7tJPUgqcXgKFdXovw6dSBSyjA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.147.0", "", {}, "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@n24q02m/mcp-core": "1.23.1",
+    "@n24q02m/mcp-core": "1.23.2",
     "html-to-text": "^10.0.1",
     "imapflow": "^1.7.2",
     "mailparser": "^3.9.15",

--- a/src/mcp-core-pin.test.ts
+++ b/src/mcp-core-pin.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, test } from 'vitest'
 describe('mcp-core dependency pin', () => {
   const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'))
 
-  test('pins the stable 1.23.1 release', () => {
+  test('pins the stable 1.23.2 release', () => {
     const dep: string = pkg.dependencies['@n24q02m/mcp-core']
-    expect(dep).toBe('1.23.1')
+    expect(dep).toBe('1.23.2')
   })
 
   test('does not use a path/workspace source for mcp-core (npm dependency only)', () => {


### PR DESCRIPTION
Closes #1161

Updates the direct @n24q02m/mcp-core pin to exact 1.23.2 and regenerates bun.lock.