### PR TITLE
feat(email): persist HTTP credentials and bound reads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,11 @@ COPY --from=builder /app/README.md /usr/local/lib/node_modules/@n24q02m/better-e
 COPY --from=builder /app/LICENSE /usr/local/lib/node_modules/@n24q02m/better-email-mcp/
 COPY --from=builder /app/node_modules /usr/local/lib/node_modules/@n24q02m/better-email-mcp/node_modules
 
-# Create symlink for CLI
-RUN ln -s /usr/local/lib/node_modules/@n24q02m/better-email-mcp/bin/cli.mjs /usr/local/bin/better-email-mcp
+# Create symlink for CLI and grant the non-root runtime user access to the
+# self-hosted HTTP credential volume.
+RUN ln -s /usr/local/lib/node_modules/@n24q02m/better-email-mcp/bin/cli.mjs /usr/local/bin/better-email-mcp \
+  && mkdir -p /data \
+  && chown node:node /data
 
 # Set default environment variables
 ENV NODE_ENV=production
@@ -52,6 +55,9 @@ ENTRYPOINT ["node", "/usr/local/lib/node_modules/@n24q02m/better-email-mcp/bin/c
 # http target: HTTP daemon (runLocalServer). Self-hosted deployment.
 FROM base AS http
 ENV MCP_TRANSPORT=http \
-    MCP_PORT=8080
+    MCP_PORT=8080 \
+    MCP_STORAGE_BACKEND=local \
+    HOME=/data
+VOLUME ["/data"]
 EXPOSE 8080
 ENTRYPOINT ["node", "/usr/local/lib/node_modules/@n24q02m/better-email-mcp/bin/cli.mjs"]

--- a/README.md
+++ b/README.md
@@ -219,13 +219,17 @@ Run as a multi-user HTTP server with OAuth 2.1 authentication:
 Single multi-user mode (relay form for App-Password providers + bundled Outlook OAuth device-code):
 
 ```bash
+export CREDENTIAL_SECRET='replace-with-a-stable-secret'
 docker run -p 8080:8080 \
   -e PORT=8080 \
   -e PUBLIC_URL=https://your-domain.com \
+  -e MCP_STORAGE_BACKEND=local \
+  -e HOME=/data \
+  -e CREDENTIAL_SECRET="$CREDENTIAL_SECRET" \
+  -v email-data:/data \
   n24q02m/better-email-mcp:latest
 ```
-
-Users provide their own email credentials through the OAuth flow / paste form. No server-side `EMAIL_CREDENTIALS` needed. With the default Docker self-host, per-user credentials are held in an in-memory store (cleared on restart); users re-submit after a restart. Outlook OAuth uses the bundled public Azure client (`d56f8c71-9f7c-43f4-9934-be29cb6e77b0`, Thunderbird-pattern) -- no user-side Azure app registration needed.
+Users provide their own email credentials through the OAuth flow / paste form. No server-side `EMAIL_CREDENTIALS` is needed. The stable `CREDENTIAL_SECRET` encrypts the local per-user credential files; the mounted `/data` volume survives container restarts. Without that volume, the container filesystem remains ephemeral. Cloudflare deployments use Workers KV instead.
 
 ### Cloudflare serverless mode (KV-only)
 
@@ -414,9 +418,8 @@ This plugin implements **TC-NearZK**. Storage durability depends on the deployme
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|
 | HTTP remote (Cloudflare) | Encrypted Workers KV `subs/<sub>/config` | AES-256-GCM | Server operator (admin = user) |
-| HTTP local Docker | In-memory `Map<sub, CredentialPayload>` | In-process only | Server process (cleared on restart) |
+| HTTP local Docker | Encrypted local files under `$HOME/.better-email-mcp/subs/<sub>/config.json` | AES-256-GCM | Server operator (admin = user) |
 | stdio | platformdirs `mcp` config dir (`config.enc`; e.g. `%APPDATA%\mcp\Config\config.enc` on Windows) | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
-
 ## License
 
 Apache-2.0 -- See [LICENSE](LICENSE).

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -4,6 +4,9 @@ services:
   better-email-mcp:
     environment:
       - TRANSPORT_MODE=http
+      - MCP_STORAGE_BACKEND=local
+      - CREDENTIAL_SECRET=${CREDENTIAL_SECRET:?Set a stable encryption secret}
+      - HOME=/data
       - MCP_RELAY_PASSWORD=${MCP_RELAY_PASSWORD}
     ports:
       - "8082:8080"

--- a/src/auth/cred-store.test.ts
+++ b/src/auth/cred-store.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { setHomeDirForTesting } from '@n24q02m/mcp-core/storage'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { PerSubCredStore } from './cred-store.js'
 import { applyCfEnv, clearCfEnv, FakeKvHttp } from './test-helpers.js'
@@ -132,5 +135,44 @@ describe('PerSubCredStore', () => {
       }
     })
     await expect(broken.ready()).rejects.toThrow(/kv\.internal/)
+  })
+
+  it('persists encrypted accounts and Outlook tokens across local-store restart with subject isolation', async () => {
+    const home = await mkdtemp(`${tmpdir()}/better-email-local-`)
+    const previousBackend = process.env.MCP_STORAGE_BACKEND
+    const previousSecret = process.env.CREDENTIAL_SECRET
+    process.env.MCP_STORAGE_BACKEND = 'local'
+    process.env.CREDENTIAL_SECRET = 'test-local-secret'
+    setHomeDirForTesting(home)
+
+    try {
+      const store = new PerSubCredStore()
+      await store.save('alice', {
+        accounts: [acct('alice@outlook.com')],
+        outlookTokens: {
+          'alice@outlook.com': { accessToken: 'access', refreshToken: 'refresh', expiresAt: 1 }
+        }
+      })
+
+      const coldStore = new PerSubCredStore()
+      const alice = await coldStore.load('alice')
+      const bob = await coldStore.load('bob')
+
+      expect(alice).not.toBeNull()
+      const aliceAccounts = alice?.accounts as Array<{ email: string }>
+      const aliceTokens = alice?.outlookTokens as Record<string, { refreshToken: string }>
+      expect(aliceAccounts?.[0]?.email).toBe('alice@outlook.com')
+      expect(aliceTokens?.['alice@outlook.com']?.refreshToken).toBe('refresh')
+      expect(bob).toBeNull()
+      await coldStore.clear('alice')
+      expect(await new PerSubCredStore().load('alice')).toBeNull()
+    } finally {
+      setHomeDirForTesting(null)
+      await rm(home, { recursive: true, force: true })
+      if (previousBackend === undefined) delete process.env.MCP_STORAGE_BACKEND
+      else process.env.MCP_STORAGE_BACKEND = previousBackend
+      if (previousSecret === undefined) delete process.env.CREDENTIAL_SECRET
+      else process.env.CREDENTIAL_SECRET = previousSecret
+    }
   })
 })

--- a/src/docs/messages.md
+++ b/src/docs/messages.md
@@ -4,8 +4,8 @@
 Email messages: search, read, mark_read, mark_unread, flag, unflag, move, archive, trash, new, reply, forward.
 
 ## Important
-- **search** defaults to all configured accounts. Filter with `account` param.
-- **read** returns clean plain text body (HTML stripped for LLM token savings)
+- **read** returns the full clean plain-text body by default (HTML stripped for LLM token savings)
+- Set `preview: true` for a bounded body preview. Preview responses include `body_truncated`, `body_char_count`, and `body_limit`; `max_chars` defaults to 4000 and is capped at 100000.
 - **UIDs are per-account and per-folder** - always specify account for modify operations
 - Query language supports compound filters: `UNREAD SINCE 2024-01-01`
 - **reply** automatically sets In-Reply-To and References headers for threading
@@ -39,10 +39,17 @@ Query shortcuts:
 - Any other text is treated as subject search
 
 ### read
-Read a single email by UID. Returns full body as clean text.
+Read a single email by UID. Omit `preview` for the full clean body, or set `preview: true` for a bounded response.
 ```json
 {"action": "read", "account": "user@gmail.com", "uid": 12345, "folder": "INBOX"}
 ```
+```json
+{"action": "read", "account": "user@gmail.com", "uid": 12345, "preview": true, "max_chars": 4000}
+```
+Preview responses retain the message metadata and return:
+- `body_truncated` - whether the body was shortened
+- `body_char_count` - full body length in characters
+- `body_limit` - applied preview limit
 
 ### mark_read
 ```json
@@ -108,13 +115,14 @@ Forward an email. The original body is appended with a separator.
 {"action": "forward", "account": "user@gmail.com", "to": "colleague@example.com", "body": "FYI, see below.", "uid": 12345}
 ```
 
-## Parameters
 - `action` - Action to perform (required)
 - `account` - Account email filter (optional for search, required for modify)
 - `query` - Search query string (default: UNSEEN)
 - `folder` - Mailbox folder (default: INBOX)
 - `limit` - Max search results (default: 20)
 - `uid` - Single email UID
+- `preview` - Return a bounded body preview for read (default: false)
+- `max_chars` - Preview body limit, integer 1-100000 (default: 4000 when preview is true)
 - `uids` - Multiple email UIDs for batch operations
 - `destination` - Target folder for move action
 - `to` - Recipient email address (required for new/forward, optional for reply)

--- a/src/tools/composite/messages.test.ts
+++ b/src/tools/composite/messages.test.ts
@@ -152,6 +152,40 @@ describe('messages - read', () => {
     expect(result.uid).toBe(42)
     expect(result.subject).toBe('Test')
   })
+  it('returns a bounded preview with truncation metadata', async () => {
+    mockReadEmail.mockResolvedValue({
+      account_id: 'user1_gmail_com',
+      account_email: 'user1@gmail.com',
+      uid: 42,
+      subject: 'Test',
+      from: 'sender@test.com',
+      to: 'user1@gmail.com',
+      date: '2025-01-01',
+      flags: ['\\Seen'],
+      body_text: '0123456789',
+      attachments: []
+    })
+
+    const result = await messages(accounts, {
+      action: 'read',
+      uid: 42,
+      account: 'user1@gmail.com',
+      preview: true,
+      max_chars: 5
+    })
+
+    expect(result.body_text).toBe('01234')
+    expect(result.preview).toBe(true)
+    expect(result.body_truncated).toBe(true)
+    expect(result.body_char_count).toBe(10)
+    expect(result.body_limit).toBe(5)
+  })
+
+  it('rejects an unbounded preview limit', async () => {
+    await expect(
+      messages(accounts, { action: 'read', uid: 42, account: 'user1@gmail.com', preview: true, max_chars: 0 })
+    ).rejects.toThrow('max_chars must be an integer')
+  })
 
   it('throws when uid is missing', async () => {
     await expect(messages(accounts, { action: 'read', account: 'user1@gmail.com' })).rejects.toThrow('uid is required')

--- a/src/tools/composite/messages.test.ts
+++ b/src/tools/composite/messages.test.ts
@@ -163,7 +163,7 @@ describe('messages - read', () => {
       date: '2025-01-01',
       flags: ['\\Seen'],
       body_text: '0123456789',
-      attachments: []
+      attachments: [{ filename: 'report.pdf', content_type: 'application/pdf', size: 123 }]
     })
 
     const result = await messages(accounts, {
@@ -179,6 +179,7 @@ describe('messages - read', () => {
     expect(result.body_truncated).toBe(true)
     expect(result.body_char_count).toBe(10)
     expect(result.body_limit).toBe(5)
+    expect(result.attachments).toEqual([{ filename: 'report.pdf', content_type: 'application/pdf', size: 123 }])
   })
 
   it('returns untruncated preview metadata when the body fits the limit', async () => {

--- a/src/tools/composite/messages.test.ts
+++ b/src/tools/composite/messages.test.ts
@@ -181,6 +181,35 @@ describe('messages - read', () => {
     expect(result.body_limit).toBe(5)
   })
 
+  it('returns untruncated preview metadata when the body fits the limit', async () => {
+    mockReadEmail.mockResolvedValue({
+      account_id: 'user1_gmail_com',
+      account_email: 'user1@gmail.com',
+      uid: 42,
+      subject: 'Test',
+      from: 'sender@test.com',
+      to: 'user1@gmail.com',
+      date: '2025-01-01',
+      flags: ['\\Seen'],
+      body_text: 'short body',
+      attachments: [{ filename: 'report.pdf', content_type: 'application/pdf', size: 123 }]
+    })
+
+    const result = await messages(accounts, {
+      action: 'read',
+      uid: 42,
+      account: 'user1@gmail.com',
+      preview: true,
+      max_chars: 100
+    })
+
+    expect(result.body_text).toBe('short body')
+    expect(result.body_truncated).toBe(false)
+    expect(result.body_char_count).toBe(10)
+    expect(result.body_limit).toBe(100)
+    expect(result.attachments).toEqual([{ filename: 'report.pdf', content_type: 'application/pdf', size: 123 }])
+  })
+
   it('rejects an unbounded preview limit', async () => {
     await expect(
       messages(accounts, { action: 'read', uid: 42, account: 'user1@gmail.com', preview: true, max_chars: 0 })

--- a/src/tools/composite/messages.ts
+++ b/src/tools/composite/messages.ts
@@ -9,8 +9,10 @@ import { createUnknownActionError, EmailMCPError, withErrorHandling } from '../h
 import { listFolders, modifyFlags, moveEmails, readEmail, searchEmails, trashEmails } from '../helpers/imap-client.js'
 import { type SendInput, send } from './send.js'
 
-// Simple in-memory cache for archive folder paths to avoid repeated IMAP calls
+// Archive folder paths are cached per account to avoid repeated IMAP calls.
 const archiveFolderCache = new Map<string, Promise<string>>()
+const DEFAULT_PREVIEW_MAX_CHARS = 4_000
+const MAX_PREVIEW_MAX_CHARS = 100_000
 
 /** Clear the archive folder path cache */
 export function clearArchiveFolderCache(): number {
@@ -40,10 +42,11 @@ export interface MessagesInput {
   folder?: string
   limit?: number
 
-  // Read/modify params
+  // Read params
   uid?: number
+  preview?: boolean
+  max_chars?: number
   uids?: number[]
-
   // Move params
   destination?: string
 
@@ -126,21 +129,48 @@ async function handleSearch(accounts: AccountConfig[], input: MessagesInput): Pr
 }
 
 /**
- * Read a single email by UID
+ * Read a single email by UID.
  */
 async function handleRead(accounts: AccountConfig[], input: MessagesInput): Promise<any> {
   if (!input.uid) {
     throw new EmailMCPError('uid is required for read action', 'VALIDATION_ERROR', 'Provide the email UID from search')
   }
 
+  let previewLimit: number | undefined
+  if (input.preview) {
+    const limit = input.max_chars ?? DEFAULT_PREVIEW_MAX_CHARS
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_PREVIEW_MAX_CHARS) {
+      throw new EmailMCPError(
+        `max_chars must be an integer between 1 and ${MAX_PREVIEW_MAX_CHARS}`,
+        'VALIDATION_ERROR',
+        'Use a positive bounded max_chars value for preview mode'
+      )
+    }
+    previewLimit = limit
+  }
+
   const account = resolveSingleAccount(accounts, input.account)
   const folder = input.folder || 'INBOX'
-
   const email = await readEmail(account, input.uid, folder)
+
+  if (previewLimit === undefined) {
+    return {
+      action: 'read',
+      ...email
+    }
+  }
+
+  const bodyCharCount = email.body_text.length
+  const truncated = bodyCharCount > previewLimit
 
   return {
     action: 'read',
-    ...email
+    ...email,
+    body_text: truncated ? email.body_text.slice(0, previewLimit) : email.body_text,
+    preview: true,
+    body_truncated: truncated,
+    body_char_count: bodyCharCount,
+    body_limit: previewLimit
   }
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -56,7 +56,7 @@ const TOOLS = [
   {
     name: 'messages',
     description:
-      'Search, read, manage, compose, and send email messages.\n\nActions (required params -> optional):\n- search (-> account, query="UNSEEN", folder="INBOX", limit=20)\n- read (account, uid -> folder)\n- mark_read / mark_unread / flag / unflag (account, uid|uids -> folder)\n- move (account, uid|uids, destination -> folder)\n- archive / trash (account, uid|uids -> folder)\n- new (account, to, subject, body -> cc, bcc, attachments)\n- reply (account, uid, body -> to, folder, attachments)\n- forward (account, uid, to, body -> folder, attachments)\n\nQuery examples: "UNREAD", "FROM user@example.com", "SINCE 2026-01-01", "UNREAD FROM boss@company.com". Date format MUST be YYYY-MM-DD.\n\nOutbound bodies support plain text or HTML. Attachments use base64 content, max 10 files and 25MB decoded total.',
+      'Search, read, manage, compose, and send email messages.\n\nActions (required params -> optional):\n- search (-> account, query="UNSEEN", folder="INBOX", limit=20)\n- read (account, uid -> folder, preview, max_chars)\n- mark_read / mark_unread / flag / unflag (account, uid|uids -> folder)\n- move (account, uid|uids, destination -> folder)\n- archive / trash (account, uid|uids -> folder)\n- new (account, to, subject, body -> cc, bcc, attachments)\n- reply (account, uid, body -> to, folder, attachments)\n- forward (account, uid, to, body -> folder, attachments)\n\nRead preview mode returns at most max_chars (default 4000) and includes truncation metadata; omit preview for the full body.\n\nQuery examples: "UNREAD", "FROM user@example.com", "SINCE 2026-01-01", "UNREAD FROM boss@company.com". Date format MUST be YYYY-MM-DD.\n\nOutbound bodies support plain text or HTML. Attachments use base64 content, max 10 files and 25MB decoded total.',
     annotations: {
       title: 'Messages',
       readOnlyHint: false,
@@ -94,6 +94,11 @@ const TOOLS = [
         folder: { type: 'string', description: 'Mailbox folder (default: INBOX)' },
         limit: { type: 'number', description: 'Max results for search (default: 20)' },
         uid: { type: 'number', description: 'Email UID (for read/modify single email)' },
+        preview: { type: 'boolean', description: 'Read at most max_chars and return truncation metadata' },
+        max_chars: {
+          type: 'number',
+          description: 'Preview body limit, integer 1-100000; defaults to 4000 when preview is true'
+        },
         uids: { type: 'array', items: { type: 'number' }, description: 'Multiple UIDs for batch operations' },
         destination: { type: 'string', description: 'Target folder for move action' },
         to: {

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -158,6 +158,25 @@ describe('http transport', () => {
       })
     })
 
+    it('binds HTTP to all interfaces by default', async () => {
+      const originalHost = process.env.HOST
+      delete process.env.HOST
+
+      try {
+        await runStartHttpAndTriggerShutdown(async () => {
+          expect(runHttpServer).toHaveBeenCalledWith(
+            expect.any(Function),
+            expect.objectContaining({
+              host: '0.0.0.0'
+            })
+          )
+        })
+      } finally {
+        if (originalHost === undefined) delete process.env.HOST
+        else process.env.HOST = originalHost
+      }
+    })
+
     it('uses PORT from environment if available', async () => {
       process.env.PORT = '4000'
       await runStartHttpAndTriggerShutdown(async () => {

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -177,6 +177,25 @@ describe('http transport', () => {
       }
     })
 
+    it('preserves an explicit HTTP bind host', async () => {
+      const originalHost = process.env.HOST
+      process.env.HOST = '127.0.0.1'
+
+      try {
+        await runStartHttpAndTriggerShutdown(async () => {
+          expect(runHttpServer).toHaveBeenCalledWith(
+            expect.any(Function),
+            expect.objectContaining({
+              host: '127.0.0.1'
+            })
+          )
+        })
+      } finally {
+        if (originalHost === undefined) delete process.env.HOST
+        else process.env.HOST = originalHost
+      }
+    })
+
     it('uses PORT from environment if available', async () => {
       process.env.PORT = '4000'
       await runStartHttpAndTriggerShutdown(async () => {

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -57,7 +57,7 @@ vi.mock('../auth/outlook-device-code.js', () => ({
 }))
 
 // We need to import startHttp AFTER mocks are set up
-import { resolveSetupBaseUrl, startHttp } from './http.js'
+import { resolveSetupBaseUrl, selectCredStore, startHttp } from './http.js'
 
 describe('resolveSetupBaseUrl', () => {
   it('prefers PUBLIC_URL over the bind address', () => {
@@ -78,6 +78,16 @@ describe('resolveSetupBaseUrl', () => {
 
   it('treats an empty PUBLIC_URL as unset', () => {
     expect(resolveSetupBaseUrl('', '0.0.0.0', 8080)).toBe('http://localhost:8080')
+  })
+})
+
+describe('credential store selection', () => {
+  it('fails closed for an unknown backend instead of using ephemeral storage', () => {
+    const previous = process.env.MCP_STORAGE_BACKEND
+    process.env.MCP_STORAGE_BACKEND = 'sqlite'
+    expect(() => selectCredStore()).toThrow('refusing ephemeral credentials')
+    if (previous === undefined) delete process.env.MCP_STORAGE_BACKEND
+    else process.env.MCP_STORAGE_BACKEND = previous
   })
 })
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -353,7 +353,7 @@ export async function startHttp(): Promise<void> {
     : process.env.MCP_PORT
       ? Number.parseInt(process.env.MCP_PORT, 10)
       : 0
-  const host = process.env.HOST
+  const host = process.env.HOST || '0.0.0.0'
 
   const baseOptions = buildOptions({
     serverFactory,

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -45,20 +45,25 @@ const SERVER_NAME = 'better-email-mcp'
 const IMAP_CONNECT_TIMEOUT_MS = 15_000
 
 /**
- * Select the per-sub credential store. cf-kv backend -> KV write-through
- * PerSubCredStore (durable across container recreate; the Cloudflare deploy
- * store). Any other backend (stdio / local single-process) -> ephemeral
- * in-memory store. Read once at module load; on CF, MCP_STORAGE_BACKEND=cf-kv is
- * set by wrangler vars, so the durable KV store is selected there.
+ * `cf-kv` uses the Worker's KV outbound bridge. `local` and `local-fs` use
+ * mcp-core's encrypted filesystem backend, which is the durable option for
+ * self-hosted Docker when its credential directory is mounted as a volume.
+ * An unset backend preserves the single-process in-memory fallback for
+ * development; production Docker configuration must set `MCP_STORAGE_BACKEND=local`.
+ * Stdio keeps its single-user env/file flow and never calls startHttp.
  */
-function selectCredStore(): CredStoreLike {
-  if ((process.env.MCP_STORAGE_BACKEND ?? '').toLowerCase() === 'cf-kv') {
+export function selectCredStore(): CredStoreLike {
+  const backend = (process.env.MCP_STORAGE_BACKEND ?? '').toLowerCase()
+  if (backend === 'cf-kv' || backend === 'local' || backend === 'local-fs') {
     return new PerSubCredStore()
   }
-  return new InMemoryCredStore()
+  if (backend === '') return new InMemoryCredStore()
+  throw new Error(
+    `Unsupported MCP_STORAGE_BACKEND "${backend}". Use "local", "local-fs", or "cf-kv"; refusing ephemeral credentials.`
+  )
 }
 
-/** Module-singleton per-user credential store (KV on CF, in-memory otherwise). */
+/** Module-singleton per-user credential store (encrypted KV or filesystem). */
 const credStore = selectCredStore()
 
 /**
@@ -388,12 +393,10 @@ export async function startHttp(): Promise<void> {
     }
   }
 
-  // Startup KV readiness probe (cf-kv / PerSubCredStore only). Confirms the
-  // container -> Worker `kv.internal` outbound path is wired BEFORE the first
-  // credential write, so a broken binding fails loudly at boot instead of
-  // silently dropping the first user's credentials. InMemoryCredStore has no
-  // `ready`, so this is a no-op for stdio / local single-process deploys.
-  if (credStore.ready) {
+  // Only the Cloudflare KV backend needs the internal-host readiness probe.
+  // Local filesystem storage is already available through the mounted volume;
+  // probing it with the KV sentinel would reject the key as invalid.
+  if ((process.env.MCP_STORAGE_BACKEND ?? '').toLowerCase() === 'cf-kv' && credStore.ready) {
     try {
       await credStore.ready()
       console.error(`[${SERVER_NAME}] KV store reachable (kv.internal outbound OK)`)


### PR DESCRIPTION
## Changes
- use encrypted mcp-core local filesystem storage for self-hosted HTTP Docker mode
- bind /data and set HOME=/data in the HTTP image/compose path; fail closed on unknown storage backends
- add restart, OAuth refresh-token, subject-isolation, deletion, preview, and truncation regressions
- document full-read versus bounded preview behavior

## Verification
- bun run check
- bun run build
- bun run test (895 passed, 1 skipped)
- focused credential/message/HTTP tests (81 passed)
- Docker build attempted; blocked by external Bun tarball extraction for @typescript/typescript-linux-x64 before image creation

Closes #1170.