### PR TITLE
docs: align mode badge with fleet standard (label 'mode', color 5C6BC0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ mcp-name: io.github.n24q02m/better-email-mcp
 **IMAP/SMTP email for AI agents -- read, send, organize folders, and manage attachments across multiple accounts, with auto-discovery.**
 
 <!-- Badge Row 1: Status -->
-[![Mode](https://img.shields.io/badge/mode:-http_remote_relay_%C2%B7_http_local_relay_%C2%B7_stdio_proxy-5C6BC0)](https://mcp.n24q02m.com/get-started/modes-overview/)
+[![Mode](https://img.shields.io/badge/mode-http_remote_relay_%C2%B7_http_local_relay_%C2%B7_stdio_proxy-5C6BC0)](https://mcp.n24q02m.com/get-started/modes-overview/)
 [![CI](https://github.com/n24q02m/better-email-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/better-email-mcp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/n24q02m/better-email-mcp/graph/badge.svg?token=O2GWBWCZGF)](https://codecov.io/gh/n24q02m/better-email-mcp)
 [![npm](https://img.shields.io/npm/v/@n24q02m/better-email-mcp?logo=npm&logoColor=white)](https://www.npmjs.com/package/@n24q02m/better-email-mcp)


### PR DESCRIPTION
1-line docs-only: align mode badge to the wave standard (label `mode`, color 5C6BC0). L4 repos merged with blue, L3 with a colon label, before the color/label converged. Part of docs-wave-20260913 completion.